### PR TITLE
glibc: Fix applying addons to glibc => 2.17

### DIFF
--- a/config/libc/glibc.in
+++ b/config/libc/glibc.in
@@ -58,14 +58,17 @@ config LIBC_GLIBC_V_2_20
 config LIBC_GLIBC_V_2_19
     bool
     prompt "2.19"
+    select LIBC_GLIBC_2_17_or_later
 
 config LIBC_GLIBC_V_2_18
     bool
     prompt "2.18"
+    select LIBC_GLIBC_2_17_or_later
 
 config LIBC_GLIBC_V_2_17
     bool
     prompt "2.17"
+    select LIBC_GLIBC_2_17_or_later
 
 config LIBC_GLIBC_V_2_16_0
     bool
@@ -141,8 +144,14 @@ endchoice
 config LIBC_GLIBC_2_21_or_later
     bool
     depends on CC_GCC_4_6_or_later
+    select LIBC_GLIBC_2_20_or_later
 
 config LIBC_GLIBC_2_20_or_later
+    bool
+    select LIBC_GLIBC_2_17_or_later
+
+# DeMark no more ports
+config LIBC_GLIBC_2_17_or_later
     bool
 
 config LIBC_CUSTOM

--- a/scripts/build/libc/glibc.sh
+++ b/scripts/build/libc/glibc.sh
@@ -17,37 +17,39 @@ do_libc_extract() {
         CT_Patch nochdir "${CT_LIBC}" "${CT_LIBC_VERSION}"
     fi
 
-    # Extract the add-opns
-    for addon in $(do_libc_add_ons_list " "); do
-        # If the addon was bundled with the main archive, we do not
-        # need to extract it. Worse, if we were to try to extract
-        # it, we'd get an error.
-        if [ -d "${addon}" ]; then
-            CT_DoLog DEBUG "Add-on '${addon}' already present, skipping extraction"
-            continue
-        fi
+    # Extract the add-opns if => 2.17
+    if [ "${CT_LIBC_GLIBC_2_17_or_later}" != "y" ]; then
+        for addon in $(do_libc_add_ons_list " "); do
+            # If the addon was bundled with the main archive, we do not
+            # need to extract it. Worse, if we were to try to extract
+            # it, we'd get an error.
+            if [ -d "${addon}" ]; then
+                CT_DoLog DEBUG "Add-on '${addon}' already present, skipping extraction"
+                continue
+            fi
 
-        CT_Extract nochdir "${CT_LIBC}-${addon}-${CT_LIBC_VERSION}"
+            CT_Extract nochdir "${CT_LIBC}-${addon}-${CT_LIBC_VERSION}"
 
-        CT_TestAndAbort "Error in add-on '${addon}': both short and long names in tarball" \
-            -d "${addon}" -a -d "${CT_LIBC}-${addon}-${CT_LIBC_VERSION}"
+            CT_TestAndAbort "Error in add-on '${addon}': both short and long names in tarball" \
+                -d "${addon}" -a -d "${CT_LIBC}-${addon}-${CT_LIBC_VERSION}"
 
-        # Some addons have the 'long' name, while others have the
-        # 'short' name, but patches are non-uniformly built with
-        # either the 'long' or 'short' name, whatever the addons name
-        # but we prefer the 'short' name and avoid duplicates.
-        if [ -d "${CT_LIBC}-${addon}-${CT_LIBC_VERSION}" ]; then
-            CT_DoExecLog FILE mv "${CT_LIBC}-${addon}-${CT_LIBC_VERSION}" "${addon}"
-        fi
+            # Some addons have the 'long' name, while others have the
+            # 'short' name, but patches are non-uniformly built with
+            # either the 'long' or 'short' name, whatever the addons name
+            # but we prefer the 'short' name and avoid duplicates.
+            if [ -d "${CT_LIBC}-${addon}-${CT_LIBC_VERSION}" ]; then
+                CT_DoExecLog FILE mv "${CT_LIBC}-${addon}-${CT_LIBC_VERSION}" "${addon}"
+            fi
 
-        CT_DoExecLog FILE ln -s "${addon}" "${CT_LIBC}-${addon}-${CT_LIBC_VERSION}"
+            CT_DoExecLog FILE ln -s "${addon}" "${CT_LIBC}-${addon}-${CT_LIBC_VERSION}"
 
-        CT_Patch nochdir "${CT_LIBC}" "${addon}-${CT_LIBC_VERSION}"
+            CT_Patch nochdir "${CT_LIBC}" "${addon}-${CT_LIBC_VERSION}"
 
-        # Remove the long name since it can confuse configure scripts to run
-        # the same source twice.
-        rm "${CT_LIBC}-${addon}-${CT_LIBC_VERSION}"
-    done
+            # Remove the long name since it can confuse configure scripts to run
+            # the same source twice.
+            rm "${CT_LIBC}-${addon}-${CT_LIBC_VERSION}"
+        done
+    fi
 
     # The configure files may be older than the configure.in files
     # if using a snapshot (or even some tarballs). Fake them being


### PR DESCRIPTION
glibc-2.17 and above no longer have external addons or ports.
So if we are => 2.17, don't even think about trying to mess with ports
or addons.

Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>