### PR TITLE
Patch glibc 2.11's configure script to support Make 4

### DIFF
--- a/patches/glibc/2.11/920-make-40.patch
+++ b/patches/glibc/2.11/920-make-40.patch
@@ -1,0 +1,12 @@
+diff -urN glibc-2.11-orig/configure glibc-2.11/configure
+--- glibc-2.11-orig/configure   2015-07-14 08:14:11.671891176 -0700
++++ glibc-2.11/configure    2015-07-14 09:14:10.053054117 -0700
+@@ -5108,7 +5108,7 @@
+   ac_prog_version=`$MAKE --version 2>&1 | sed -n 's/^.*GNU Make[^0-9]*\([0-9][0-9.]*\).*$/\1/p'`
+   case $ac_prog_version in
+     '') ac_prog_version="v. ?.??, bad"; ac_verc_fail=yes;;
+-    3.79* | 3.[89]*)
++    3.79* | 3.[89]* | 4.* )
+        ac_prog_version="$ac_prog_version, ok"; ac_verc_fail=no;;
+     *) ac_prog_version="$ac_prog_version, bad"; ac_verc_fail=yes;;
+ 


### PR DESCRIPTION
Similar patch in http://colocsbar.blogspot.fr/2014/01/crosstool-ng-1190-et-make-40.html