### PR TITLE
Newlib headers for Canadian Crosses

### DIFF
--- a/scripts/build/cc/gcc.sh
+++ b/scripts/build/cc/gcc.sh
@@ -205,20 +205,16 @@ do_cc_core_backend() {
             extra_config+=("--enable-threads=no")
             extra_config+=("--disable-shared")
             extra_user_config=( "${CT_CC_CORE_EXTRA_CONFIG_ARRAY[@]}" )
-            copy_headers=y  # For baremetal, as there's no headers to copy,
-                            # we copy an empty directory. So, who cares?
             ;;
         shared)
             extra_config+=("--enable-shared")
             extra_user_config=( "${CT_CC_CORE_EXTRA_CONFIG_ARRAY[@]}" )
-            copy_headers=y
             ;;
         baremetal)
             extra_config+=("--with-newlib")
             extra_config+=("--enable-threads=no")
             extra_config+=("--disable-shared")
             extra_user_config=( "${CT_CC_EXTRA_CONFIG_ARRAY[@]}" )
-            copy_headers=n
             ;;
         *)
             CT_Abort "Internal Error: 'mode' must be one of: 'static', 'shared' or 'baremetal', not '${mode:-(empty)}'"
@@ -231,10 +227,8 @@ do_cc_core_backend() {
         [ -n "${CT_TOOLCHAIN_BUGURL}" ] && extra_config+=("--with-bugurl=${CT_TOOLCHAIN_BUGURL}")
     fi
 
-    if [ "${copy_headers}" = "y" ]; then
-        CT_DoLog DEBUG "Copying headers to install area of bootstrap gcc, so it can build libgcc2"
-        CT_DoExecLog ALL cp -a "${CT_HEADERS_DIR}" "${prefix}/${CT_TARGET}/include"
-    fi
+    CT_DoLog DEBUG "Copying headers to install area of core C compiler"
+    CT_DoExecLog ALL cp -a "${CT_HEADERS_DIR}" "${prefix}/${CT_TARGET}/include"
 
     for tmp in ARCH ABI CPU TUNE FPU FLOAT; do
         eval tmp="\${CT_ARCH_WITH_${tmp}}"

--- a/scripts/build/libc/newlib.sh
+++ b/scripts/build/libc/newlib.sh
@@ -50,16 +50,16 @@ do_libc_check_config() {
 }
 
 do_libc_start_files() {
+    CT_DoStep INFO "Installing C library headers & start files"
+    CT_DoExecLog ALL cp -a "${CT_SRC_DIR}/newlib-${CT_LIBC_VERSION}/newlib/libc/include/." \
+    "${CT_HEADERS_DIR}"
     if [ "${CT_ATMEL_AVR32_HEADERS}" = "y" ]; then
-        CT_DoStep INFO "Installing C library headers & start files"
-
         CT_DoLog EXTRA "Installing Atmel's AVR32 headers"
         CT_DoExecLog ALL mkdir -p "${CT_PREFIX_DIR}/${CT_TARGET}/include"
         CT_DoExecLog ALL cp -r "${CT_SRC_DIR}/${LIBC_NEWLIB_AVR_HDRS_BASE}/avr32"   \
                                "${CT_PREFIX_DIR}/${CT_TARGET}/include/"
-
-        CT_EndStep
     fi
+    CT_EndStep
 }
 
 do_libc() {


### PR DESCRIPTION
These two patches have newlib match other libcs in the do_libc_start_files function by copying their headers from source to CT_HEADERS_DIR.

The second patch then makes copy_headers=y the default in gcc.sh for all modes, picking up the new headers copied from newlib by the first patch (contrary to the comment that there are no headers to copy for baremetal in the 'static' and 'baremetal' modes of do_cc_core_backend) 

Believe this should resolve #18 