### PR TITLE
arch: do not allow specifying both --with-arch and --with-cpu

### DIFF
--- a/config/target.in
+++ b/config/target.in
@@ -196,6 +196,7 @@ config ARCH_ARCH
     string
     prompt "Architecture level"
     depends on ARCH_SUPPORTS_WITH_ARCH
+    depends on ARCH_CPU = ""
     default ""
     help
       GCC uses this name to determine what kind of instructions it can emit


### PR DESCRIPTION
Normally, a specific CPU fully implies the architecture level. For
example, a cortec-a8 is forcibly an armv7, so spwecifying both is
redundant, and even dangerous (as incompatible values may be passed).

So far, gcc was pretty happy when both were specified at the same time,
and some time ago, it started being a warning, and only recently was it
turned into a hard error.

So, hide the architecture level prompt when a CPU has been specified.

Signed-off-by: "Yann E. MORIN" <yann.morin.1998@free.fr>