### PR TITLE
newlib/patch: Add eabihf patch

### DIFF
--- a/patches/newlib/1.20.0/110-fix-eabihf.patch
+++ b/patches/newlib/1.20.0/110-fix-eabihf.patch
@@ -1,0 +1,12 @@
+diff -ur newlib-1.20.0.orig/libgloss/arm/configure.in newlib-1.20.0/libgloss/arm/configure.in
+--- newlib-1.20.0.orig/libgloss/arm/configure.in    2006-05-10 22:51:40.000000000 +0200
++++ newlib-1.20.0/libgloss/arm/configure.in 2015-01-04 15:27:41.471549917 +0100
+@@ -49,7 +49,7 @@
+ LIB_AM_PROG_AS
+
+ case "${target}" in
+-  *-*-elf | *-*-eabi)
++  *-*-elf | *-*-eabi*)
+    objtype=elf-
+    ;;
+   *-*-coff)


### PR DESCRIPTION
This patch gets newlib 1.20.0 to work with eabihf tuple.

This commit closes #23

Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>