### PR TITLE
populate: also search for gconv modules

### DIFF
--- a/scripts/populate.in
+++ b/scripts/populate.in
@@ -184,13 +184,13 @@ do_add_lib() {
     local dir
     local mode
 
-    for dir in lib usr/lib; do
+    for dir in lib usr/lib usr/lib/gconv; do
         if [ -e "${dir}/${libname}" ]; then
             ${CT_PRINTF} "    already present\n"
             return 0
         fi
     done
-    for dir in lib usr/lib; do
+    for dir in lib usr/lib usr/lib/gconv; do
         ${CT_PRINTF} "    trying in '%s'" "${dir}"
         libfile="${CT_SYSROOT_DIR}/${dir}/${libname}"
         ${CT_PRINTF} ": '%s'\n" "${libfile}"


### PR DESCRIPTION
The gconv modules are present in the (e)glibc toolchains, and some
applications directly link with one or more of those modules (even
though the classic way of using them is by dlopen()ing them).

So, also look in /usr/lib/gconv when searching for libraries.

Signed-off-by: "Yann E. MORIN" <yann.morin.1998@free.fr>