### PR TITLE
scripts: If paths.sh is included, use the variables

### DIFF
--- a/scripts/addToolVersion.sh
+++ b/scripts/addToolVersion.sh
@@ -80,9 +80,9 @@ addToolVersion() {
     # to try adding a new version if the one he/she wants is not listed.
     # But it can be the case where the version is hidden behind either one
     # of EXPERIMENTAL or OBSOLETE, so warn if the version is already listed.
-    if grep -E "^config ${config_ver_option}$" "${file}" >/dev/null 2>&1; then
+    if ${grep} -E "^config ${config_ver_option}$" "${file}" >/dev/null 2>&1; then
         echo "'${tool}': version '${version}' already present:"
-        grep -A1 -B0 -n                                                     \
+        ${grep} -A1 -B0 -n                                                     \
              -E "^(config ${config_ver_option}| {4}prompt \"${version}\")$" \
              "${file}" /dev/null
         return 0

--- a/scripts/crosstool-NG.sh.in
+++ b/scripts/crosstool-NG.sh.in
@@ -562,7 +562,7 @@ if [ -z "${CT_RESTART}" ]; then
     CT_DoLog EXTRA "Installing user-supplied crosstool-NG configuration"
     CT_DoExecLog ALL mkdir -p "${CT_PREFIX_DIR}/bin"
     CT_DoExecLog DEBUG install -m 0755 "${CT_LIB_DIR}/scripts/toolchain-config.in" "${CT_PREFIX_DIR}/bin/${CT_TARGET}-ct-ng.config"
-    CT_DoExecLog DEBUG sed -i -e 's,@@grep@@,"'"${grep}"'",;' "${CT_PREFIX_DIR}/bin/${CT_TARGET}-ct-ng.config"
+    CT_DoExecLog DEBUG ${sed} -i -e 's,@@grep@@,"'"${grep}"'",;' "${CT_PREFIX_DIR}/bin/${CT_TARGET}-ct-ng.config"
     bzip2 -c -9 .config >>"${CT_PREFIX_DIR}/bin/${CT_TARGET}-ct-ng.config"
 
     CT_DoStep EXTRA "Dumping internal crosstool-NG configuration"

--- a/scripts/saveSample.sh.in
+++ b/scripts/saveSample.sh.in
@@ -89,8 +89,8 @@ cp .config .defconfig
 CT_DoAddFileToSample() {
     source="$1"
     dest="$2"
-    inode_s=$(ls -i "${source}" |awk '{ print $1; }')
-    inode_d=$(ls -i "${dest}" 2>/dev/null |awk '{ print $1; }' || true)
+    inode_s=$(ls -i "${source}" | ${awk} '{ print $1; }')
+    inode_d=$(ls -i "${dest}" 2>/dev/null | ${awk} '{ print $1; }' || true)
     if [ "${inode_s}" != "${inode_d}" ]; then
         cp "${source}" "${dest}"
     fi
@@ -132,7 +132,7 @@ read -p "Reporter name [${reporter_name}]: " reporter_name
 read -p "Reporter URL [${reporter_url}]: " reporter_url
 if [ -n "${reporter_comment}" ]; then
   echo "Old comment:"
-  printf "${reporter_comment}\n" |sed -r -e 's/^/  > /;'
+  printf "${reporter_comment}\n" | ${sed} -r -e 's/^/  > /;'
 fi
 echo "Reporter comment (Ctrl-D to finish, '.' to use previous):"
 reporter_comment=$(cat)


### PR DESCRIPTION
This commit changes sed, awk, and grep to use the ones we found during
configure time. This helps make the build more consistent.

Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>