### PR TITLE
autoconf: Update sub directory name

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -391,8 +391,8 @@ AS_IF(
      subdocdir=""
      datarootdir="$prefix"
      mandir="$docdir"],
-    [sublibdir="/ct-ng.\${VERSION}"
-     subdocdir="/ct-ng.\${VERSION}"])
+    [sublibdir="/\${VERSION}"
+     subdocdir="/\${VERSION}"])
 
 #--------------------------------------------------------------------
 # Finally, generate the output file(s)


### PR DESCRIPTION
Due to patch 0e45cdf, the VERSION string has changed. And so, the the sub
directory names has changed too:

From 'ct-ng.1.21.0' to 'ct-ng.crosstool-ng-1.21.0-xx-yyyyyyy'

This patch rename the sub directory to: 'crosstool-ng-1.21.0-xx-yyyyyyy'

Signed-off-by: Jean-Marie Lemetayer <jeanmarie.lemetayer@gmail.com>