### PR TITLE
Do not use strlen to check that a string is empty

### DIFF
--- a/patches/binutils/2.25/300-012_check_ldrunpath_length.patch
+++ b/patches/binutils/2.25/300-012_check_ldrunpath_length.patch
@@ -15,7 +15,7 @@ index 137446f..bb8391a 100644
    rpath = command_line.rpath;
    if (rpath == NULL)
      rpath = (const char *) getenv ("LD_RUN_PATH");
-+  if ((rpath) && (strlen (rpath) == 0))
++  if ((rpath) && (*rpath == '\0'))
 +  	rpath = NULL;
  
    for (abfd = link_info.input_bfds; abfd; abfd = abfd->link.next)


### PR DESCRIPTION
Here, the exact size of a not empty string is useless.