### PR TITLE
mingw: WINAPI_V_DEVEL should depend on EXPERIMENTAL

### DIFF
--- a/config/libc/mingw.in
+++ b/config/libc/mingw.in
@@ -20,6 +20,7 @@ choice
 config WINAPI_V_DEVEL
     bool
     prompt "devel"
+    depends on EXPERIMENTAL
 
 config WINAPI_V_4_0_2
     bool


### PR DESCRIPTION
While we do want users to be able to use the mingw from git, being under
the experimental umbrella makes it more obvious that this should not be
used as a production toolchain.

Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>