### PR TITLE
fix gccgo build

### DIFF
--- a/patches/gcc/4.9.2/001_gccgo_unused.patch
+++ b/patches/gcc/4.9.2/001_gccgo_unused.patch
@@ -1,0 +1,13 @@
+diff --git a/libgo/runtime/mprof.goc b/libgo/runtime/mprof.goc
+index 7507dfc..44d5669 100644
+--- a/libgo/runtime/mprof.goc
++++ b/libgo/runtime/mprof.goc
+@@ -465,7 +465,7 @@ func ThreadCreateProfile(p Slice) (n int, ok bool) {
+ 
+ func Stack(b Slice, all bool) (n int) {
+ 	byte *pc, *sp;
+-	bool enablegc;
++	bool enablegc = false;
+ 	
+ 	sp = runtime_getcallersp(&b);
+ 	pc = (byte*)(uintptr)runtime_getcallerpc(&b);

--- a/scripts/build/binutils/binutils.sh
+++ b/scripts/build/binutils/binutils.sh
@@ -115,13 +115,13 @@ do_binutils_for_host() {
     fi
 
     # Make those new tools available to the core C compilers to come.
-    # Note: some components want the ${TARGET}-{ar,as,ld,ranlib,strip} commands
+    # Note: some components want the ${TARGET}-{ar,as,ld,ranlib,strip,objcopy,objdump} commands
     # as well. Create that.
     # Don't do it for canadian or cross-native, because the binutils
     # are not executable on the build machine.
     case "${CT_TOOLCHAIN_TYPE}" in
         cross|native)
-            binutils_tools=( ar as ld ranlib strip )
+            binutils_tools=( ar as ld ranlib strip objcopy objdump )
             if [ -n "${CT_ARCH_BINFMT_FLAT}" ]; then
                 binutils_tools+=( elf2flt flthdr )
             fi


### PR DESCRIPTION
This allows gccgo to build with gcc 4.9.2 , I tested with mips big endian, linux 2.6, and linux 3.1
The errors were missing binary utilities, and a false compiler warning about a maybe uninitialized variable.