### PR TITLE
gcc: Remove --enable-c99

### DIFF
--- a/scripts/build/cc/100-gcc.sh
+++ b/scripts/build/cc/100-gcc.sh
@@ -859,7 +859,6 @@ do_gcc_backend() {
         ${CC_SYSROOT_ARG}                           \
         "${extra_config[@]}"                        \
         --with-local-prefix="${CT_SYSROOT_DIR}"     \
-        --enable-c99                                \
         --enable-long-long                          \
         "${CT_CC_GCC_EXTRA_CONFIG_ARRAY[@]}"
 


### PR DESCRIPTION
This option is old. GCC 4.3.x old. It isn't supported anymore, and just
confuses me. I'm not planning to support 4.3.x, or really anything older
then 4.7. So this option is gone to the wind.

Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>