### PR TITLE
Fix for issue #149:

### DIFF
--- a/config/libc/newlib.in
+++ b/config/libc/newlib.in
@@ -40,23 +40,28 @@ config LIBC_NEWLIB_LINARO_V_2_2_0
     bool
     prompt "Linaro 2.2.0-2015.01"
     depends on CC_NEWLIB_SHOW_LINARO
+    select LIBC_NEWLIB_2_2
 
 config LIBC_NEWLIB_V_2_2_0
     bool
     prompt "2.2.0"
+    select LIBC_NEWLIB_2_2
 
 config LIBC_NEWLIB_LINARO_V_2_1_0
     bool
     prompt "Linaro 2.1.0-2014.09"
     depends on CC_NEWLIB_SHOW_LINARO
+    select LIBC_NEWLIB_2_1
 
 config LIBC_NEWLIB_V_2_1_0
     bool
     prompt "2.1.0"
+    select LIBC_NEWLIB_2_1
 
 config LIBC_NEWLIB_V_2_0_0
     bool
     prompt "2.0.0"
+    select LIBC_NEWLIB_2_0
 
 config LIBC_NEWLIB_V_1_20_0
     bool
@@ -80,6 +85,61 @@ config LIBC_NEWLIB_CUSTOM
     depends on EXPERIMENTAL
 
 endchoice
+
+if LIBC_NEWLIB_CUSTOM
+
+choice
+    bool
+    prompt "Custom newlib version"
+
+config LIBC_NEWLIB_V_2_2_X
+    bool
+    prompt "2.2.x"
+    select LIBC_NEWLIB_2_2
+
+config LIBC_NEWLIB_V_2_1_X
+    bool
+    prompt "2.1.x"
+    select LIBC_NEWLIB_2_1
+
+config LIBC_NEWLIB_V_2_0_X
+    bool
+    prompt "2.0.x"
+    select LIBC_NEWLIB_2_0
+
+config LIBC_NEWLIB_V_other
+    bool
+    prompt "other"
+
+endchoice
+
+endif #LIBC_NEWLIB_CUSTOM
+
+config LIBC_NEWLIB_2_2
+    bool
+    select LIBC_NEWLIB_2_2_or_later
+
+config LIBC_NEWLIB_2_1
+    bool
+    select LIBC_NEWLIB_2_1_or_later
+
+config LIBC_NEWLIB_2_0
+    bool
+    select LIBC_NEWLIB_2_0_or_later
+
+config LIBC_NEWLIB_2_2_or_later
+    bool
+    select LIBC_NEWLIB_2_1_or_later
+
+config LIBC_NEWLIB_2_1_or_later
+    bool
+    select LIBC_NEWLIB_2_0_or_later
+
+# maybe older versions of newlib will support it too, but this
+# needs to be checked
+config LIBC_NEWLIB_2_0_or_later
+    bool
+    select LIBC_PROVIDES_CXA_ATEXIT
 
 if LIBC_NEWLIB_CUSTOM
 


### PR DESCRIPTION
Added newlib version selection, if LIBC_NEWLIB_CUSTOM is selected.
All newlib versions >=2.0.0 does provide __cxa_atexit. To enable this function
in GCC, all versions >=2.0.0 does now select LIBC_PROVIDES_CXA_ATEXIT.
Note: The patch for issue #147 needs to be applied for a working
      "ct-ng menuconfig" execution!
Signed-off-by: Jasmin Jessich <jasmin@anw.at>
