### PR TITLE
config: Add config knob for linaro

### DIFF
--- a/config/binutils/binutils.in
+++ b/config/binutils/binutils.in
@@ -2,6 +2,23 @@
 
 comment "GNU binutils"
 
+config BINUTILS_SHOW_LINARO
+    bool
+    prompt "Show Linaro versions"
+    help
+      Linaro is maintaining some advanced/more stable/experimental versions
+      of binutils, especially for the ARM architecture.
+      
+      Those versions have not been blessed by the binutils comunity (nor have they
+      been cursed either!), but they look to be pretty much stable, and even
+      more stable than the upstream versions. YMMV...
+      
+      If you do not know what this Linaro stuff is, then simply say 'n' here,
+      and rest in peace. OTOH, if you know what you are doing, you will be
+      able to use and enjoy :-) the Linaro versions by saying 'y' here.
+      
+      Linaro: http://www.linaro.org/
+
 choice
     bool
     prompt "binutils version"
@@ -11,6 +28,7 @@ choice
 config BINUTILS_LINARO_V_2_25
     bool
     prompt "linaro-2.25.0-2015.01-2"
+    depends on BINUTILS_SHOW_LINARO
     select BINUTILS_2_25_or_later
 
 config BINUTILS_V_2_25
@@ -21,6 +39,7 @@ config BINUTILS_V_2_25
 config BINUTILS_LINARO_V_2_24
     bool
     prompt "linaro-2.24.0-2014.11-2"
+    depends on BINUTILS_SHOW_LINARO
     select BINUTILS_2_24_or_later
 
 config BINUTILS_V_2_24

--- a/config/libc/glibc.in
+++ b/config/libc/glibc.in
@@ -11,6 +11,23 @@
 config THREADS
     default "nptl"
 
+config LIBC_GLIBC_SHOW_LINARO
+    bool
+    prompt "Show Linaro versions"
+    help
+      Linaro is maintaining some advanced/more stable/experimental versions
+      of glibc, especially for the ARM architecture.
+      
+      Those versions have not been blessed by the glibc comunity (nor have they
+      been cursed either!), but they look to be pretty much stable, and even
+      more stable than the upstream versions. YMMV...
+      
+      If you do not know what this Linaro stuff is, then simply say 'n' here,
+      and rest in peace. OTOH, if you know what you are doing, you will be
+      able to use and enjoy :-) the Linaro versions by saying 'y' here.
+      
+      Linaro: http://www.linaro.org/
+
 choice
     bool
     prompt "glibc version"
@@ -20,6 +37,7 @@ choice
 config LIBC_GLIBC_LINARO_V_2_20
     bool
     prompt "Linaro 2.20-2014.11"
+    depends on LIBC_GLIBC_SHOW_LINARO
     select LIBC_GLIBC_2_20_or_later
 
 config LIBC_GLIBC_V_2_20


### PR DESCRIPTION
With gcc and gdb, it's default to not enable linaro support unless a
knob is enabled to "show linaro versions".

This patch adds the same knob to binutils and glibc.

This change was missing from #24

Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>