### PR TITLE
Only create ${CT_TARGET}-cc${ext} symlink if ${CT_TARGET}-gcc exists

### DIFF
--- a/scripts/build/cc/gcc.sh
+++ b/scripts/build/cc/gcc.sh
@@ -492,7 +492,9 @@ do_cc_core_backend() {
     # check whether compiler has an extension
     file="$( ls -1 "${prefix}/bin/${CT_TARGET}-gcc."* 2>/dev/null || true )"
     [ -z "${file}" ] || ext=".${file##*.}"
-    CT_DoExecLog ALL ln -sfv "${CT_TARGET}-gcc${ext}" "${prefix}/bin/${CT_TARGET}-cc${ext}"
+    if [ -f "${prefix}/bin/${CT_TARGET}-gcc${ext}" ]; then
+        CT_DoExecLog ALL ln -sfv "${CT_TARGET}-gcc${ext}" "${prefix}/bin/${CT_TARGET}-cc${ext}"
+    fi
 
     if [ "${CT_MULTILIB}" = "y" ]; then
         if [ "${CT_CANADIAN}" = "y" -a "${mode}" = "baremetal" \
@@ -884,7 +886,9 @@ do_cc_backend() {
     # check whether compiler has an extension
     file="$( ls -1 "${CT_PREFIX_DIR}/bin/${CT_TARGET}-gcc."* 2>/dev/null || true )"
     [ -z "${file}" ] || ext=".${file##*.}"
-    CT_DoExecLog ALL ln -sfv "${CT_TARGET}-gcc${ext}" "${CT_PREFIX_DIR}/bin/${CT_TARGET}-cc${ext}"
+    if [ -f "${CT_PREFIX_DIR}/bin/${CT_TARGET}-gcc${ext}" ]; then
+        CT_DoExecLog ALL ln -sfv "${CT_TARGET}-gcc${ext}" "${CT_PREFIX_DIR}/bin/${CT_TARGET}-cc${ext}"
+    fi
 
     if [ "${CT_MULTILIB}" = "y" ]; then
         if [ "${CT_CANADIAN}" = "y" ]; then


### PR DESCRIPTION
Without this canadion cross builds create invalid symlinks: When `do_cc_core_backend` is called there is no `${CT_TARGET}-gcc` in the install directory. Therefore `ext` is empty and we create a link to `${CT_TARGET}-gcc`. The final compiler step then installs `${CT_TARGET}-gcc.exe` and creates a working `${CT_TARGET}-cc.exe` symlink but we still keep the invalid link as well.

Tested with various cross/canadian cross compilers with windows/linux hosts.