### PR TITLE
test-suite: define $tmpdir to $TOPDIR

### DIFF
--- a/contrib/gcc-test-suite/Makefile
+++ b/contrib/gcc-test-suite/Makefile
@@ -45,6 +45,7 @@ $(LOGDIR):
 
 $(LOGDIR)/site.exp: $(TOPDIR)/default.cfg $(LOGDIR)
 	@{ echo 'lappend boards_dir "$(LOGDIR)"'; \
+	   echo 'set tmpdir "$(TOPDIR)"'; \
 	   echo 'set target_alias $(TARGET)';     } > $@
 
 $(LOGDIR)/board.exp: $(TOPDIR)/default.cfg $(LOGDIR)


### PR DESCRIPTION
The missing definition of $tmpdir caused it to default to /tmp, which
may cause problems when testcases generate temporary files in the
current directory ($TOPDIR) and then try to access them at $tmpdir.

Errors such as the following were reported in test-suite runs for both
arm and powerpc toolchains due to $tmpdir pointing to /tmp and files
being generated in $TOPDIR:

  error: could not open dump file '/tmp/dump1/dump-noaddr.c.011t.cfg':
  No such file or directory
  FAIL: gcc.c-torture/unsorted/dump-noaddr.c,  -O0   -dumpbase
  dump1/dump-noaddr.c -DMASK=1 -x c --param ggc-min-heapsize=1
  -fdump-ipa-all -fdump-rtl-all -fdump-tree-all -fdump-noaddr

  FAIL: gcc.dg/tree-prof/ic-misattribution-1.c execution:
  file ic-misattribution-1.gcda does not exist,  -fprofile-generate
  -D_PROFILE_GENERATE

Signed-off-by: Erico Nunes <erico.nunes@datacom.ind.br>