### PR TITLE
Update of powerpc-e500v2-linux-gnuspe

### DIFF
--- a/config/cc/gcc.in
+++ b/config/cc/gcc.in
@@ -57,6 +57,11 @@ config CC_V_linaro_4_8
     depends on CC_GCC_SHOW_LINARO
     select CC_GCC_4_8
 
+config CC_V_4_8_4
+    bool
+    prompt "4.8.4"
+    select CC_GCC_4_8
+
 config CC_V_4_8_3
     bool
     prompt "4.8.3"
@@ -501,6 +506,7 @@ config CC_VERSION
     default "4.9.1" if CC_V_4_9_1
     default "4.9.0" if CC_V_4_9_0
     default "linaro-4.8-2014.04" if CC_V_linaro_4_8
+    default "4.8.4" if CC_V_4_8_4
     default "4.8.3" if CC_V_4_8_3
     default "4.8.2" if CC_V_4_8_2
     default "4.8.1" if CC_V_4_8_1

--- a/patches/gcc/4.8.4/001_gcc_bug_62231.patch
+++ b/patches/gcc/4.8.4/001_gcc_bug_62231.patch
@@ -1,0 +1,129 @@
+As-applied.  From:
+
+https://gcc.gnu.org/ml/gcc-patches/2014-09/msg02625.html
+
+Linked from bug62231 comment 4 there
+
+diff -durN a/gcc/defaults.h b/gcc/defaults.h
+--- a/gcc/defaults.h	2013-01-10 12:38:27.000000000 -0800
++++ b/gcc/defaults.h	2014-12-15 13:26:13.498904465 -0800
+@@ -438,6 +438,11 @@
+ #define DWARF_FRAME_REGNUM(REG) DBX_REGISTER_NUMBER (REG)
+ #endif
+ 
++/* The mapping from dwarf CFA reg number to internal dwarf reg numbers.  */
++#ifndef DWARF_REG_TO_UNWIND_COLUMN
++#define DWARF_REG_TO_UNWIND_COLUMN(REGNO) (REGNO)
++#endif
++
+ /* Map register numbers held in the call frame info that gcc has
+    collected using DWARF_FRAME_REGNUM to those that should be output in
+    .debug_frame and .eh_frame.  */
+diff -durN a/gcc/dwarf2cfi.c b/gcc/dwarf2cfi.c
+--- a/gcc/dwarf2cfi.c	2013-01-10 12:38:27.000000000 -0800
++++ b/gcc/dwarf2cfi.c	2014-12-15 13:50:24.554883694 -0800
+@@ -225,7 +225,44 @@
+   emit_move_insn (adjust_address (mem, mode, offset), GEN_INT (size));
+ }
+ 
+-/* Generate code to initialize the register size table.  */
++/* Helper for expand_builtin_init_dwarf_reg_sizes.  Generate code to
++   initialize the dwarf register size table entry corresponding to register
++   REGNO in REGMODE.  TABLE is the table base address, SLOTMODE is the mode
++   to use for the size entry to initialize, and WROTE_RETURN_COLUMN needs to
++   be set to true if the dwarf register number for REGNO is the dwarf return
++   column number.  */
++
++static
++void init_one_dwarf_reg_size (int regno, enum machine_mode regmode,
++			      rtx table, enum machine_mode slotmode,
++			      bool *wrote_return_column)
++{
++  const unsigned int dnum = DWARF_FRAME_REGNUM (regno);
++  const unsigned int rnum = DWARF2_FRAME_REG_OUT (dnum, 1);
++  const unsigned int dcol = DWARF_REG_TO_UNWIND_COLUMN (rnum);
++  
++  const HOST_WIDE_INT slotoffset = dcol * GET_MODE_SIZE (slotmode);
++  const HOST_WIDE_INT regsize = GET_MODE_SIZE (regmode);
++
++  if (rnum >= DWARF_FRAME_REGISTERS)
++    return;
++
++  if (dnum == DWARF_FRAME_RETURN_COLUMN)
++    {
++      if (regmode == VOIDmode)
++	return;
++      *wrote_return_column = true;
++    }
++
++  if (slotoffset < 0)
++    return;
++
++  emit_move_insn (adjust_address (table, slotmode, slotoffset),
++		  gen_int_mode (regsize, slotmode));
++}
++
++/* Generate code to initialize the dwarf register size table located
++   at the provided ADDRESS.  */
+ 
+ void
+ expand_builtin_init_dwarf_reg_sizes (tree address)
+@@ -238,30 +275,21 @@
+ 
+   for (i = 0; i < FIRST_PSEUDO_REGISTER; i++)
+     {
+-      unsigned int dnum = DWARF_FRAME_REGNUM (i);
+-      unsigned int rnum = DWARF2_FRAME_REG_OUT (dnum, 1);
+-
+-      if (rnum < DWARF_FRAME_REGISTERS)
+-	{
+-	  HOST_WIDE_INT offset = rnum * GET_MODE_SIZE (mode);
+-	  enum machine_mode save_mode = reg_raw_mode[i];
+-	  HOST_WIDE_INT size;
+-
+-	  if (HARD_REGNO_CALL_PART_CLOBBERED (i, save_mode))
+-	    save_mode = choose_hard_reg_mode (i, 1, true);
+-	  if (dnum == DWARF_FRAME_RETURN_COLUMN)
+-	    {
+-	      if (save_mode == VOIDmode)
+-		continue;
+-	      wrote_return_column = true;
+-	    }
+-	  size = GET_MODE_SIZE (save_mode);
+-	  if (offset < 0)
+-	    continue;
++      enum machine_mode save_mode = reg_raw_mode[i];
++      rtx span;
+ 
+-	  emit_move_insn (adjust_address (mem, mode, offset),
+-			  gen_int_mode (size, mode));
+-	}
++      span = targetm.dwarf_register_span (gen_rtx_REG (save_mode, i));
++      if (!span)
++        init_one_dwarf_reg_size (i, save_mode, mem, mode, &wrote_return_column);
++      else
++        {
++          for (int si = 0; si < XVECLEN (span, 0); si++)
++            {
++              rtx reg = XVECEXP (span, 0, si);
++              init_one_dwarf_reg_size
++              (REGNO (reg), GET_MODE (reg), mem, mode, &wrote_return_column);
++            }
++        }
+     }
+ 
+   if (!wrote_return_column)
+diff -durN a/libgcc/unwind-dw2.c b/libgcc/unwind-dw2.c
+--- a/libgcc/unwind-dw2.c	2013-05-31 16:21:46.000000000 -0700
++++ b/libgcc/unwind-dw2.c	2014-12-15 13:26:13.570904866 -0800
+@@ -55,10 +55,6 @@
+ #define PRE_GCC3_DWARF_FRAME_REGISTERS DWARF_FRAME_REGISTERS
+ #endif
+ 
+-#ifndef DWARF_REG_TO_UNWIND_COLUMN
+-#define DWARF_REG_TO_UNWIND_COLUMN(REGNO) (REGNO)
+-#endif
+-
+ /* ??? For the public function interfaces, we tend to gcc_assert that the
+    column numbers are in range.  For the dwarf2 unwind info this does happen,
+    although so far in a case that doesn't actually matter.

--- a/patches/gcc/4.8.4/002_gcc_bug_62231.patch
+++ b/patches/gcc/4.8.4/002_gcc_bug_62231.patch
@@ -1,0 +1,18 @@
+As-applied.  From:
+
+https://gcc.gnu.org/ml/gcc-patches/2014-10/msg02605.html
+
+Linked from bug62231 comment 4 there
+
+diff -durN a/gcc/config/rs6000/rs6000.c b/gcc/config/rs6000/rs6000.c
+--- a/gcc/config/rs6000/rs6000.c	2014-12-08 17:29:04.000000000 -0800
++++ b/gcc/config/rs6000/rs6000.c	2014-12-15 14:44:46.568801843 -0800
+@@ -1673,7 +1673,7 @@
+      SCmode so as to pass the value correctly in a pair of
+      registers.  */
+   else if (TARGET_E500_DOUBLE && FLOAT_MODE_P (mode) && mode != SCmode
+-	   && !DECIMAL_FLOAT_MODE_P (mode))
++	   && !DECIMAL_FLOAT_MODE_P (mode) && SPE_SIMD_REGNO_P (regno))
+     reg_size = UNITS_PER_FP_WORD;
+ 
+   else

