### PR TITLE
scripts/*/*.sh: prioritize http downloads

### DIFF
--- a/scripts/build/binutils/binutils.sh
+++ b/scripts/build/binutils/binutils.sh
@@ -15,8 +15,8 @@ do_binutils_get() {
                        http://cbuild.validation.linaro.org/snapshots
         else
             CT_GetFile "binutils-${CT_BINUTILS_VERSION}"                                        \
-                       ftp://{sourceware.org,gcc.gnu.org}/pub/binutils/{releases,snapshots}     \
-                       {ftp,http}://{ftp.gnu.org/gnu,ftp.kernel.org/pub/linux/devel}/binutils
+                       {http,ftp}://{ftp.gnu.org/gnu,ftp.kernel.org/pub/linux/devel}/binutils   \
+                       ftp://{sourceware.org,gcc.gnu.org}/pub/binutils/{releases,snapshots}
         fi
     fi
 

--- a/scripts/build/cc/gcc.sh
+++ b/scripts/build/cc/gcc.sh
@@ -23,8 +23,8 @@ do_cc_get() {
         # Also, Split out linaro mirrors, so that downloads happen faster.
         if [ x"${linaro_version}" = x"${CT_CC_VERSION}" ]; then
             CT_GetFile "gcc-${CT_CC_VERSION}"                                                   \
-                       ftp://{gcc.gnu.org,sourceware.org}/pub/gcc/releases/gcc-${CT_CC_VERSION} \
-                       {http,ftp,https}://ftp.gnu.org/gnu/gcc/gcc-${CT_CC_VERSION}
+                       {http,ftp,https}://ftp.gnu.org/gnu/gcc/gcc-${CT_CC_VERSION}              \
+                       ftp://{gcc.gnu.org,sourceware.org}/pub/gcc/releases/gcc-${CT_CC_VERSION}
         else
             YYMM=`echo ${CT_CC_VERSION} |cut -d- -f3 |${sed} -e 's,^..,,'`
             CT_GetFile "gcc-${CT_CC_VERSION}"                                                               \
@@ -39,7 +39,9 @@ do_cc_get() {
     # GCC source tree, which will not be there unless we get it and
     # put it there ourselves
     if [ "${CT_CC_LANG_JAVA_USE_ECJ}" = "y" ]; then
-        CT_GetFile ecj-latest .jar ftp://gcc.gnu.org/pub/java   \
+        CT_GetFile ecj-latest .jar http://mirrors.kernel.org/sourceware/java/ \
+                                   http://crosstool-ng.org/pub/java           \
+                                   ftp://gcc.gnu.org/pub/java                 \
                                    ftp://sourceware.org/pub/java
     fi
 }

--- a/scripts/build/debug/300-gdb.sh
+++ b/scripts/build/debug/300-gdb.sh
@@ -52,8 +52,9 @@ do_debug_gdb_get() {
 
             if [ x"${linaro_version}" = x"${CT_GDB_VERSION}" ]; then
                 CT_GetFile "gdb-${CT_GDB_VERSION}"                             \
-                           ftp://{sourceware.org,gcc.gnu.org}/pub/gdb/releases \
-                           {http,ftp,https}://ftp.gnu.org/pub/gnu/gdb
+                           http://mirrors.kernel.org/sourceware/gdb            \
+                           {http,ftp,https}://ftp.gnu.org/pub/gnu/gdb          \
+                           ftp://{sourceware.org,gcc.gnu.org}/pub/gdb/releases
             else
                 YYMM=`echo ${CT_GDB_VERSION} |cut -d- -f3 |${sed} -e 's,^..,,'`
                 CT_GetFile "gdb-${CT_GDB_VERSION}"                                                        \

--- a/scripts/build/debug/400-ltrace.sh
+++ b/scripts/build/debug/400-ltrace.sh
@@ -2,7 +2,7 @@
 
 do_debug_ltrace_get() {
     CT_GetFile "ltrace_${CT_LTRACE_VERSION}.orig" .tar.gz               \
-               {ftp,http}://ftp.debian.org/debian/pool/main/l/ltrace/
+               {http,ftp}://ftp.debian.org/debian/pool/main/l/ltrace/
     # Create a link so that the following steps are easier to do:
     CT_Pushd "${CT_TARBALLS_DIR}"
     ltrace_ext=$(CT_GetFileExtension "ltrace_${CT_LTRACE_VERSION}.orig")

--- a/scripts/build/libc/glibc.sh
+++ b/scripts/build/libc/glibc.sh
@@ -50,6 +50,7 @@ do_libc_get() {
         esac
 
         if ! CT_GetFile "glibc-${addon}-${CT_LIBC_VERSION}"                      \
+               http://mirrors.kernel.org/sourceware/glibc                        \
                {http,ftp,https}://ftp.gnu.org/gnu/glibc                          \
                ftp://{sourceware.org,gcc.gnu.org}/pub/glibc/{releases,snapshots}
         then

--- a/scripts/build/libc/newlib.sh
+++ b/scripts/build/libc/newlib.sh
@@ -10,7 +10,8 @@ LIBC_NEWLIB_AVR_HDRS_BASE="avr-headers-3.2.3.970"
 LIBC_NEWLIB_AVR_HDRS_EXT=".zip"
 
 do_libc_get() {
-    local libc_src="ftp://sourceware.org/pub/newlib"
+    local libc_src="{http://mirrors.kernel.org/sourceware/newlib,
+                     ftp://sourceware.org/pub/newlib}"
 
     if [ "${CT_LIBC_NEWLIB_CUSTOM}" = "y" ]; then
         CT_GetCustom "newlib" "${CT_LIBC_VERSION}"      \


### PR DESCRIPTION
Prirotize http downloads before ftp downloads.
By having http download first, those using proxy will work with the
current download mechnism.

This tells me that that mechnism needs to be updated.
(proxy support and/or kconfig toggles)

closes #3

Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>