### PR TITLE
populate: Add gconv path

### DIFF
--- a/scripts/populate.in
+++ b/scripts/populate.in
@@ -184,13 +184,13 @@ do_add_lib() {
     local dir
     local mode
 
-    for dir in lib usr/lib; do
+    for dir in lib usr/lib usr/lib/gconv; do
         if [ -e "${dir}/${libname}" ]; then
             ${CT_PRINTF} "    already present\n"
             return 0
         fi
     done
-    for dir in lib usr/lib; do
+    for dir in lib usr/lib usr/lib/gconv; do
         ${CT_PRINTF} "    trying in '%s'" "${dir}"
         libfile="${CT_SYSROOT_DIR}/${dir}/${libname}"
         ${CT_PRINTF} ": '%s'\n" "${libfile}"


### PR DESCRIPTION
When using populate, it fails on gconv libraries:

========================================================================
$ x86_64-pc-linux-gnu-populate -s ~/dev/x-tools/x86_64-pc-linux-gnu/x86_64-pc-linux-gnu/sysroot -d ./rootimage
x86_64-pc-linux-gnu-populate: library 'libJIS.so' not found!
========================================================================

With this patch, the usr/lib/gconv directory is also installed to the
destination sysroot properly.

This closes #100

Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>