### PR TITLE
config: Add show linaro config knobs for newlib

### DIFF
--- a/config/libc/newlib.in
+++ b/config/libc/newlib.in
@@ -13,6 +13,23 @@
 ## help array of processors, and will usually work on any architecture with
 ## help the addition of a few low-level routines.
 
+config LIBC_NEWLIB_SHOW_LINARO
+    bool
+    prompt "Show Linaro versions"
+    help
+      Linaro is maintaining some advanced/more stable/experimental versions
+      of newlib, especially for the ARM architecture.
+      
+      Those versions have not been blessed by the newlib comunity (nor have they
+      been cursed either!), but they look to be pretty much stable, and even
+      more stable than the upstream versions. YMMV...
+      
+      If you do not know what this Linaro stuff is, then simply say 'n' here,
+      and rest in peace. OTOH, if you know what you are doing, you will be
+      able to use and enjoy :-) the Linaro versions by saying 'y' here.
+      
+      Linaro: http://www.linaro.org/
+
 choice
     bool
     prompt "newlib version"
@@ -22,6 +39,7 @@ choice
 config LIBC_NEWLIB_LINARO_V_2_2_0
     bool
     prompt "Linaro 2.2.0-2015.01"
+    depends on LIBC_NEWLIB_SHOW_LINARO
 
 config LIBC_NEWLIB_V_2_2_0
     bool
@@ -30,6 +48,7 @@ config LIBC_NEWLIB_V_2_2_0
 config LIBC_NEWLIB_LINARO_V_2_1_0
     bool
     prompt "Linaro 2.1.0-2014.09"
+    depends on LIBC_NEWLIB_SHOW_LINARO
 
 config LIBC_NEWLIB_V_2_1_0
     bool


### PR DESCRIPTION
I forgot about newlib in 081aba3fdc223e028930b156040dd6b38174a0c3.
This commit adds showing/hiding linaro versions for newlib.

Signed-off-by: Bryan Hundven <bhundven@erado.com>