### PR TITLE
fix linux-unwind.h siginfo incomplete type

### DIFF
--- a/patches/gcc/4.5.3/120-siginfo.patch
+++ b/patches/gcc/4.5.3/120-siginfo.patch
@@ -1,0 +1,112 @@
+diff --git a/gcc/config/alpha/linux-unwind.h b/gcc/config/alpha/linux-unwind.h
+index e43aacf..3b52101 100644
+--- a/gcc/config/alpha/linux-unwind.h
++++ b/gcc/config/alpha/linux-unwind.h
+@@ -48,7 +48,7 @@ alpha_fallback_frame_state (struct _Unwind_Context *context,
+   else if (pc[1] == 0x201f015f)	/* lda $0,NR_rt_sigreturn */
+     {
+       struct rt_sigframe {
+-	struct siginfo info;
++	siginfo_t info;
+ 	struct ucontext uc;
+       } *rt_ = context->cfa;
+       sc = &rt_->uc.uc_mcontext;
+diff --git a/gcc/config/bfin/linux-unwind.h b/gcc/config/bfin/linux-unwind.h
+index 88c8285..419f72d 100644
+--- a/gcc/config/bfin/linux-unwind.h
++++ b/gcc/config/bfin/linux-unwind.h
+@@ -51,7 +51,7 @@ bfin_fallback_frame_state (struct _Unwind_Context *context,
+ 	struct siginfo *pinfo;
+ 	void *puc;
+ 	char retcode[8];
+-	struct siginfo info;
++	siginfo_t info;
+ 	struct ucontext uc;
+       } *rt_ = context->cfa;
+ 
+diff --git a/gcc/config/ia64/linux-unwind.h b/gcc/config/ia64/linux-unwind.h
+index 93f762d..baf80ee 100644
+--- a/gcc/config/ia64/linux-unwind.h
++++ b/gcc/config/ia64/linux-unwind.h
+@@ -47,7 +47,7 @@ ia64_fallback_frame_state (struct _Unwind_Context *context,
+       struct sigframe {
+ 	char scratch[16];
+ 	unsigned long sig_number;
+-	struct siginfo *info;
++	siginfo_t *info;
+ 	struct sigcontext *sc;
+       } *frame_ = (struct sigframe *)context->psp;
+       struct sigcontext *sc = frame_->sc;
+@@ -137,7 +137,7 @@ ia64_handle_unwabi (struct _Unwind_Context *context, _Unwind_FrameState *fs)
+       struct sigframe {
+ 	char scratch[16];
+ 	unsigned long sig_number;
+-	struct siginfo *info;
++	siginfo_t *info;
+ 	struct sigcontext *sc;
+       } *frame = (struct sigframe *)context->psp;
+       struct sigcontext *sc = frame->sc;
+diff --git a/gcc/config/mips/linux-unwind.h b/gcc/config/mips/linux-unwind.h
+index 02f7cd5..69d96f1 100644
+--- a/gcc/config/mips/linux-unwind.h
++++ b/gcc/config/mips/linux-unwind.h
+@@ -75,7 +75,7 @@ mips_fallback_frame_state (struct _Unwind_Context *context,
+       struct rt_sigframe {
+ 	u_int32_t ass[4];  /* Argument save space for o32.  */
+ 	u_int32_t trampoline[2];
+-	struct siginfo info;
++	siginfo_t info;
+ 	_sig_ucontext_t uc;
+       } *rt_ = context->cfa;
+       sc = &rt_->uc.uc_mcontext;
+diff --git a/gcc/config/pa/linux-unwind.h b/gcc/config/pa/linux-unwind.h
+index a0560e9..dd8f590 100644
+--- a/gcc/config/pa/linux-unwind.h
++++ b/gcc/config/pa/linux-unwind.h
+@@ -63,7 +63,7 @@ pa32_fallback_frame_state (struct _Unwind_Context *context,
+   int i;
+   struct sigcontext *sc;
+   struct rt_sigframe {
+-    struct siginfo info;
++    siginfo_t info;
+     struct ucontext uc;
+   } *frame;
+ 
+diff --git a/gcc/config/sh/linux-unwind.h b/gcc/config/sh/linux-unwind.h
+index 94ed95d..c1e1adb 100644
+--- a/gcc/config/sh/linux-unwind.h
++++ b/gcc/config/sh/linux-unwind.h
+@@ -80,9 +80,9 @@ shmedia_fallback_frame_state (struct _Unwind_Context *context,
+ 	   && (*(unsigned long *) (pc+11)  == 0x6ff0fff0))
+     {
+       struct rt_sigframe {
+-	struct siginfo *pinfo;
++	siginfo_t *pinfo;
+ 	void *puc;
+-	struct siginfo info;
++	siginfo_t info;
+ 	struct ucontext uc;
+       } *rt_ = context->cfa;
+       /* The void * cast is necessary to avoid an aliasing warning.
+@@ -179,7 +179,7 @@ sh_fallback_frame_state (struct _Unwind_Context *context,
+ 		&& (*(unsigned short *) (pc+14)  == 0x00ad))))
+     {
+       struct rt_sigframe {
+-	struct siginfo info;
++	siginfo_t info;
+ 	struct ucontext uc;
+       } *rt_ = context->cfa;
+       /* The void * cast is necessary to avoid an aliasing warning.
+diff --git a/gcc/config/xtensa/linux-unwind.h b/gcc/config/xtensa/linux-unwind.h
+index 32e9349..dda1f29 100644
+--- a/gcc/config/xtensa/linux-unwind.h
++++ b/gcc/config/xtensa/linux-unwind.h
+@@ -62,7 +62,7 @@ xtensa_fallback_frame_state (struct _Unwind_Context *context,
+   struct sigcontext *sc;
+ 
+   struct rt_sigframe {
+-    struct siginfo info;
++    siginfo_t info;
+     struct ucontext uc;
+   } *rt_;
+ 


### PR DESCRIPTION
I was attempting to build a gcc-4.5.3 toolchain for MIPS; this changeset fixed the problem I encountered in  the 'final gcc' stage: struct siginfo was an incomplete type.