### PR TITLE
glibc: Add 2.22, and add a constraint on glibc >= 2.21

### DIFF
--- a/config/libc/glibc.in
+++ b/config/libc/glibc.in
@@ -34,10 +34,15 @@ choice
 # Don't remove next line
 # CT_INSERT_VERSION_BELOW
 
+config LIBC_GLIBC_V_2_22
+    bool
+    prompt "2.22"
+    select LIBC_GLIBC_2_21_or_later
+
 config LIBC_GLIBC_V_2_21
     bool
     prompt "2.21"
-    select LIBC_GLIBC_2_20_or_later
+    select LIBC_GLIBC_2_21_or_later
 
 config LIBC_GLIBC_LINARO_V_2_20
     bool
@@ -132,6 +137,11 @@ config LIBC_GLIBC_CUSTOM
 
 endchoice
 
+# glibc 2.21 depends on gcc >= 4.6
+config LIBC_GLIBC_2_21_or_later
+    bool
+    depends on CC_GCC_4_6_or_later
+
 config LIBC_GLIBC_2_20_or_later
     bool
 
@@ -154,6 +164,7 @@ config LIBC_VERSION
     string
 # Don't remove next line
 # CT_INSERT_VERSION_STRING_BELOW
+    default "2.22" if LIBC_GLIBC_V_2_22
     default "2.21" if LIBC_GLIBC_V_2_21
     default "linaro-2.20-2014.11" if LIBC_GLIBC_LINARO_V_2_20
     default "2.20" if LIBC_GLIBC_V_2_20


### PR DESCRIPTION
* Add glibc 2.22
* Add a constraint on glibc-2.21 that depends on gcc-4.6 or greater.
  See: https://sourceware.org/ml/libc-alpha/2015-02/msg00119.html
======================================================================
* The minimum GCC version that can be used to build this version of
  the GNU C Library is GCC 4.6.  Older GCC versions, and non-GNU
  compilers, can still be used to compile programs using the GNU C
  Library.
======================================================================

Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>