### PR TITLE
Fix for issue #147:

### DIFF
--- a/config/cc/gcc.in.2
+++ b/config/cc/gcc.in.2
@@ -165,7 +165,7 @@ config CC_CXA_ATEXIT
     bool
     prompt "Use __cxa_atexit"
     default y
-    depends on ! BARE_METAL
+    depends on ! BARE_METAL || LIBC_PROVIDES_CXA_ATEXIT
     help
       If you get the missing symbol "__cxa_atexit" when building C++ programs,
       you might want to try disabling this option.

--- a/config/libc.in
+++ b/config/libc.in
@@ -35,6 +35,9 @@ config LIBC_SUPPORT_THREADS_LT
 config LIBC_SUPPORT_THREADS_NONE
     bool
 
+config LIBC_PROVIDES_CXA_ATEXIT
+    bool
+
 # C libraries should provide other values
 config THREADS
     string


### PR DESCRIPTION
Enable definition of "Use __cxa_atexit" for bare-metal systems, if the used
libc does provide such a function. The libc configuration have to select
LIBC_PROVIDES_CXA_ATEXIT.

Signed-off-by: Jasmin Jessich <jasmin@anw.at>