### PR TITLE
kernel: Update versions. Remove older kernels

### DIFF
--- a/config/kernel/linux.in
+++ b/config/kernel/linux.in
@@ -28,157 +28,41 @@ choice
 
 config KERNEL_V_4_0
     bool
-    prompt "4.0.3"
+    prompt "4.0.4 (stable)"
 
 config KERNEL_V_3_19
     bool
-    prompt "3.19.8"
+    prompt "3.19.8 (EOL)"
 
 config KERNEL_V_3_18
     bool
-    prompt "3.18.13 (longterm)"
-
-config KERNEL_V_3_17
-    bool
-    prompt "3.17.8"
-
-config KERNEL_V_3_16
-    bool
-    prompt "3.16.7"
-
-config KERNEL_V_3_15
-    bool
-    prompt "3.15.10"
+    prompt "3.18.14"
 
 config KERNEL_V_3_14
     bool
-    prompt "3.14.42 (longterm)"
-
-config KERNEL_V_3_13
-    bool
-    prompt "3.13.11"
+    prompt "3.14.43"
 
 config KERNEL_V_3_12
     bool
-    prompt "3.12.42 (longterm)"
-
-config KERNEL_V_3_11
-    bool
-    prompt "3.11.10"
+    prompt "3.12.43"
 
 config KERNEL_V_3_10
     bool
-    prompt "3.10.78 (longterm)"
-
-config KERNEL_V_3_9
-    bool
-    prompt "3.9.11"
-
-config KERNEL_V_3_8
-    bool
-    prompt "3.8.13"
-
-config KERNEL_V_3_7
-    bool
-    prompt "3.7.10"
-
-config KERNEL_V_3_6
-    bool
-    prompt "3.6.11"
-
-config KERNEL_V_3_5
-    bool
-    prompt "3.5.7"
+    prompt "3.10.79"
 
 config KERNEL_V_3_4
     bool
-    prompt "3.4.107 (longterm)"
-
-config KERNEL_V_3_3
-    bool
-    prompt "3.3.8"
+    prompt "3.4.107"
 
 config KERNEL_V_3_2
     bool
-    prompt "3.2.69 (longterm)"
-
-config KERNEL_V_3_1
-    bool
-    prompt "3.1.10"
-
-config KERNEL_V_3_0
-    bool
-    prompt "3.0.101"
-
-config KERNEL_V_2_6_39
-    bool
-    prompt "2.6.39.4"
-
-config KERNEL_V_2_6_38
-    bool
-    prompt "2.6.38.8"
-
-config KERNEL_V_2_6_37
-    bool
-    prompt "2.6.37.6"
-
-config KERNEL_V_2_6_36
-    bool
-    prompt "2.6.36.4"
-
-config KERNEL_V_2_6_33
-    bool
-    prompt "2.6.33.20"
-    help
-      This is primarily for the use of those people who are stuck using the
-      .33-rt kernel.  Anyone else who really wants to use the .33 kernel tree
-      is welcome to use this one as well.
+    prompt "3.2.69"
 
 config KERNEL_V_2_6_32
     bool
-    prompt "2.6.32.65 (longterm)"
+    prompt "2.6.32.66"
     help
