### PR TITLE
debug/ltrace : avoid a gcc 5.1.0 error

### DIFF
--- a/patches/ltrace/0.7.3/110-ltrace.git-8c3674c86688a79a8689772c3d0c84d6e7aaa118.patch
+++ b/patches/ltrace/0.7.3/110-ltrace.git-8c3674c86688a79a8689772c3d0c84d6e7aaa118.patch
@@ -1,0 +1,25 @@
+From 8c3674c86688a79a8689772c3d0c84d6e7aaa118 Mon Sep 17 00:00:00 2001
+From: Petr Machata <pmachata@redhat.com>
+Date: Tue, 8 Jan 2013 23:22:49 +0100
+Subject: Fix conditions in elf_read_u{16,32,64}
+
+- The calling convention of need_data is 0 on success, <0 on failure.
+  The condition seems to have it all mixed, using both a ! and a
+  comparison.
+
+diff --git a/ltrace-elf.c b/ltrace-elf.c
+index 29c204f..0ecdc38 100644
+--- a/ltrace-elf.c
++++ b/ltrace-elf.c
+@@ -219,7 +219,7 @@ need_data(Elf_Data *data, GElf_Xword offset, GElf_Xword size)
+ 	int								\
+ 	NAME(Elf_Data *data, GElf_Xword offset, uint##SIZE##_t *retp)	\
+ 	{								\
+-		if (!need_data(data, offset, SIZE / 8) < 0)		\
++		if (need_data(data, offset, SIZE / 8) < 0)		\
+ 			return -1;					\
+ 									\
+ 		if (data->d_buf == NULL) /* NODATA section */ {		\
+-- 
+cgit v0.10.2
+


### PR DESCRIPTION
to avoid a gcc 5.1.0 error add a patch for ltrace 0.7.3

Signed-off-by: Daniel Zimmermann <netzimme@gmail.com>