### PR TITLE
complibs: Update requirements for gcc-5.1

### DIFF
--- a/config/cc/gcc.in
+++ b/config/cc/gcc.in
@@ -454,7 +454,7 @@ config CC_GCC_USE_GRAPHITE
     bool
     default y
     depends on CC_GCC_HAS_GRAPHITE
-    select CLOOG_NEEDED
+    select CLOOG_NEEDED if !CC_GCC_5_1_or_later
     select PPL_NEEDED if !CC_GCC_4_8_or_later
     select ISL_NEEDED if CC_GCC_4_8_or_later
     help

--- a/config/companion_libs/isl.in
+++ b/config/companion_libs/isl.in
@@ -17,6 +17,7 @@ config ISL_V_0_12_2
 config ISL_V_0_11_1
     bool
     prompt "0.11.1"
+    depends on ! CC_GCC_5_1_or_later
 
 endchoice
 


### PR DESCRIPTION
As per: https://gcc.gnu.org/gcc-5/changes.html

"The Graphite framework for loop optimizations no longer requires the
CLooG library, only ISL version 0.14 (recommended) or 0.12.2. The
installation manual contains more information about requirements to
build GCC."

This change helps to avoid version badness.

Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>