### PR TITLE
Display 'Other languages' for bare metal as well

### DIFF
--- a/config/cc.in
+++ b/config/cc.in
@@ -120,6 +120,8 @@ config CC_LANG_GOLANG
       Only select this if you know that your specific version of the
       compiler supports this language.
 
+endif # ! BARE_METAL
+
 config CC_LANG_OTHERS
     string
     prompt "Other languages (EXPERIMENTAL)"
@@ -131,8 +133,6 @@ config CC_LANG_OTHERS
 
       Eg. gcc-4.1+ has a toy programming language, treelang. As it is not useful
       in real life, it is not available in the selection above.
-
-endif # ! BARE_METAL
 
 source "config.gen/cc.in.2"
 


### PR DESCRIPTION
There are other languages which work with bare metal compilers. As an example crosstool-ng is recommended to build D/GDC bare metal compilers.

Signed-off-by: Johannes Pfau <johannespfau@gmail.com>

See http://wiki.dlang.org/GDC/Cross_Compiler/crosstool-NG