### PR TITLE
Remove CC_GCC_CUSTOM from the version choice

### DIFF
--- a/config/cc/gcc.in
+++ b/config/cc/gcc.in
@@ -300,13 +300,15 @@ config CC_GCC_V_3_4_6
     prompt "3.4.6 (OBSOLETE)"
     depends on OBSOLETE
 
+endchoice
+
 config CC_GCC_CUSTOM
     bool
     prompt "Custom gcc"
     depends on EXPERIMENTAL
-    select CC_GCC_latest
-
-endchoice
+    help
+      The choosen compiler version shall be not downloaded. Instead use
+      a custom location to get the source.
 
 if CC_GCC_CUSTOM
 
@@ -616,7 +618,6 @@ config CC_GCC_VERSION
     default "4.1.2" if CC_GCC_V_4_1_2
     default "4.0.4" if CC_GCC_V_4_0_4
     default "3.4.6" if CC_GCC_V_3_4_6
-    default "custom" if CC_GCC_CUSTOM
 
 config CC_LANG_JAVA_USE_ECJ
     bool


### PR DESCRIPTION
CC_GCC_CUSTOM is no longer part of the gcc version choice, but an independent
configuration to enable CC_GCC_CUSTOM_LOCATION.

Signed-off-by: Jasmin Jessich <jasmin@anw.at>
