### PR TITLE
gcc: Workaround an uninitialized bool

### DIFF
--- a/scripts/build/cc/100-gcc.sh
+++ b/scripts/build/cc/100-gcc.sh
@@ -841,6 +841,11 @@ do_gcc_backend() {
         extra_config+=("--disable-multilib")
     fi
 
+    # Workaround for an uninitialized bool in libgo/runtime/mprof.goc:406
+    if [ "${CT_CC_LANG_GOLANG}" = "y" ]; then
+        extra_config+=("--enable-werror=no")
+    fi
+
     CT_DoLog DEBUG "Extra config passed: '${extra_config[*]}'"
 
     CT_DoExecLog CFG                                \


### PR DESCRIPTION
in: libgo/runtime/mprof.goc:406
enablegc is not initialized and throws a warning. -Werror is on by
default and cause the build to fail.

=========== TEMPORARY =============
This commit is not complete. The build still fails.
See: https://sourceware.org/ml/crossgcc/2015-06/msg00011.html
That issue should be fixed in this commit as well.
But, is currently unresolved.
This patch is just being pushed for review.
===================================

Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>