### PR TITLE
config: Add gcc-5.1.0

### DIFF
--- a/config/cc/gcc.in
+++ b/config/cc/gcc.in
@@ -36,6 +36,11 @@ choice
 # Don't remove next line
 # CT_INSERT_VERSION_BELOW
 
+config CC_V_5_1
+    bool
+    prompt "5.1.0"
+    select CC_GCC_5_1
+
 config CC_V_linaro_4_9
     bool
     prompt "linaro-4.9-2015.03"
@@ -409,9 +414,27 @@ config CC_GCC_4_9_or_later
     bool
     select CC_GCC_4_8_or_later
 
-config CC_GCC_latest
+config CC_GCC_5_1
+    bool
+    select CC_GCC_5_1_or_later
+    select CC_GCC_USE_GMP_MPFR
+    select CC_GCC_USE_MPC
+    select CC_GCC_HAS_GRAPHITE
+    select CC_GCC_HAS_LTO
+    select CC_GCC_HAS_PKGVERSION_BUGURL
+    select CC_GCC_HAS_BUILD_ID
+    select CC_GCC_HAS_LNK_HASH_STYLE
+    select CC_GCC_HAS_LIBQUADMATH
+    select CC_GCC_HAS_LIBSANITIZER
+    select CC_SUPPORT_GOLANG
+
+config CC_GCC_5_1_or_later
     bool
     select CC_GCC_4_9_or_later
+
+config CC_GCC_latest
+    bool
+    select CC_GCC_5_1_or_later
     select CC_GCC_USE_GMP_MPFR
     select CC_GCC_USE_MPC
     select CC_GCC_HAS_GRAPHITE
@@ -508,6 +531,7 @@ config CC_VERSION
     string
 # Don't remove next line
 # CT_INSERT_VERSION_STRING_BELOW
+    default "5.1.0" if CC_V_5_1
     default "linaro-4.9-2015.03" if CC_V_linaro_4_9
     default "4.9.2" if CC_V_4_9_2
     default "4.9.1" if CC_V_4_9_1


### PR DESCRIPTION
This change needs another change from pull request #81, but it's kind of
a chicken/egg scenario. The 'select's in CC_GCC_5_1 need to be
refactored a bit, and would be easier to test if gcc-5.1.0 was commited.

Most of the refactoring will happen with CC_GCC_HAS_GRAPHITE.

Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>