### PR TITLE
arch: do not allow specifying both --with-cpu and --with-tune

### DIFF
--- a/config/target.in
+++ b/config/target.in
@@ -253,6 +253,7 @@ config ARCH_TUNE
     string
     prompt "Tune for CPU"
     depends on ARCH_SUPPORTS_WITH_TUNE
+    depends on ARCH_CPU = ""
     default ""
     help
       This option is very similar to the ARCH_CPU option (above), except


### PR DESCRIPTION
Similarly to what we've just done to prevent both --with-arch and
--with-cpu, we do the same to prevent using both --with-cpu and
--with-tune at the same time, since --with-cpu should fully imply
the CPU to tune for (and gcc now errors out when both are specified.

Signed-off-by: "Yann E. MORIN" <yann.morin.1998@free.fr>
Cc: Bryan Hundven <bryanhundven@gmail.com>