### PR TITLE
Add glibc 2.21

### DIFF
--- a/config/libc/glibc.in
+++ b/config/libc/glibc.in
@@ -6,7 +6,7 @@
 ## select CC_CORE_PASSES_NEEDED
 ##
 ## help The de-facto standard for Linux distributions.
-## help Feature-rich, but large...  Most usefull for desktop-like systems.
+## help Feature-rich, but large...  Most useful for desktop-like systems.
 
 config THREADS
     default "nptl"
@@ -16,6 +16,11 @@ choice
     prompt "glibc version"
 # Don't remove next line
 # CT_INSERT_VERSION_BELOW
+
+config LIBC_GLIBC_V_2_21
+    bool
+    prompt "2.21"
+    select LIBC_GLIBC_2_20_or_later
 
 config LIBC_GLIBC_LINARO_V_2_20
     bool
@@ -131,6 +136,7 @@ config LIBC_VERSION
     string
 # Don't remove next line
 # CT_INSERT_VERSION_STRING_BELOW
+    default "2.21" if LIBC_GLIBC_V_2_21
     default "linaro-2.20-2014.11" if LIBC_GLIBC_LINARO_V_2_20
     default "2.20" if LIBC_GLIBC_V_2_20
     default "2.19" if LIBC_GLIBC_V_2_19


### PR DESCRIPTION
2.21 was released yesterday, announcement: https://sourceware.org/ml/libc-alpha/2015-02/msg00119.html

I have compile-tested this with a mips-multilib configuration, but apart from that I can not guarantee anything :)
Should/can we encode the minimum requirement for gcc 4.6 mentioned in that mail somewhere?