### PR TITLE
Update case-sensitivity information for Cygwin

### DIFF
--- a/docs/B - Known issues.txt
+++ b/docs/B - Known issues.txt
@@ -79,8 +79,9 @@ Symptoms:
 
 Explanations:
   This is not related to crosstool-NG. Mounts under Cygwin are by default not
-  case-sensitive. You have to use so-called "managed" mounts. See:
-  http://cygwin.com/faq.html section 4, question 32.
+  case-sensitive. You have to change a registry setting to disable
+  case-insensitivity. See:
+  http://cygwin.com/faq.html section 4, question 30.
 
 Status:
   DEPRECATED

--- a/docs/B - Known issues.txt
+++ b/docs/B - Known issues.txt
@@ -87,8 +87,7 @@ Status:
   DEPRECATED
 
 Fix:
-  Use "managed" mounts for the directories where you build *and* install your
-  toolchains.
+  Change the registry value as per the instructions on the Cygwin website.
 
 Workaround:
   None.


### PR DESCRIPTION
Cygwin no longer supports managed mounts, enabling case-sensitivity in Cygwin requires changing the registry.

FAQ number has also changed.