### PR TITLE
gcc: Backport upstream fix for libgo uninitialized variable

### DIFF
--- a/config/cc.in
+++ b/config/cc.in
@@ -115,6 +115,7 @@ config CC_LANG_GOLANG
     prompt "Go (EXPERIMENTAL)"
     depends on EXPERIMENTAL
     depends on CC_SUPPORT_GOLANG
+    select LIBC_UCLIBC_IPV6 if LIBC_uClibc
     help
       Enable building a Go compiler.
 

--- a/patches/gcc/4.9.3/110-libgo-runtime-initialize-variable.patch
+++ b/patches/gcc/4.9.3/110-libgo-runtime-initialize-variable.patch
@@ -1,0 +1,28 @@
+From 1b02261e37ffab86986b039d289fb2773c4c386b Mon Sep 17 00:00:00 2001
+From: ian <ian@138bc75d-0d04-0410-961f-82ee72b054a4>
+Date: Tue, 4 Aug 2015 03:39:21 +0000
+Subject: [PATCH]     runtime: initialize variable to avoid compiler warning
+
+    Reviewed-on: https://go-review.googlesource.com/13095
+
+
+git-svn-id: svn+ssh://gcc.gnu.org/svn/gcc/trunk@226543 138bc75d-0d04-0410-961f-82ee72b054a4
+---
+ libgo/runtime/mprof.goc | 2 +-
+ 1 files changed, 1 insertions(+), 1 deletions(-)
+
+diff --git a/libgo/runtime/mprof.goc b/libgo/runtime/mprof.goc
+index c9022df..4e8cfc9 100644
+--- a/libgo/runtime/mprof.goc
++++ b/libgo/runtime/mprof.goc
+@@ -465,7 +465,7 @@ func ThreadCreateProfile(p Slice) (n int, ok bool) {
+ 
+ func Stack(b Slice, all bool) (n int) {
+ 	byte *pc, *sp;
+-	bool enablegc;
++	bool enablegc = false;
+ 	
+	sp = runtime_getcallersp(&b);
+ 	pc = (byte*)(uintptr)runtime_getcallerpc(&b);
+-- 
+1.9.4

--- a/patches/gcc/5.2.0/110-libgo-runtime-initialize-variable.patch
+++ b/patches/gcc/5.2.0/110-libgo-runtime-initialize-variable.patch
@@ -1,0 +1,28 @@
+From 1b02261e37ffab86986b039d289fb2773c4c386b Mon Sep 17 00:00:00 2001
+From: ian <ian@138bc75d-0d04-0410-961f-82ee72b054a4>
+Date: Tue, 4 Aug 2015 03:39:21 +0000
+Subject: [PATCH]     runtime: initialize variable to avoid compiler warning
+
+    Reviewed-on: https://go-review.googlesource.com/13095
+
+
+git-svn-id: svn+ssh://gcc.gnu.org/svn/gcc/trunk@226543 138bc75d-0d04-0410-961f-82ee72b054a4
+---
+ libgo/runtime/mprof.goc | 2 +-
+ 1 files changed, 1 insertions(+), 1 deletions(-)
+
+diff --git a/libgo/runtime/mprof.goc b/libgo/runtime/mprof.goc
+index c9022df..4e8cfc9 100644
+--- a/libgo/runtime/mprof.goc
++++ b/libgo/runtime/mprof.goc
+@@ -403,7 +403,7 @@ func ThreadCreateProfile(p Slice) (n int, ok bool) {
+ 
+ func Stack(b Slice, all bool) (n int) {
+ 	byte *pc, *sp;
+-	bool enablegc;
++	bool enablegc = false;
+ 	
+	sp = runtime_getcallersp(&b);
+ 	pc = (byte*)(uintptr)runtime_getcallerpc(&b);
+-- 
+1.9.4


### PR DESCRIPTION
This commit is backported from gcc-6 development branch to 4.9.0 to
5.2.0. If requested, I will add another set of changes to include 4.8.x
if required.

This commit closes #96

Signed-off-by: Bryan Hundven bryanhundven@gmail.com
