### PR TITLE
Added new config ISL_V_0_14_or_later and ISL_V_0_12_or_later to select

### DIFF
--- a/config/companion_libs/isl.in
+++ b/config/companion_libs/isl.in
@@ -9,10 +9,12 @@ choice
 config ISL_V_0_14
     bool
     prompt "0.14"
+    select ISL_V_0_14_or_later
 
 config ISL_V_0_12_2
     bool
     prompt "0.12.2"
+    select ISL_V_0_12_or_later
 
 config ISL_V_0_11_1
     bool
@@ -20,6 +22,13 @@ config ISL_V_0_11_1
     depends on ! CC_GCC_5_1_or_later
 
 endchoice
+
+config ISL_V_0_14_or_later
+    bool
+    select ISL_V_0_12_or_later
+
+config ISL_V_0_12_or_later
+    bool
 
 config ISL_VERSION
     string

--- a/scripts/build/companion_libs/121-isl.sh
+++ b/scripts/build/companion_libs/121-isl.sh
@@ -87,6 +87,7 @@ do_isl_backend() {
     local cflags
     local cxxflags
     local ldflags
+    local -a extra_config
     local arg
 
     for arg in "$@"; do
@@ -94,6 +95,15 @@ do_isl_backend() {
     done
 
     CT_DoLog EXTRA "Configuring ISL"
+
+    if [ "${CT_ISL_V_0_12_or_later}" != "y" ]; then
+        extra_config+=("--with-libgmp-prefix=${prefix}")
+        extra_config+=("--with-libgmpxx-prefix=${prefix}")
+    fi
+
+    if [ "${CT_ISL_V_0_14_or_later}" != "y" ]; then
+        extra_config+=("--with-piplib=no")
+    fi
 
     CT_DoExecLog CFG                                \
     CFLAGS="${cflags}"                              \
@@ -103,14 +113,11 @@ do_isl_backend() {
         --build=${CT_BUILD}                         \
         --host=${host}                              \
         --prefix="${prefix}"                        \
-        --with-libgmp-prefix="${prefix}"            \
-        --with-libgmpxx-prefix="${prefix}"          \
-        --with-gmp-prefix="${prefix}"               \
+        "${extra_config[@]}"                        \
         --disable-shared                            \
         --enable-static                             \
         --with-gmp=system                           \
         --with-gmp-prefix="${prefix}"               \
-        --with-piplib=no                            \
         --with-clang=no
 
     CT_DoLog EXTRA "Building ISL"


### PR DESCRIPTION
Fix for issue #141 Unknown configure options for lib ISL:
Added new config ISL_V_0_14_or_later and ISL_V_0_12_or_later to select
proper configure options for isl 0.14.x and 0.12.x in 121-isl.sh.

Signed-off-by: Jasmin Jessich <jasmin@anw.at>
