### PR TITLE
Update .gitignore files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,11 +3,12 @@ configure
 autom4te.cache
 config.log
 config.status
-Makefile
+/Makefile
 *ct-ng*
 !ct-ng.comp
 !ct-ng.in
 paths.*
+!paths.in
 config.gen/
 .config
 .config.2

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,2 +1,3 @@
 *ct-ng*.1
 *ct-ng*.1.gz
+!ct-ng.1.in


### PR DESCRIPTION
The current .gitignore files cause changes to files which are actually part of
the repository to be ignored. This commit modifies the rules so that this does
not happen. The files that were affected are:

  config/global/paths.in
  contrib/gcc-test-suite/Makefile
  docs/ct-ng.1.in
  kconfig/Makefile

(as revealed by 'git ls-files --ignored --exclude-standard')

Signed-off-by: James Byrne james.byrne@origamienergy.com
