### PR TITLE
build compat fix for mac os: define offsetof if it's missing

### DIFF
--- a/kconfig/zconf.gperf
+++ b/kconfig/zconf.gperf
@@ -7,6 +7,15 @@
 %pic
 %struct-type
 
+%{
+# ifndef offsetof
+#  include <stddef.h>
+#  ifndef offsetof
+#   define offsetof(st, m) ((size_t)(&((st *)0)->m))
+#  endif
+# endif
+%}
+
 struct kconf_id;
 
 static struct kconf_id *kconf_id_lookup(register const char *str, register unsigned int len);


### PR DESCRIPTION
When building on Mac OS, we don't seem to have offsetof when we need it for
gperf-generated code.   This patch solves that issue.

Signed-off-by: Lawrence D'Anna <larry@elder-gods.org>