### PR TITLE
libc/glibc: install obsolete RPC for both eglibc and glibc

### DIFF
--- a/scripts/build/libc/glibc-eglibc.sh-common
+++ b/scripts/build/libc/glibc-eglibc.sh-common
@@ -214,8 +214,6 @@ do_libc_backend_once() {
             else
                 OPTIMIZE=-O2
             fi
-            # always include rpc, the user can still override it with TI-RPC
-            extra_config+=( --enable-obsolete-rpc )
             ;;
         glibc)
             # glibc can't be built without -O2 (reference needed!)
@@ -224,6 +222,9 @@ do_libc_backend_once() {
             extra_config+=( --disable-debug --disable-sanity-checks )
             ;;
     esac
+
+    # always include rpc, the user can still override it with TI-RPC
+    extra_config+=( --enable-obsolete-rpc )
 
     # Add some default glibc config options if not given by user.
     # We don't need to be conditional on wether the user did set different


### PR DESCRIPTION
(Originally submitted to mailing list by Jérôme 16th Feb 2013 - not applied yet, but still relevant.)

Currently, the obsolete RPC headers are only installed for eglibc,
but glibc has the same /deficiency/, so install the obsolete RPC
for both.

Signed-off-by: Jérôme BARDON bardon.pro@gmail.com
Signed-off-by: David Holsgrove david.holsgrove@xilinx.com
