### PR TITLE
config: Add new gcc stable versions

### DIFF
--- a/config/cc/gcc.in
+++ b/config/cc/gcc.in
@@ -48,6 +48,11 @@ config CC_GCC_V_linaro_4_9
     depends on CC_GCC_SHOW_LINARO
     select CC_GCC_4_9
 
+config CC_GCC_V_4_9_3
+    bool
+    prompt "4.9.3"
+    select CC_GCC_4_9
+
 config CC_GCC_V_4_9_2
     bool
     prompt "4.9.2"
@@ -67,6 +72,11 @@ config CC_GCC_V_linaro_4_8
     bool
     prompt "linaro-4.8-2015.02"
     depends on CC_GCC_SHOW_LINARO
+    select CC_GCC_4_8
+
+config CC_GCC_V_4_8_5
+    bool
+    prompt "4.8.5"
     select CC_GCC_4_8
 
 config CC_GCC_V_4_8_4
@@ -533,10 +543,12 @@ config CC_GCC_VERSION
 # CT_INSERT_VERSION_STRING_BELOW
     default "5.1.0" if CC_GCC_V_5_1_0
     default "linaro-4.9-2015.03" if CC_GCC_V_linaro_4_9
+    default "4.9.3" if CC_GCC_V_4_9_3
     default "4.9.2" if CC_GCC_V_4_9_2
     default "4.9.1" if CC_GCC_V_4_9_1
     default "4.9.0" if CC_GCC_V_4_9_0
     default "linaro-4.8-2015.02" if CC_GCC_V_linaro_4_8
+    default "4.8.5" if CC_GCC_V_4_8_5
     default "4.8.4" if CC_GCC_V_4_8_4
     default "4.8.3" if CC_GCC_V_4_8_3
     default "4.8.2" if CC_GCC_V_4_8_2


### PR DESCRIPTION
This commit adds gcc 4.8.5 and 4.9.3.
Release notes can be found in these urls:
https://gcc.gnu.org/gcc-4.8/
https://gcc.gnu.org/gcc-4.9/

Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>