### PR TITLE
avr: add support for AVR avr-libc toolchains

### DIFF
--- a/config/arch/avr.in
+++ b/config/arch/avr.in
@@ -1,0 +1,8 @@
+# AVR specific config options
+
+## select ARCH_SUPPORTS_8
+## select ARCH_DEFAULT_8
+## select ARCH_REQUIRES_MULTILIB
+##
+## help The 8-bit AVR architecture, as defined by:
+## help     http://www.atmel.com/products/microcontrollers/avr

--- a/config/kernel/linux.in
+++ b/config/kernel/linux.in
@@ -1,5 +1,6 @@
 # Linux kernel options
 
+## depends on ! ARCH_avr
 ## select KERNEL_SUPPORTS_SHARED_LIBS
 ##
 ## help Build a toolchain targeting systems running Linux as a kernel.

--- a/config/libc/avr-libc.in
+++ b/config/libc/avr-libc.in
@@ -1,0 +1,51 @@
+# avr-libc options
+
+## depends on ARCH_avr
+## depends on ! LINUX && ! WINDOWS && BARE_METAL
+##
+## select LIBC_SUPPORT_THREADS_NONE
+##
+## help The AVR Libc package provides a subset of the standard C library for
+## help Atmel AVR 8-bit RISC microcontrollers. In addition, the library
+## help provides the basic startup code needed by most applications.
+
+choice
+    bool
+    prompt "avr-libc version"
+# Don't remove next line
+# CT_INSERT_VERSION_BELOW
+
+config LIBC_AVR_LIBC_V_1_8_1
+    bool
+    prompt "1.8.1"
+
+config LIBC_AVR_LIBC_V_1_8_0
+    bool
+    prompt "1.8.0"
+
+config LIBC_AVR_LIBC_CUSTOM
+    bool
+    prompt "Custom avr-libc"
+    depends on EXPERIMENTAL
+
+endchoice
+
+if LIBC_AVR_LIBC_CUSTOM
+
+config LIBC_AVR_LIBC_CUSTOM_LOCATION
+    string
+    prompt "Full path to custom avr-libc source"
+    default ""
+    help
+      Enter the path to the directory (or tarball) of your source for avr-libc,
+      or leave blank to use default CT_CUSTOM_LOCATION_ROOT_DIR/avr-libc
+
+endif # LIBC_AVR_LIBC_CUSTOM
+
+config LIBC_VERSION
+    string
+# Don't remove next line
+# CT_INSERT_VERSION_STRING_BELOW
+    default "1.8.1" if LIBC_AVR_LIBC_V_1_8_1
+    default "1.8.0" if LIBC_AVR_LIBC_V_1_8_0
+    default "custom" if LIBC_AVR_LIBC_CUSTOM

--- a/config/libc/avr-libc.in.2
+++ b/config/libc/avr-libc.in.2
@@ -1,0 +1,8 @@
+# avr-libc second-part options
+
+config LIBC_AVR_LIBC_EXTRA_CONFIG_ARRAY
+    string
+    prompt "Extra config for avr-libc"
+    default ""
+    help
+      Extra flags to pass onto ./configure when configuring the avr-libc.

--- a/config/target.in
+++ b/config/target.in
@@ -8,6 +8,7 @@ config ARCH
 # Pre-declare target optimisation variables
 config ARCH_SUPPORTS_BOTH_MMU
 config ARCH_SUPPORTS_BOTH_ENDIAN
+config ARCH_SUPPORTS_8
 config ARCH_SUPPORTS_32
 config ARCH_SUPPORTS_64
 config ARCH_SUPPORTS_WITH_ARCH
@@ -60,6 +61,10 @@ config ARCH_SUFFIX
 comment "Generic target options"
 
 #--------------------------------------
+config ARCH_REQUIRES_MULTILIB
+    bool
+    select MULTILIB
+
 config MULTILIB
     bool
     prompt "Build a multilib toolchain (READ HELP!!!)"
@@ -133,10 +138,16 @@ config ARCH_ENDIAN
     default "little"    if ARCH_LE
 
 #--------------------------------------
+config ARCH_SUPPORTS_8
+    bool
+
 config ARCH_SUPPORTS_32
     bool
 
 config ARCH_SUPPORTS_64
+    bool
+
+config ARCH_DEFAULT_8
     bool
 
 config ARCH_DEFAULT_32
@@ -147,14 +158,21 @@ config ARCH_DEFAULT_64
 
 config ARCH_BITNESS
     int
+    default "8"     if ARCH_8
     default "32"    if ARCH_32
     default "64"    if ARCH_64
 
 choice
     bool
     prompt "Bitness:"
+    default ARCH_8  if ARCH_DEFAULT_8
     default ARCH_32 if ARCH_DEFAULT_32
     default ARCH_64 if ARCH_DEFAULT_64
+
+config ARCH_8
+    bool
+    prompt "8-bit"
+    depends on ARCH_SUPPORTS_8
 
 config ARCH_32
     bool

--- a/config/toolchain.in
+++ b/config/toolchain.in
@@ -99,6 +99,7 @@ comment "Tuple completion and aliasing"
 config TARGET_VENDOR
     string
     prompt "Tuple's vendor string"
+    depends on !LIBC_avr_libc
     default "unknown"
     help
       Vendor part of the target tuple.

