### PR TITLE
gdb: add gdb 7.9.1

### DIFF
--- a/config/debug/gdb.in
+++ b/config/debug/gdb.in
@@ -33,6 +33,11 @@ choice
 # Don't remove next line
 # CT_INSERT_VERSION_BELOW
 
+config GDB_V_7_9_1
+    bool
+    prompt "7.9.1"
+    select GDB_7_2_or_later
+
 config GDB_V_7_9
     bool
     prompt "7.9"
@@ -185,6 +190,7 @@ config GDB_VERSION
     string
 # Don't remove next line
 # CT_INSERT_VERSION_STRING_BELOW
+    default "7.9.1" if GDB_V_7_9_1
     default "7.9" if GDB_V_7_9
     default "7.8.2" if GDB_V_7_8_2
     default "linaro-7.8-2014.09" if GDB_V_linaro_7_8


### PR DESCRIPTION
As per: http://www.gnu.org/software/gdb/download/ANNOUNCEMENT

========================================================================
GDB 7.9.1 brings the following fixes and enhancements over GDB 7.9:

   * PR build/18033 (C++ style comment used in gdb/iq2000-tdep.c and
     gdb/compile/compile-*.c)
   * PR build/18298 ("compile" command cannot find compiler if tools
     configured with triplet instead of quadruplet)
   * PR tui/18311 (Random SEGV when displaying registers in TUI mode)
   * PR python/18299 (exception when registering a global pretty-printer
     in verbose mode)
   * PR python/18066 (argument "word" seems broken in Command.complete
     (text, word))
   * PR pascal/17815 (Fix pascal behavior for class fields with
   * testcase)
   * PR python/18285 (ptype expr-with-xmethod causes SEGV)
========================================================================

Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>