-      The Linux 2.6.32 tree is a "longterm" maintenance branch.
-      
-      It is intended to fill the niche for users who are not using distribution
-      kernels but want to use a regression-free kernel for a longer time.
-      
-      Critical bug fixes to later 2.6 releases are often ported to this branch
-      which makes 2.6.32 a very useful base for many embedded developers seeking
-      stable APIs or those who do not need the latest bleeding edge features.
-      
-      ... and no, this kernel has not undergone any specific QA testing.
-      
-      See the original announcement by Greg Kroah-Hartman in the following
-      mailing list entry:
-        http://marc.info/?l=linux-kernel&m=126384198403392&w=4
-
-config KERNEL_V_2_6_31
-    bool
-    prompt "2.6.31.14"
-
-config KERNEL_V_2_6_27
-    bool
-    prompt "2.6.27.62 (longterm)"
-    help
-      The Linux 2.6.27 tree is a "longterm" maintenance branch.
-      
-      It is intended to fill the niche for users who are not using distribution
-      kernels but want to use a regression-free kernel for a longer time.
-      
-      Critical bug fixes to later 2.6 releases are often ported to this branch
-      which makes 2.6.27 a very useful base for many embedded developers seeking
-      stable APIs or those who do not need the latest bleeding edge features.
-      
-      ... and no, this kernel has not undergone any specific QA testing.
-      
-      See the original announcement by Adrian Bunk in the following mailing list
-      entry:
-        http://marc.info/?l=linux-kernel&m=122375909403298&w=4
-      
-      It is now maintained by Greg Kroah-Hartman, see this mailing list entry:
-        http://marc.info/?l=linux-kernel&m=129133701916793&w=4
-
+ 
 config KERNEL_LINUX_CUSTOM
     bool
     prompt "custom tarball or directory"
@@ -199,35 +83,15 @@ config KERNEL_VERSION
     string
 # Don't remove next line
 # CT_INSERT_VERSION_STRING_BELOW
-    default "4.0.3" if KERNEL_V_4_0
+    default "4.0.4" if KERNEL_V_4_0
     default "3.19.8" if KERNEL_V_3_19
-    default "3.18.13" if KERNEL_V_3_18
-    default "3.17.8" if KERNEL_V_3_17
-    default "3.16.7" if KERNEL_V_3_16
-    default "3.15.10" if KERNEL_V_3_15
-    default "3.14.42" if KERNEL_V_3_14
-    default "3.13.11" if KERNEL_V_3_13
-    default "3.12.42" if KERNEL_V_3_12
-    default "3.11.10" if KERNEL_V_3_11
-    default "3.10.78" if KERNEL_V_3_10
-    default "3.9.11" if KERNEL_V_3_9
-    default "3.8.13" if KERNEL_V_3_8
-    default "3.7.10" if KERNEL_V_3_7
-    default "3.6.11" if KERNEL_V_3_6
-    default "3.5.7" if KERNEL_V_3_5
+    default "3.18.14" if KERNEL_V_3_18
+    default "3.14.43" if KERNEL_V_3_14
+    default "3.12.43" if KERNEL_V_3_12
+    default "3.10.79" if KERNEL_V_3_10
     default "3.4.107" if KERNEL_V_3_4
-    default "3.3.8" if KERNEL_V_3_3
     default "3.2.69" if KERNEL_V_3_2
-    default "3.1.10" if KERNEL_V_3_1
-    default "3.0.101" if KERNEL_V_3_0
-    default "2.6.39.4" if KERNEL_V_2_6_39
-    default "2.6.38.8" if KERNEL_V_2_6_38
-    default "2.6.37.6" if KERNEL_V_2_6_37
-    default "2.6.36.4" if KERNEL_V_2_6_36
-    default "2.6.33.20" if KERNEL_V_2_6_33
-    default "2.6.32.65" if KERNEL_V_2_6_32
-    default "2.6.31.14" if KERNEL_V_2_6_31
-    default "2.6.27.62" if KERNEL_V_2_6_27
+    default "2.6.32.66" if KERNEL_V_2_6_32
     default "custom" if KERNEL_LINUX_CUSTOM
 
 endif # ! KERNEL_LINUX_USE_CUSTOM_HEADERS


### PR DESCRIPTION
In this update the following kernels updated:
 * 4.0.3 -> 4.0.4
 * 3.18.13 -> 3.18.14
 * 3.14.42 -> 3.14.43
 * 3.12.42 -> 3.12.43
 * 3.10.78 -> 3.10.79
 * 3.2.68 -> 3.2.69
 * 2.6.32.65 -> 3.6.32.66

Also, let's remove the older EOL'd kernels.
This makes updating kernel versions easier.

Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>