--- a/patches/binutils/2.25/avr/0001-AVR-only-support-C-for-AVR-memory-usage.patch
+++ b/patches/binutils/2.25/avr/0001-AVR-only-support-C-for-AVR-memory-usage.patch
@@ -1,0 +1,536 @@
+From 55e9a09c2249f3d5bbc09d718679365604436aac Mon Sep 17 00:00:00 2001
+From: Erico Nunes <nunes.erico@gmail.com>
+Date: Sat, 13 Jun 2015 00:53:25 -0300
+Subject: [PATCH] AVR only; support -C for AVR memory usage
+
+Source: http://git.makehackvoid.com/cgi-bin/gitweb.cgi?p=mhvavrtools.git;a=blob_plain;f=mhvavrtools/patches/binutils-001-avr-size.patch;h=e80d28eae46217551d996a2253256c97d10aa4b5;hb=refs/heads/master
+
+Signed-off-by: Erico Nunes <nunes.erico@gmail.com>
+---
+ binutils/size.c | 414 +++++++++++++++++++++++++++++++++++++++++++++++++++++---
+ 1 file changed, 394 insertions(+), 20 deletions(-)
+
+diff --git a/binutils/size.c b/binutils/size.c
+index 0937de5..486ddde 100644
+--- a/binutils/size.c
++++ b/binutils/size.c
+@@ -36,10 +36,31 @@
+ #include "getopt.h"
+ #include "bucomm.h"
+ 
+-#ifndef BSD_DEFAULT
+-#define BSD_DEFAULT 1
++typedef enum
++{
++    format_sysv = 0,
++    format_bsd = 1,
++    format_avr = 2,
++} format_type_t;
++
++
++/* Set the default format. */
++#define FORMAT_DEFAULT_SYSV 0
++#define FORMAT_DEFAULT_BSD 1
++#define FORMAT_DEFAULT_AVR 0
++
++#if FORMAT_DEFAULT_SYSV
++    #define FORMAT_DEFAULT format_sysv
++    #define FORMAT_NAME "sysv"
++#elif FORMAT_DEFAULT_BSD
++    #define FORMAT_DEFAULT format_bsd
++    #define FORMAT_NAME "berkeley"
++#elif FORMAT_DEFAULT_AVR
++    #define FORMAT_DEFAULT format_avr
++    #define FORMAT_NAME "avr"
+ #endif
+ 
++
+ /* Program options.  */
+ 
+ static enum
+@@ -48,9 +69,8 @@ static enum
+   }
+ radix = decimal;
+ 
+-/* 0 means use AT&T-style output.  */
+-static int berkeley_format = BSD_DEFAULT;
+ 
++format_type_t format = FORMAT_DEFAULT;
+ static int show_version = 0;
+ static int show_help = 0;
+ static int show_totals = 0;
+@@ -64,6 +84,246 @@ static bfd_size_type total_textsize;
+ /* Program exit status.  */
+ static int return_code = 0;
+ 
++
++/* AVR Size specific stuff */
++
++#define AVR64 64UL
++#define AVR128 128UL
++#define AVR256 256UL
++#define AVR512 512UL
++#define AVR1K 1024UL
++#define AVR2K 2048UL
++#define AVR4K 4096UL
++#define AVR8K 8192UL
++#define AVR16K 16384UL
++#define AVR20K 20480UL
++#define AVR24K 24576UL
++#define AVR32K 32768UL
++#define AVR36K 36864UL
++#define AVR40K 40960UL
++#define AVR64K 65536UL
++#define AVR68K 69632UL
++#define AVR128K 131072UL
++#define AVR136K 139264UL
++#define AVR200K 204800UL
++#define AVR256K 262144UL
++#define AVR264K 270336UL
++
++typedef struct
++{
++    char *name;
++	long flash;
++	long ram;
++	long eeprom;
++} avr_device_t;
++
++avr_device_t avr[] =
++{
++	{"atxmega256a3",  AVR264K, AVR16K, AVR4K},
++	{"atxmega256a3b", AVR264K, AVR16K, AVR4K},
++	{"atxmega256d3",  AVR264K, AVR16K, AVR4K},
++
++	{"atmega2560",    AVR256K, AVR8K,  AVR4K},
++	{"atmega2561",    AVR256K, AVR8K,  AVR4K},
++
++	{"atxmega192a3",  AVR200K, AVR16K, AVR2K},
++	{"atxmega192d3",  AVR200K, AVR16K, AVR2K},
++
++	{"atxmega128a1",  AVR136K, AVR8K,  AVR2K},
++	{"atxmega128a1u", AVR136K, AVR8K,  AVR2K},
++	{"atxmega128a3",  AVR136K, AVR8K,  AVR2K},
++	{"atxmega128d3",  AVR136K, AVR8K,  AVR2K},
++
++	{"at43usb320",    AVR128K, 608UL,  0UL},
++	{"at90can128",    AVR128K, AVR4K,  AVR4K},
++	{"at90usb1286",   AVR128K, AVR8K,  AVR4K},
++	{"at90usb1287",   AVR128K, AVR8K,  AVR4K},
++	{"atmega128",     AVR128K, AVR4K,  AVR4K},
++	{"atmega1280",    AVR128K, AVR8K,  AVR4K},
++	{"atmega1281",    AVR128K, AVR8K,  AVR4K},
++	{"atmega1284p",   AVR128K, AVR16K, AVR4K},
++	{"atmega128rfa1", AVR128K, AVR16K, AVR4K},
++	{"atmega103",     AVR128K, 4000UL, AVR4K},
++
++	{"atxmega64a1",   AVR68K,  AVR4K,  AVR2K},
++	{"atxmega64a1u",  AVR68K,  AVR4K,  AVR2K},
++	{"atxmega64a3",   AVR68K,  AVR4K,  AVR2K},
++	{"atxmega64d3",   AVR68K,  AVR4K,  AVR2K},
++
++	{"at90can64",     AVR64K,  AVR4K,  AVR2K},
++	{"at90scr100",    AVR64K,  AVR4K,  AVR2K},
++	{"at90usb646",    AVR64K,  AVR4K,  AVR2K},
++	{"at90usb647",    AVR64K,  AVR4K,  AVR2K},
++	{"atmega64",      AVR64K,  AVR4K,  AVR2K},
++	{"atmega640",     AVR64K,  AVR8K,  AVR4K},
++	{"atmega644",     AVR64K,  AVR4K,  AVR2K},
++	{"atmega644a",    AVR64K,  AVR4K,  AVR2K},
++	{"atmega644p",    AVR64K,  AVR4K,  AVR2K},
++	{"atmega644pa",   AVR64K,  AVR4K,  AVR2K},
++	{"atmega645",     AVR64K,  AVR4K,  AVR2K},
++	{"atmega645a",    AVR64K,  AVR4K,  AVR2K},
++	{"atmega645p",    AVR64K,  AVR4K,  AVR2K},
++	{"atmega6450",    AVR64K,  AVR4K,  AVR2K},
++	{"atmega6450a",   AVR64K,  AVR4K,  AVR2K},
++	{"atmega6450p",   AVR64K,  AVR4K,  AVR2K},
++	{"atmega649",     AVR64K,  AVR4K,  AVR2K},
++	{"atmega649a",    AVR64K,  AVR4K,  AVR2K},
++	{"atmega649p",    AVR64K,  AVR4K,  AVR2K},
++	{"atmega6490",    AVR64K,  AVR4K,  AVR2K},
++	{"atmega6490a",   AVR64K,  AVR4K,  AVR2K},
++	{"atmega6490p",   AVR64K,  AVR4K,  AVR2K},
++	{"atmega64c1",    AVR64K,  AVR4K,  AVR2K},
++	{"atmega64hve",   AVR64K,  AVR4K,  AVR1K},
++	{"atmega64m1",    AVR64K,  AVR4K,  AVR2K},
++   {"m3000",         AVR64K,  AVR4K,  0UL},
++
++	{"atmega406",     AVR40K,  AVR2K,  AVR512},
++
++	{"atxmega32a4",   AVR36K,  AVR4K,  AVR1K},
++	{"atxmega32d4",   AVR36K,  AVR4K,  AVR1K},
++
++	{"at90can32",     AVR32K,  AVR2K,  AVR1K},
++	{"at94k",         AVR32K,  AVR4K,  0UL},
++	{"atmega32",      AVR32K,  AVR2K,  AVR1K},
++	{"atmega323",     AVR32K,  AVR2K,  AVR1K},
++	{"atmega324a",    AVR32K,  AVR2K,  AVR1K},
++	{"atmega324p",    AVR32K,  AVR2K,  AVR1K},
++	{"atmega324pa",   AVR32K,  AVR2K,  AVR1K},
++	{"atmega325",     AVR32K,  AVR2K,  AVR1K},
++	{"atmega325a",    AVR32K,  AVR2K,  AVR1K},
++	{"atmega325p",    AVR32K,  AVR2K,  AVR1K},
++	{"atmega3250",    AVR32K,  AVR2K,  AVR1K},
++	{"atmega3250a",   AVR32K,  AVR2K,  AVR1K},
++	{"atmega3250p",   AVR32K,  AVR2K,  AVR1K},
++	{"atmega328",     AVR32K,  AVR2K,  AVR1K},
++	{"atmega328p",    AVR32K,  AVR2K,  AVR1K},
++	{"atmega329",     AVR32K,  AVR2K,  AVR1K},
++	{"atmega329a",    AVR32K,  AVR2K,  AVR1K},
++	{"atmega329p",    AVR32K,  AVR2K,  AVR1K},
++	{"atmega329pa",   AVR32K,  AVR2K,  AVR1K},
++	{"atmega3290",    AVR32K,  AVR2K,  AVR1K},
++	{"atmega3290a",   AVR32K,  AVR2K,  AVR1K},
++	{"atmega3290p",   AVR32K,  AVR2K,  AVR1K},
++	{"atmega32hvb",   AVR32K,  AVR2K,  AVR1K},
++	{"atmega32c1",    AVR32K,  AVR2K,  AVR1K},
++   {"atmega32hvb",   AVR32K,  AVR2K,  AVR1K},
++	{"atmega32m1",    AVR32K,  AVR2K,  AVR1K},
++	{"atmega32u2",    AVR32K,  AVR1K,  AVR1K},
++	{"atmega32u4",    AVR32K,  2560UL, AVR1K},
++	{"atmega32u6",    AVR32K,  2560UL, AVR1K},
++
++	{"at43usb355",    AVR24K,  1120UL,   0UL},
++
++	{"atxmega16a4",   AVR20K,  AVR2K,  AVR1K},
++	{"atxmega16d4",   AVR20K,  AVR2K,  AVR1K},
++
++	{"at76c711",      AVR16K,  AVR2K,  0UL},
++	{"at90pwm216",    AVR16K,  AVR1K,  AVR512},
++	{"at90pwm316",    AVR16K,  AVR1K,  AVR512},
++	{"at90usb162",    AVR16K,  AVR512, AVR512},
++	{"atmega16",      AVR16K,  AVR1K,  AVR512},
++	{"atmega16a",     AVR16K,  AVR1K,  AVR512},
++	{"atmega161",     AVR16K,  AVR1K,  AVR512},
++	{"atmega162",     AVR16K,  AVR1K,  AVR512},
++	{"atmega163",     AVR16K,  AVR1K,  AVR512},
++	{"atmega164",     AVR16K,  AVR1K,  AVR512},
++	{"atmega164a",    AVR16K,  AVR1K,  AVR512},
++	{"atmega164p",    AVR16K,  AVR1K,  AVR512},
++	{"atmega165a",    AVR16K,  AVR1K,  AVR512},
++	{"atmega165",     AVR16K,  AVR1K,  AVR512},
++	{"atmega165p",    AVR16K,  AVR1K,  AVR512},
++	{"atmega168",     AVR16K,  AVR1K,  AVR512},
++	{"atmega168a",    AVR16K,  AVR1K,  AVR512},
++	{"atmega168p",    AVR16K,  AVR1K,  AVR512},
++	{"atmega169",     AVR16K,  AVR1K,  AVR512},
++	{"atmega169a",    AVR16K,  AVR1K,  AVR512},
++	{"atmega169p",    AVR16K,  AVR1K,  AVR512},
++	{"atmega169pa",   AVR16K,  AVR1K,  AVR512},
++	{"atmega16hva",   AVR16K,  768UL,  AVR256},
++	{"atmega16hva2",  AVR16K,  AVR1K,  AVR256},
++   {"atmega16hvb",   AVR16K,  AVR1K,  AVR512},
++	{"atmega16m1",    AVR16K,  AVR1K,  AVR512},
++	{"atmega16u2",    AVR16K,  AVR512, AVR512},
++	{"atmega16u4",    AVR16K,  1280UL, AVR512},
++	{"attiny167",     AVR16K,  AVR512, AVR512},
++
++	{"at90c8534",     AVR8K,   352UL,  AVR512},
++	{"at90pwm1",      AVR8K,   AVR512, AVR512},
++	{"at90pwm2",      AVR8K,   AVR512, AVR512},
++	{"at90pwm2b",     AVR8K,   AVR512, AVR512},
++	{"at90pwm3",      AVR8K,   AVR512, AVR512},
++	{"at90pwm3b",     AVR8K,   AVR512, AVR512},
++	{"at90pwm81",     AVR8K,   AVR256, AVR512},
++	{"at90s8515",     AVR8K,   AVR512, AVR512},
++	{"at90s8535",     AVR8K,   AVR512, AVR512},
++	{"at90usb82",     AVR8K,   AVR512, AVR512},
++	{"ata6289",       AVR8K,   AVR512, 320UL},
++	{"atmega8",       AVR8K,   AVR1K,  AVR512},
++	{"atmega8515",    AVR8K,   AVR512, AVR512},
++	{"atmega8535",    AVR8K,   AVR512, AVR512},
++	{"atmega88",      AVR8K,   AVR1K,  AVR512},
++	{"atmega88a",     AVR8K,   AVR1K,  AVR512},
++	{"atmega88p",     AVR8K,   AVR1K,  AVR512},
++	{"atmega88pa",    AVR8K,   AVR1K,  AVR512},
++	{"atmega8hva",    AVR8K,   768UL,  AVR256},
++	{"atmega8u2",     AVR8K,   AVR512, AVR512},
++	{"attiny84",      AVR8K,   AVR512, AVR512},
++	{"attiny84a",     AVR8K,   AVR512, AVR512},
++	{"attiny85",      AVR8K,   AVR512, AVR512},
++	{"attiny861",     AVR8K,   AVR512, AVR512},
++	{"attiny861a",    AVR8K,   AVR512, AVR512},
++	{"attiny87",      AVR8K,   AVR512, AVR512},
++	{"attiny88",      AVR8K,   AVR512, AVR64},
++
++	{"at90s4414",     AVR4K,   352UL,  AVR256},
++	{"at90s4433",     AVR4K,   AVR128, AVR256},
++	{"at90s4434",     AVR4K,   352UL,  AVR256},
++	{"atmega48",      AVR4K,   AVR512, AVR256},
++	{"atmega48a",     AVR4K,   AVR512, AVR256},
++	{"atmega48p",     AVR4K,   AVR512, AVR256},
++	{"attiny4313",    AVR4K,   AVR256, AVR256},
++	{"attiny43u",     AVR4K,   AVR256, AVR64},
++	{"attiny44",      AVR4K,   AVR256, AVR256},
++	{"attiny44a",     AVR4K,   AVR256, AVR256},
++	{"attiny45",      AVR4K,   AVR256, AVR256},
++	{"attiny461",     AVR4K,   AVR256, AVR256},
++	{"attiny461a",    AVR4K,   AVR256, AVR256},
++	{"attiny48",      AVR4K,   AVR256, AVR64},
++
++	{"at86rf401",     AVR2K,   224UL,  AVR128},
++	{"at90s2313",     AVR2K,   AVR128, AVR128},
++	{"at90s2323",     AVR2K,   AVR128, AVR128},
++	{"at90s2333",     AVR2K,   224UL,  AVR128},
++	{"at90s2343",     AVR2K,   AVR128, AVR128},
++   {"attiny20",      AVR2K,   AVR128, 0UL},
++	{"attiny22",      AVR2K,   224UL,  AVR128},
++	{"attiny2313",    AVR2K,   AVR128, AVR128},
++	{"attiny2313a",   AVR2K,   AVR128, AVR128},
++	{"attiny24",      AVR2K,   AVR128, AVR128},
++	{"attiny24a",     AVR2K,   AVR128, AVR128},
++	{"attiny25",      AVR2K,   AVR128, AVR128},
++	{"attiny26",      AVR2K,   AVR128, AVR128},
++	{"attiny261",     AVR2K,   AVR128, AVR128},
++	{"attiny261a",    AVR2K,   AVR128, AVR128},
++	{"attiny28",      AVR2K,   0UL,    0UL},
++   {"attiny40",      AVR2K,   AVR256, 0UL},
++
++	{"at90s1200",     AVR1K,   0UL,    AVR64},
++   {"attiny9",       AVR1K,   32UL,   0UL},
++   {"attiny10",      AVR1K,   32UL,   0UL},
++	{"attiny11",      AVR1K,   0UL,    AVR64},
++	{"attiny12",      AVR1K,   0UL,    AVR64},
++	{"attiny13",      AVR1K,   AVR64,  AVR64},
++	{"attiny13a",     AVR1K,   AVR64,  AVR64},
++	{"attiny15",      AVR1K,   0UL,    AVR64},
++
++   {"attiny4",       AVR512,  32UL,   0UL},
++   {"attiny5",       AVR512,  32UL,   0UL},
++};
++
++static char *avrmcu = NULL;
++
++
+ static char *target = NULL;
+ 
+ /* Forward declarations.  */
+@@ -79,7 +339,8 @@ usage (FILE *stream, int status)
+   fprintf (stream, _(" Displays the sizes of sections inside binary files\n"));
+   fprintf (stream, _(" If no input file(s) are specified, a.out is assumed\n"));
+   fprintf (stream, _(" The options are:\n\
+-  -A|-B     --format={sysv|berkeley}  Select output style (default is %s)\n\
++  -A|-B|-C  --format={sysv|berkeley|avr}  Select output style (default is %s)\n\
++            --mcu=<avrmcu>            MCU name for AVR format only\n\
+   -o|-d|-x  --radix={8|10|16}         Display numbers in octal, decimal or hex\n\
+   -t        --totals                  Display the total sizes (Berkeley only)\n\
+             --common                  Display total size for *COM* syms\n\
+@@ -88,11 +349,7 @@ usage (FILE *stream, int status)
+   -h        --help                    Display this information\n\
+   -v        --version                 Display the program's version\n\
+ \n"),
+-#if BSD_DEFAULT
+-  "berkeley"
+-#else
+-  "sysv"
+-#endif
++FORMAT_NAME
+ );
+   list_supported_targets (program_name, stream);
+   if (REPORT_BUGS_TO[0] && status == 0)
+@@ -103,6 +360,7 @@ usage (FILE *stream, int status)
+ #define OPTION_FORMAT (200)
+ #define OPTION_RADIX (OPTION_FORMAT + 1)
+ #define OPTION_TARGET (OPTION_RADIX + 1)
++#define OPTION_MCU (OPTION_TARGET + 1) 
+ 
+ static struct option long_options[] =
+ {
+@@ -110,6 +368,7 @@ static struct option long_options[] =
+   {"format", required_argument, 0, OPTION_FORMAT},
+   {"radix", required_argument, 0, OPTION_RADIX},
+   {"target", required_argument, 0, OPTION_TARGET},
++  {"mcu", required_argument, 0, 203},
+   {"totals", no_argument, &show_totals, 1},
+   {"version", no_argument, &show_version, 1},
+   {"help", no_argument, &show_help, 1},
+@@ -141,7 +400,7 @@ main (int argc, char **argv)
+   bfd_init ();
+   set_default_bfd_target ();
+ 
+-  while ((c = getopt_long (argc, argv, "ABHhVvdfotx", long_options,
++  while ((c = getopt_long (argc, argv, "ABCHhVvdfotx", long_options,
+ 			   (int *) 0)) != EOF)
+     switch (c)
+       {
+@@ -150,11 +409,15 @@ main (int argc, char **argv)
+ 	  {
+ 	  case 'B':
+ 	  case 'b':
+-	    berkeley_format = 1;
++	    format = format_bsd;
+ 	    break;
+ 	  case 'S':
+ 	  case 's':
+-	    berkeley_format = 0;
++	    format = format_sysv;
++	    break;
++	  case 'A':
++	  case 'a':
++	    format = format_avr;
+ 	    break;
+ 	  default:
+ 	    non_fatal (_("invalid argument to --format: %s"), optarg);
+@@ -162,6 +425,10 @@ main (int argc, char **argv)
+ 	  }
+ 	break;
+ 
++      case OPTION_MCU:
++	avrmcu = optarg;
++	break;
++
+       case OPTION_TARGET:
+ 	target = optarg;
+ 	break;
+@@ -190,11 +457,14 @@ main (int argc, char **argv)
+ 	break;
+ 
+       case 'A':
+-	berkeley_format = 0;
++	format = format_sysv;
+ 	break;
+       case 'B':
+-	berkeley_format = 1;
++	format = format_bsd;
+ 	break;
++      case 'C':
++    format = format_avr;
++    break;
+       case 'v':
+       case 'V':
+ 	show_version = 1;
+@@ -240,7 +510,7 @@ main (int argc, char **argv)
+     for (; optind < argc;)
+       display_file (argv[optind++]);
+ 
+-  if (show_totals && berkeley_format)
++  if (show_totals && format == format_bsd)
+     {
+       bfd_size_type total = total_textsize + total_datasize + total_bsssize;
+ 
+@@ -599,13 +869,117 @@ print_sysv_format (bfd *file)
+   printf ("\n\n");
+ }
+ 
++
++static avr_device_t *
++avr_find_device (void)
++{
++  unsigned int i;
++  if (avrmcu != NULL)
++  {
++    for (i = 0; i < sizeof(avr) / sizeof(avr[0]); i++)
++    {
++      if (strcmp(avr[i].name, avrmcu) == 0)
++      {
++        /* Match found */
++        return (&avr[i]);
++      }
++    }
++  }
++  return (NULL);
++}
++
++
++
++static void
++print_avr_format (bfd *file)
++{
++  char *avr_name = "Unknown";
++  int flashmax = 0;
++  int rammax = 0;
++  int eeprommax = 0;
++  asection *section; 
++  bfd_size_type my_datasize = 0;
++  bfd_size_type my_textsize = 0;
++  bfd_size_type my_bsssize = 0;
++  bfd_size_type bootloadersize = 0;
++  bfd_size_type noinitsize = 0;
++  bfd_size_type eepromsize = 0;
++
++  avr_device_t *avrdevice = avr_find_device();
++  if (avrdevice != NULL)
++  {
++    avr_name = avrdevice->name;
++    flashmax = avrdevice->flash;
++    rammax = avrdevice->ram;
++    eeprommax = avrdevice->eeprom;
++  }
++
++  if ((section = bfd_get_section_by_name (file, ".data")) != NULL)
++    my_datasize = bfd_section_size (file, section);
++  if ((section = bfd_get_section_by_name (file, ".text")) != NULL)
++    my_textsize = bfd_section_size (file, section);
++  if ((section = bfd_get_section_by_name (file, ".bss")) != NULL)
++    my_bsssize = bfd_section_size (file, section);
++  if ((section = bfd_get_section_by_name (file, ".bootloader")) != NULL)
++    bootloadersize = bfd_section_size (file, section);
++  if ((section = bfd_get_section_by_name (file, ".noinit")) != NULL)
++    noinitsize = bfd_section_size (file, section);
++  if ((section = bfd_get_section_by_name (file, ".eeprom")) != NULL)
++    eepromsize = bfd_section_size (file, section);
++  
++  bfd_size_type text = my_textsize + my_datasize + bootloadersize;
++  bfd_size_type data = my_datasize + my_bsssize + noinitsize;
++  bfd_size_type eeprom = eepromsize;
++  
++  printf ("AVR Memory Usage\n"
++          "----------------\n"
++          "Device: %s\n\n", avr_name);
++  
++  /* Text size */
++  printf ("Program:%8ld bytes", text);
++  if (flashmax > 0)
++  {
++    printf (" (%2.1f%% Full)", ((float)text / flashmax) * 100);
++  }
++  printf ("\n(.text + .data + .bootloader)\n\n");
++  
++  /* Data size */
++  printf ("Data:   %8ld bytes", data);
++  if (rammax > 0)
++  {
++    printf (" (%2.1f%% Full)", ((float)data / rammax) * 100);
++  }
++  printf ("\n(.data + .bss + .noinit)\n\n");
++  
++  /* EEPROM size */
++  if (eeprom > 0) 
++  { 
++    printf ("EEPROM: %8ld bytes", eeprom);
++    if (eeprommax > 0)
++    {
++      printf (" (%2.1f%% Full)", ((float)eeprom / eeprommax) * 100);
++    }
++    printf ("\n(.eeprom)\n\n");
++  }
++}
++
++
+ static void
+ print_sizes (bfd *file)
+ {
+   if (show_common)
+     calculate_common_size (file);
+-  if (berkeley_format)
+-    print_berkeley_format (file);
+-  else
+-    print_sysv_format (file);
++  switch (format)
++  {
++    case format_sysv:
++      print_sysv_format (file);
++      break;
++    case format_bsd:
++      print_berkeley_format (file);
++      break;
++    case format_avr:
++    default:
++      print_avr_format (file);
++      break;
++  }
+ }
+-- 
+2.4.1
+

--- a/samples/avr/crosstool.config
+++ b/samples/avr/crosstool.config
@@ -1,0 +1,4 @@
+CT_ARCH_avr=y
+CT_CC_GCC_V_4_9_2=y
+CT_DEBUG_gdb=y
+CT_ISL_V_0_12_2=y

--- a/samples/avr/crosstool.config
+++ b/samples/avr/crosstool.config
@@ -1,4 +1,5 @@
 CT_ARCH_avr=y
 CT_CC_GCC_V_4_9_2=y
+CT_CC_LANG_CXX=y
 CT_DEBUG_gdb=y
 CT_ISL_V_0_12_2=y

--- a/samples/avr/reported.by
+++ b/samples/avr/reported.by
@@ -1,0 +1,3 @@
+reporter_name="Erico Nunes"
+reporter_url="https://github.com/enunes"
+reporter_comment="EXPERIMENTAL AVR 8-bit toolchain"

--- a/scripts/build/arch/avr.sh
+++ b/scripts/build/arch/avr.sh
@@ -1,0 +1,5 @@
+# Compute AVR-specific values
+
+CT_DoArchTupleValues() {
+    CT_TARGET_ARCH="${CT_ARCH}"
+}

--- a/scripts/build/libc/avr-libc.sh
+++ b/scripts/build/libc/avr-libc.sh
@@ -1,0 +1,71 @@
+# This file adds functions to build the avr-libc C library
+
+do_libc_get() {
+    local libc_src
+
+    libc_src="http://download.savannah.gnu.org/releases/avr-libc"
+
+    if [ "${CT_LIBC_AVR_LIBC_CUSTOM}" = "y" ]; then
+        CT_GetCustom "avr-libc" "${CT_LIBC_VERSION}"      \
+                     "${CT_LIBC_AVR_LIBC_CUSTOM_LOCATION}"
+    else # ! custom location
+        CT_GetFile "avr-libc-${CT_LIBC_VERSION}" "${libc_src}"
+    fi # ! custom location
+}
+
+do_libc_extract() {
+    # If using custom directory location, nothing to do.
+    if [ "${CT_LIBC_AVR_LIBC_CUSTOM}" = "y" ]; then
+        # Abort if the custom directory is not found.
+        if ! [ -d "${CT_SRC_DIR}/avr-libc-${CT_LIBC_VERSION}" ]; then
+            CT_Abort "Directory not found: ${CT_SRC_DIR}/avr-libc-${CT_LIBC_VERSION}"
+        fi
+
+        return 0
+    fi
+
+    CT_Extract "avr-libc-${CT_LIBC_VERSION}"
+    CT_Patch "avr-libc" "${CT_LIBC_VERSION}"
+}
+
+do_libc_check_config() {
+    :
+}
+
+do_libc_configure() {
+    CT_DoLog EXTRA "Configuring C library"
+
+    CT_DoExecLog CFG                \
+    ./configure                     \
+        --build=${CT_BUILD}         \
+        --host=${CT_TARGET}         \
+        --prefix=${CT_PREFIX_DIR}   \
+        "${CT_LIBC_AVR_LIBC_EXTRA_CONFIG_ARRAY[@]}"
+}
+
+do_libc_start_files() {
+    :
+}
+
+do_libc() {
+    :
+}
+
+do_libc_post_cc() {
+    CT_DoStep INFO "Installing C library"
+
+    CT_DoLog EXTRA "Copying sources to build directory"
+    CT_DoExecLog ALL cp -av "${CT_SRC_DIR}/avr-libc-${CT_LIBC_VERSION}" \
+                            "${CT_BUILD_DIR}/build-libc-post-cc"
+    cd "${CT_BUILD_DIR}/build-libc-post-cc"
+
+    do_libc_configure
+
+    CT_DoLog EXTRA "Building C library"
+    CT_DoExecLog ALL make ${JOBSFLAGS}
+
+    CT_DoLog EXTRA "Installing C library"
+    CT_DoExecLog ALL make install
+
+    CT_EndStep
+}

--- a/scripts/build/libc/glibc.sh
+++ b/scripts/build/libc/glibc.sh
@@ -665,3 +665,7 @@ do_libc_locales() {
                           install_root="${CT_SYSROOT_DIR}"          \
                           localedata/install-locales
 }
+
+do_libc_post_cc() {
+    :
+}

--- a/scripts/build/libc/mingw.sh
+++ b/scripts/build/libc/mingw.sh
@@ -112,3 +112,7 @@ do_libc() {
 
     CT_EndStep
 }
+
+do_libc_post_cc() {
+    :
+}

--- a/scripts/build/libc/musl.sh
+++ b/scripts/build/libc/musl.sh
@@ -113,3 +113,7 @@ do_libc() {
 
     CT_EndStep
 }
+
+do_libc_post_cc() {
+    :
+}

--- a/scripts/build/libc/newlib.sh
+++ b/scripts/build/libc/newlib.sh
@@ -149,3 +149,7 @@ do_libc() {
 
     CT_EndStep
 }
+
+do_libc_post_cc() {
+    :
+}

--- a/scripts/build/libc/none.sh
+++ b/scripts/build/libc/none.sh
@@ -21,3 +21,7 @@ do_libc_start_files() {
 do_libc() {
     :
 }
+
+do_libc_post_cc() {
+    :
+}

--- a/scripts/build/libc/uClibc.sh
+++ b/scripts/build/libc/uClibc.sh
@@ -554,3 +554,7 @@ mungeuClibcConfig() {
 
     sed -r -f "${munge_file}" "${src_config_file}" >"${dst_config_file}"
 }
+
+do_libc_post_cc() {
+    :
+}

--- a/scripts/functions
+++ b/scripts/functions
@@ -1206,6 +1206,11 @@ CT_DoBuildTargetTuple() {
         *glibc) CT_TARGET_SYS=gnu;;
         uClibc) CT_TARGET_SYS=uclibc;;
         musl)   CT_TARGET_SYS=musl;;
+        avr-libc)
+            # avr-libc only seems to work with the non-canonical "avr" target.
+            CT_TARGET_SKIP_CONFIG_SUB=y
+            CT_TARGET_SYS= # CT_TARGET_SYS must be empty too
+        ;;
         *)      CT_TARGET_SYS=elf;;
     esac
 
@@ -1259,7 +1264,10 @@ CT_DoBuildTargetTuple() {
     esac
 
     # Canonicalise it
-    CT_TARGET=$(CT_DoConfigSub "${CT_TARGET}")
+    if [ "${CT_TARGET_SKIP_CONFIG_SUB}" != "y" ]; then
+        CT_TARGET=$(CT_DoConfigSub "${CT_TARGET}")
+    fi
+
     # Prepare the target CFLAGS
     CT_ARCH_TARGET_CFLAGS="${CT_ARCH_TARGET_CFLAGS} ${CT_ARCH_ENDIAN_CFLAG}"
     CT_ARCH_TARGET_CFLAGS="${CT_ARCH_TARGET_CFLAGS} ${CT_ARCH_ARCH_CFLAG}"

--- a/scripts/functions
+++ b/scripts/functions
@@ -1101,13 +1101,14 @@ CT_Patch() {
     CT_DoLog EXTRA "Patching '${pkgdir}'"
 
     bundled_patch_dir="${CT_LIB_DIR}/patches/${pkgname}/${version}"
+    bundled_patch_arch_dir="${bundled_patch_dir}/${CT_ARCH}"
     local_patch_dir="${CT_LOCAL_PATCH_DIR}/${pkgname}/${version}"
 
     case "${CT_PATCH_ORDER}" in
-        bundled)        patch_dirs=("${bundled_patch_dir}");;
+        bundled)        patch_dirs=("${bundled_patch_dir}" "${bundled_patch_arch_dir}");;
         local)          patch_dirs=("${local_patch_dir}");;
-        bundled,local)  patch_dirs=("${bundled_patch_dir}" "${local_patch_dir}");;
-        local,bundled)  patch_dirs=("${local_patch_dir}" "${bundled_patch_dir}");;
+        bundled,local)  patch_dirs=("${bundled_patch_dir}" "${bundled_patch_arch_dir}" "${local_patch_dir}");;
+        local,bundled)  patch_dirs=("${local_patch_dir}" "${bundled_patch_dir}" "${bundled_patch_arch_dir}");;
         none)           patch_dirs=;;
     esac
 

