### PR TITLE
config/gcc: Fix gcc 5.1.0 version knob

### DIFF
--- a/config/cc/gcc.in
+++ b/config/cc/gcc.in
@@ -37,7 +37,7 @@ choice
 # Don't remove next line
 # CT_INSERT_VERSION_BELOW
 
-config CC_GCC_V_5_1
+config CC_GCC_V_5_1_0
     bool
     prompt "5.1.0"
     select CC_GCC_5_1
@@ -181,7 +181,6 @@ config CC_GCC_V_4_5_0
     bool
     prompt "4.5.0"
     select CC_GCC_4_5
-
 
 config CC_GCC_V_linaro_4_4
     bool
@@ -532,7 +531,7 @@ config CC_GCC_VERSION
     string
 # Don't remove next line
 # CT_INSERT_VERSION_STRING_BELOW
-    default "5.1.0" if CC_GCC_V_5_1
+    default "5.1.0" if CC_GCC_V_5_1_0
     default "linaro-4.9-2015.03" if CC_GCC_V_linaro_4_9
     default "4.9.2" if CC_GCC_V_4_9_2
     default "4.9.1" if CC_GCC_V_4_9_1


### PR DESCRIPTION
This change makes the 5.1.0 version knob consistant with previous gcc
versions.

Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>