### PR TITLE
musl: Update versions

### DIFF
--- a/config/libc/musl.in
+++ b/config/libc/musl.in
@@ -18,14 +18,14 @@ choice
 # Don't remove next line
 # CT_INSERT_VERSION_BELOW
 
-config LIBC_MUSL_V_1_1_5
+config LIBC_MUSL_V_1_1
     bool
-    prompt "1.1.5 (Mainline)"
+    prompt "1.1.9 (Mainline)"
     depends on EXPERIMENTAL
 
-config LIBC_MUSL_V_1_0_4
+config LIBC_MUSL_V_1_0
     bool
-    prompt "1.0.4 (Stable)"
+    prompt "1.0.5 (Stable)"
 
 config LIBC_MUSL_V_CUSTOM
     bool
@@ -38,6 +38,6 @@ config LIBC_VERSION
     string
 # Don't remove next line
 # CT_INSERT_VERSION_STRING_BELOW
-    default "1.1.5" if LIBC_MUSL_V_1_1_5
-    default "1.0.4" if LIBC_MUSL_V_1_0_4
+    default "1.1.9" if LIBC_MUSL_V_1_1
+    default "1.0.5" if LIBC_MUSL_V_1_0
     default "custom" if LIBC_MUSL_V_CUSTOM


### PR DESCRIPTION
This commit updates the version knobs so that oldconfig does the right
thing when we bump versions.

Also, we update stable to 1.0.5 and experimental to 1.1.9.

Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>