### PR TITLE
libc/newlib: Canadian baremetal builds require core pass-1

### DIFF
--- a/config/libc/newlib.in
+++ b/config/libc/newlib.in
@@ -3,7 +3,8 @@
 ## depends on BARE_METAL
 ##
 ## select LIBC_SUPPORT_THREADS_NONE
-## select CC_CORE_PASS_2_NEEDED
+## select CC_CORE_PASSES_NEEDED if CANADIAN
+## select CC_CORE_PASS_2_NEEDED if ! CANADIAN
 ##
 ## help Newlib is a C library intended for use on embedded systems. It is a
 ## help conglomeration of several library parts, all under free software


### PR DESCRIPTION
Can safely skip the core pass-1 for normal baremetal builds,
but when building a canadian baremetal, the repair_cc
functionality (GCC_FOR_TARGET) in gcc.sh will force the
core pass-2 to attempt to build gcc and libgcc without a
${CT_TARGET}-gcc existing, causing a failure on
${CT_TARGET}-gcc -dumpspecs > tmp-specs

Signed-off-by: David Holsgrove david.holsgrove@xilinx.com