--- a/patches/gcc/4.8.4/003-PR57717-E500v2.patch
+++ b/patches/gcc/4.8.4/003-PR57717-E500v2.patch
@@ -1,0 +1,21 @@
+This backports fix from http://gcc.gnu.org/bugzilla/show_bug.cgi?id=57717
+
+Upstream-Status: Backport
+Signed-off-by: Julian Brown <Julian_Brown@mentor.com>
+
+fix for PR57717 (PowerPC E500v2)
+http://gcc.gnu.org/ml/gcc-patches/2013-08/msg00668.html
+
+--- a/gcc/config/rs6000/rs6000.c	2013-05-09 20:54:06.000000000 -0500
++++ b/gcc/config/rs6000/rs6000.c	2013-08-28 01:25:24.865218744 -0500
+@@ -7385,9 +7385,7 @@
+       && GET_CODE (XEXP (x, 1)) == CONST_INT
+       && reg_offset_p
+       && !SPE_VECTOR_MODE (mode)
+-      && !(TARGET_E500_DOUBLE && (mode == DFmode || mode == TFmode
+-				  || mode == DDmode || mode == TDmode
+-				  || mode == DImode))
++      && !(TARGET_E500_DOUBLE && GET_MODE_SIZE (mode) > UNITS_PER_WORD)
+       && (!VECTOR_MODE_P (mode) || VECTOR_MEM_NONE_P (mode)))
+     {
+       HOST_WIDE_INT val = INTVAL (XEXP (x, 1));

--- a/samples/powerpc-e500v2-linux-gnuspe/crosstool.config
+++ b/samples/powerpc-e500v2-linux-gnuspe/crosstool.config
@@ -3,7 +3,7 @@ CT_SAVE_TARBALLS=y
 CT_LOG_EXTRA=y
 CT_ARCH_CPU="8548"
 CT_ARCH_TUNE="8548"
-CT_ARCH_FLOAT_SW=y
+CT_ARCH_FLOAT_HW=y
 CT_TARGET_CFLAGS="-mfloat-gprs=double -Wa,-me500x2"
 CT_ARCH_powerpc=y
 CT_ARCH_powerpc_ABI_SPE=y
@@ -11,9 +11,11 @@ CT_TARGET_VENDOR="e500v2"
 CT_KERNEL_linux=y
 CT_BINUTILS_EXTRA_CONFIG_ARRAY="--enable-spe=yes --enable-e500x2 --with-e500x2"
 CT_LIBC_glibc=y
-# CT_LIBC_GLIBC_FORCE_UNWIND is not set
+CT_LIBC_GLIBC_EXTRA_CONFIG_ARRAY="--without-fp"
+CT_LIBC_GLIBC_FORCE_UNWIND=y
+# CT_CC_GCC_SJLJ_EXCEPTIONS is not set
 CT_CC_GCC_SHOW_LINARO=y
-CT_CC_V_4_6_4=y
+CT_CC_V_4_8_4=y
 CT_CC_LANG_CXX=y
 CT_CC_CORE_EXTRA_CONFIG_ARRAY="--with-long-double-128 --enable-e500_double"
 CT_CC_EXTRA_CONFIG_ARRAY="--with-long-double-128 --enable-e500_double"

--- a/samples/powerpc-e500v2-linux-gnuspe/reported.by
+++ b/samples/powerpc-e500v2-linux-gnuspe/reported.by
@@ -1,12 +1,6 @@
-reporter_name="Anthony Foiani <anthony.foiani@gmail.com>"
-reporter_url="http://sourceware.org/ml/crossgcc/2010-09/msg00100.html"
+reporter_name="Manfred Rudigier <manfred.rudigier@omicron.at>"
+reporter_url="http://www.omicron.at"
 reporter_comment="This is a sample config file for Freescale e500v2 processors (e.g., MPC8548,
-MPC8572). It uses eglibc (for e500/SPE patches) and a recent gcc (4.6.0,
-for e500v2 DPFP support) and will generate appropriate dual-precision
-floating point instructions by default.
-
-Note: If building a Linux kernel with this toolchain, you will want to make
-sure -mno-spe AND -mspe=no are passed to gcc to prevent SPE ABI/instructions
-from getting into the kernel (which is currently unsupported). At this time,
-the kernel build system properly passes those two options, but older kernels
-were only passing -mno-spe by default."
+MPC8572, P2020, ...). It uses the recent glibc 2.19 (for e500/SPE patches) and
+a recent gcc (4.8.4, for e500v2 DPFP support) and will generate appropriate
+dual-precision floating point instructions by default."


### PR DESCRIPTION
I have updated this tool chain to a newer GCC 4.8.4 version. I had to add some patches from mailing lists so that the tool chain is actually working.

I've tried the tool chain on a p2020 board, but it should work for any e500v2 powerpc.