### PR TITLE
Update functions to grok symlinks

### DIFF
--- a/scripts/functions
+++ b/scripts/functions
@@ -543,7 +543,7 @@ CT_GetFileExtension() {
     # peculiar components that don't have one (such as sstrip from
     # buildroot).
     for ext in ${first_ext} $(CT_DoListTarballExt) /.git ''; do
-        if [ -e "${CT_TARBALLS_DIR}/${file}${ext}" ]; then
+        if [ -e "${CT_TARBALLS_DIR}/${file}${ext}" -o -L  "${CT_TARBALLS_DIR}/${file}${ext}" ]; then
             echo "${ext}"
             exit 0
         fi


### PR DESCRIPTION
when specifying a custom kernel provided as a tar ball, the tar ball gets symlinked. the -e test will fail for symbolic links, i had to add the -L test as well.