### PR TITLE
arch/nios2:add nios2

### DIFF
--- a/config/arch/nios2.in
+++ b/config/arch/nios2.in
@@ -1,0 +1,9 @@
+# NIOS232 specific configuration file
+
+## select ARCH_SUPPORTS_32
+## select ARCH_DEFAULT_32
+## select ARCH_DEFAULT_LE
+## select ARCH_SUPPORTS_WITH_CPU
+##
+## help The NIOS2 architecture, as defined by:
+## help     http://www.altera.com

--- a/scripts/build/arch/nios2.sh
+++ b/scripts/build/arch/nios2.sh
@@ -1,0 +1,13 @@
+# Compute NIOS2-specific values
+
+CT_DoArchTupleValues() {
+    # gcc ./configure flags
+    CT_ARCH_WITH_ARCH=
+    CT_ARCH_WITH_ABI=
+    CT_ARCH_WITH_CPU=
+    CT_ARCH_WITH_TUNE=
+    CT_ARCH_WITH_FPU=
+    CT_ARCH_WITH_FLOAT=
+    CT_TARGET_SYS=elf
+
+}


### PR DESCRIPTION
add the nios2 architecture to crosstool-ng.

Signed-off-by: Daniel Zimmermann <netzimme@gmail.com>