--- a/scripts/functions
+++ b/scripts/functions
@@ -1132,7 +1132,9 @@ CT_Patch() {
             eval ${cfg}="${CT_LIB_DIR}/scripts/${cfg/_/.}"
             [ -e "${CT_TOP_DIR}/scripts/${cfg/_/.}" ] && eval ${cfg}="${CT_TOP_DIR}/scripts/${cfg/_/.}"
             # Can't use CT_DoExecLog because of the '{} \;' to be passed un-mangled to find
-            find . -type f -name "${cfg/_/.}" -exec cp -v "${!cfg}" {} \; |CT_DoLog ALL
+            find . -type f -name "${cfg/_/.}" \
+                -exec chmod -v u+w {} \; \
+                -exec cp -v "${!cfg}" {} \; |CT_DoLog ALL
         done
     fi
 

--- a/steps.mk
+++ b/steps.mk
@@ -30,6 +30,7 @@ CT_STEPS := libc_check_config        \
             libc                     \
             cc_for_build             \
             cc_for_host              \
+            libc_post_cc             \
             libelf_for_target        \
             binutils_for_target      \
             debug                    \


### PR DESCRIPTION
This patch series adds support for AVR avr-libc toolchains.
It is broken in a patch to add the AVR architecture and first 8-bit options,
followed by adding avr-libc as a C library option, then an avr target sample
and finally some other minor issues observed during testing.

Initially this was tested by adding a lot of other configuration options by
taking the Arch Linux recipes as a reference. They can be found in:
https://projects.archlinux.org/svntogit/community.git/plain/trunk/PKGBUILD?h=packages/avr-binutils
https://projects.archlinux.org/svntogit/community.git/plain/trunk/PKGBUILD?h=packages/avr-gcc
https://projects.archlinux.org/svntogit/community.git/plain/trunk/PKGBUILD?h=packages/avr-libc
Trying to make crosstool-ng equivalent to these options would require a lot of
changes to the crosstool-ng scripts and configuration options.
Because of this, I ended up just using them for initial tests and to make it
work for the first time, but I decided to keep the ammount of changes for this
initial inclusion of the AVR architecture to the minimum possible which
produces a working AVR toolchain with avr-libc.

The avr-libc manual and most distributions build the AVR 8-bit gcc toolchain
with the "avr" (non-canonical) target.
Some experimentation also led to the conclusion that other (canonical) targets
are not very well supported, so I'm forcing the "avr" target for crosstool-ng
as well. avr-libc seems to have an "avr/include" path hardcoded in its
Makefiles which causes the standard include paths to miss the avr-libc headers
when the target is different than "avr".

The manual also recommends building avr-libc after the final gcc build.
To accomplish this with crosstool-ng, a new do_libc_post_cc step is added, in
which currently only avr-libc performs its build, and is a no-op for the other
libc options.

It seems that it is also possible to build the AVR toolchain with newlib
instead of avr-libc, but this is untested yet with crosstool-ng. This may be
tested and supported after the initial AVR inclusion in crosstool-ng has been
concluded.
For the newlib case, it may be possible to build it with a canonical target.
There is at least this reference:
http://antoni.buszta.info/2013/07/18/avr-toolchain-with-gcc-4-8-1-and-c-stl-support

Another detail which took some time to figure out is the fact that AVR
toolchains require multilib support. Building it with "--disable-multilib"
made link crt* with a wrong path (crtm328p.o instead of avr/lib/avr5/crtm328p.o
or equivalent, depending on the mcu) and to generate an error during linking.
I have decided then to force multilib for the AVR architecture.

After putting it to work and having cleaned all of the experimental code, I
performed the following tests:
- Built my existing AVR/avr-libc code at https://github.com/enunes/avr with
this toolchain (it finds all of the avr-libc headers and mcu specific libraries
as well as it did with the distribution toolchain). Also built some C++ code
with avr-g++.
- Programmed an AVR binary to an ATmega328p microcontroller and observed it
working properly.

To test whether it would have affected other architectures:
- Rebuilt a few of my existing toolchains, for arm-unknown-linux-gnueabi,
arm-none-eabi (newlib) and i686-unknown-elf targets, and rebuilt code that I
used to build them with.
- Built a linux filesystem with buildroot using the arm-unknown-linux-gnueabi
toolchain (qemu_arm_vexpress_defconfig) and booted it in qemu.
- Programmed an arm binary built with arm-none-eabi to an arm cortex-m4
microcontroller and observed it working properly.

This series also closes #66.