### PR TITLE
32-bit multilib support for gcc and glibc

### DIFF
--- a/scripts/build/arch/x86.sh
+++ b/scripts/build/arch/x86.sh
@@ -8,6 +8,8 @@ CT_DoArchTupleValues() {
         CT_TARGET_ARCH=x86_64
     else
         arch="${CT_ARCH_ARCH}"
+	# Check if this is a multilib target variant
+        [ -z "${arch}" -a "${CT_TARGET_ARCH}" = "x86_64" ] && arch=i686
         [ -z "${arch}" ] && arch="${CT_ARCH_TUNE}"
         case "${arch}" in
             "")                           CT_TARGET_ARCH=i386;;

--- a/scripts/build/libc/glibc.sh
+++ b/scripts/build/libc/glibc.sh
@@ -172,6 +172,11 @@ do_libc_backend() {
                         fi
                     done
                 done
+                # Copy the gnu/{lib-names,stubs}-${multi_dir} headers needed by gnu/{lib-names,stubs}.h
+                CT_DoExecLog ALL cp -v "${CT_SYSROOT_DIR}/${multi_dir}/usr/include/gnu/lib-names-${multi_dir}.h" \
+                                       "${CT_HEADERS_DIR}/gnu/lib-names-${multi_dir}.h"
+                CT_DoExecLog ALL cp -v "${CT_SYSROOT_DIR}/${multi_dir}/usr/include/gnu/stubs-${multi_dir}.h" \
+                                       "${CT_HEADERS_DIR}/gnu/stubs-${multi_dir}.h"
                 # Remove the multi_dir now it is no longer useful
                 CT_DoExecLog DEBUG rm -rf "${CT_SYSROOT_DIR}/${multi_dir}"
             fi # libc_mode == final

--- a/scripts/build/libc/glibc.sh
+++ b/scripts/build/libc/glibc.sh
@@ -355,7 +355,7 @@ do_libc_backend_once() {
     CT_DoExecLog CFG                                                \
     BUILD_CC="${CT_BUILD}-gcc"                                      \
     CFLAGS="${glibc_cflags}"                                        \
-    CC="${CT_TARGET}-gcc ${CT_LIBC_EXTRA_CC_ARGS} ${extra_cc_args}" \
+    CC="${cross_cc} ${CT_LIBC_EXTRA_CC_ARGS} ${extra_cc_args}" \
     AR=${CT_TARGET}-ar                                              \
     RANLIB=${CT_TARGET}-ranlib                                      \
     "${CONFIG_SHELL}"                                               \
@@ -450,7 +450,9 @@ do_libc_backend_once() {
             # However, since we will never actually execute its code,
             # it doesn't matter what it contains.  So, treating '/dev/null'
             # as a C source file, we produce a dummy 'libc.so' in one step
-            CT_DoExecLog ALL "${cross_cc}" -nostdlib        \
+            CT_DoExecLog ALL "${cross_cc}" ${CT_LIBC_EXTRA_CC_ARGS} \
+                                           ${extra_cc_args} \
+                                           -nostdlib        \
                                            -nostartfiles    \
                                            -shared          \
                                            -x c /dev/null   \

--- a/scripts/build/libc/glibc.sh
+++ b/scripts/build/libc/glibc.sh
@@ -296,6 +296,15 @@ do_libc_backend_once() {
             ;;
     esac
 
+    glibc_target="${CT_TARGET}"
+    case "${extra_flags}" in
+        *-m32*)
+            if [ -n "${CT_TARGET_32}" ]; then
+                glibc_target="${CT_TARGET_32}"
+            fi
+            ;;
+    esac
+
     touch config.cache
     if [ "${CT_LIBC_GLIBC_FORCE_UNWIND}" = "y" ]; then
         echo "libc_cv_forced_unwind=yes" >>config.cache
@@ -353,7 +362,7 @@ do_libc_backend_once() {
     "${src_dir}/configure"                                          \
         --prefix=/usr                                               \
         --build=${CT_BUILD}                                         \
-        --host=${CT_TARGET}                                         \
+        --host=${glibc_target}                                      \
         --cache-file="$(pwd)/config.cache"                          \
         --without-cvs                                               \
         --disable-profile                                           \

--- a/scripts/crosstool-NG.sh.in
+++ b/scripts/crosstool-NG.sh.in
@@ -339,21 +339,26 @@ if [ -z "${CT_RESTART}" ]; then
         CT_Popd
     fi
 
-    # Since we're *not* multilib on the target side, we want all the
-    # libraries to end up in "lib".  We create "lib64" (for 64-bit
+    # For multilib on the target side, create "lib64" (for 64-bit
     # build or host architectures) and "lib32" (for 32-bit emulation
-    # on 64-bit) as symlinks to "lib".
+    # on 64-bit) as symlinks to "lib" and "lib/32", respectively.
     #
     # Not all of these symlinks are necessary, but better safe than
-    # sorry. They are summarily removed by build/internals.sh:do_finish.
+    # sorry. The ones in ${CT_PREFIX_DIR} are summarily removed by
+    # build/internals.sh:do_finish.
     for d in                            \
         "${CT_PREFIX_DIR}"              \
         "${CT_SYSROOT_DIR}"             \
         "${CT_SYSROOT_DIR}/usr"         \
         "${CT_PREFIX_DIR}/${CT_TARGET}" \
     ; do
-        CT_DoExecLog ALL ln -sf "lib" "${d}/lib32"
-        CT_DoExecLog ALL ln -sf "lib" "${d}/lib64"
+        if [ "${CT_ARCH_BITNESS}" = "64" ]; then
+            CT_DoExecLog ALL ln -sf "lib" "${d}/lib64"
+            CT_DoExecLog ALL ln -sf "lib/32" "${d}/lib32"
+        else
+            CT_DoExecLog ALL ln -sf "lib" "${d}/lib32"
+            CT_DoExecLog ALL ln -sf "lib/64" "${d}/lib64"
+        fi
     done
 
     # Determine build system if not set by the user

--- a/scripts/functions
+++ b/scripts/functions
@@ -1252,6 +1252,19 @@ CT_DoBuildTargetTuple() {
     CT_TARGET="${CT_TARGET}${CT_TARGET_KERNEL:+-${CT_TARGET_KERNEL}}"
     CT_TARGET="${CT_TARGET}${CT_TARGET_SYS:+-${CT_TARGET_SYS}}"
 
+    # Fetch 32-bit target arch for multilib
+    if [ "${CT_ARCH_BITNESS}" = "64" -a "${CT_ARCH_SUPPORTS_32}" = "y" ]; then
+        __save_target_arch="${CT_TARGET_ARCH}"
+        CT_ARCH_BITNESS=32 CT_ARCH_32=y CT_ARCH_64=n CT_DoArchTupleValues
+        CT_TARGET_32="${CT_TARGET_ARCH}"
+        CT_TARGET_32="${CT_TARGET_32}${CT_TARGET_VENDOR:+-${CT_TARGET_VENDOR}}"
+        CT_TARGET_32="${CT_TARGET_32}${CT_TARGET_KERNEL:+-${CT_TARGET_KERNEL}}"
+        CT_TARGET_32="${CT_TARGET_32}${CT_TARGET_SYS:+-${CT_TARGET_SYS}}"
+        # Canonicalise it
+        CT_TARGET_32=$(CT_DoConfigSub "${CT_TARGET_32}")
+        CT_TARGET_ARCH="${__save_target_arch}"
+    fi
+
     # Sanity checks
     __sed_alias=""
     if [ -n "${CT_TARGET_ALIAS_SED_EXPR}" ]; then


### PR DESCRIPTION
Quoting the email I'm drafting to the ct-ng list:
I've encountered a series of problems after enabling multilib support with CT_MULTILIB=y using gcc and glibc on amd64. These may also affect non-x86 64-bit targets with a 32-bit multilib target.

When multilib support is enabled, --host=${CT_TARGET} is still blindly passed to glibc's configure, although ${extra_cflags} is set. This causes multilib builds to fail when the primary target is amd64 and ${extra_cflags} is -m32. To solve this, we need to derive a target tuple for i586 or i686 (glibc 2.21 does not support a i386 target) and pass it with --host when ${extra_cflags} contains -m32. I introduced a new CT_TARGET_32 in CT_DoBuildTargetTuple, used in conjunction with -m32 by scripts/build/libc/glibc.sh (a similar entry for -m64 may be useful).

The second problem encountered is that pass 2 gcc's -m32 libgcc_s requires a stub libc.so installed with libc_startfiles, but all copies of libc.so are built identically without -m32. This is because the multilib ${extra_cflags} aren't being passed for their compilation. I fixed the parameters to be consistent with those used in CC when configuring glibc.

The third problem is that script/build/libc/glibc.sh's do_libc_backend installs a symlink to the location of the stub and startfiles to usr/lib/${multi_dir} on the assumption that "gcc expects them in {,usr/}lib/${extra_dir}", while the pass 2 gcc build on Linux/amd64 actually searches usr/lib32 and not /usr/lib/32 when -m32 is used. This is because for Linux/amd64, gcc/config/i386/t-linux64 specifies "m32=../lib32", etc. in MULTILIB_OSDIRNAMES for the available multilib options.

In ct-ng, usr/lib32 and usr/lib64 are both symlinks to usr/lib created by scripts/crosstool-NG.sh with this explanation: "we're *not* multilib on the target side". This assumption appears to be broken by enabling CT_MULTILIB. Either MULTILIB_OSDIRNAMES or the usr/lib32 symlink has to be altered to satisify libgcc_s linking. MULTILIB_OSDIRNAMES has variety of platform-specific configurations, so there are potentially bad side effects from overriding it globally globally, and extra work if patching each affected platform configuration file. Pointing the usr/lib{32,64} symlink corresponding to the multilib target to usr/lib/{32,64}, respectively, may be preferable for this case. For a 64-bit primary target I leave usr/lib64 symlinked to lib, as glibc still */lib64 install and runtime paths.

The final problem is the missing gnu/stubs-32.h and gnu/lib-names-32.h headers while building the final compiler, despite a multilib install of glibc. The initial gnu/stubs.h is an empty file created by scripts/build/libc/glibc.sh, but it is populated by the final glibc install, which also installs gnu/stubs-64.h. The multilib build of glibc installs the headers under ${CT_SYSROOT_DIR}/${multi_dir} which is subsequently deleted. The solution is to copy ${CT_SYSROOT_DIR}/${multi_dir}/usr/include/gnu/*-{multi_dir}.h to ${CT_HEADERS_DIR} before the deletion.

These changes produce a gcc/glibc toolchain capable of successfully compiling and linking programs with -m32.

-Albert