### PR TITLE
bugfix: pass extra build CFLAGS and LDFLAGS to glibc

### DIFF
--- a/scripts/build/libc/glibc.sh
+++ b/scripts/build/libc/glibc.sh
@@ -371,6 +371,10 @@ do_libc_backend_once() {
             ;;
     esac
 
+    CT_CFLAGS_FOR_BUILD+=" ${CT_EXTRA_CFLAGS_FOR_BUILD}"
+    CT_LDFLAGS_FOR_BUILD+=" ${CT_EXTRA_LDFLAGS_FOR_BUILD}"
+    extra_make_args+=( "BUILD_CFLAGS=${CT_CFLAGS_FOR_BUILD}" "BUILD_LDFLAGS=${CT_LDFLAGS_FOR_BUILD}" )
+
     if [ "${libc_headers}" = "y" ]; then
         CT_DoLog EXTRA "Installing C library headers"
 


### PR DESCRIPTION
Glibc actually does create a build executable.  It's under sunrpc and it's
called cross-rpcgen.  It uses gettext, so if that's not available in a standard
place on your system (for example if you're using Mac OS X and Homebrew), then
you are all out of luck.