### PR TITLE
Remove LIBC_NEWLIB_CUSTOM from the version choice

### DIFF
--- a/config/libc/newlib.in
+++ b/config/libc/newlib.in
@@ -40,23 +40,28 @@ config LIBC_NEWLIB_LINARO_V_2_2_0
     bool
     prompt "Linaro 2.2.0-2015.01"
     depends on CC_NEWLIB_SHOW_LINARO
+    select LIBC_NEWLIB_2_2
 
 config LIBC_NEWLIB_V_2_2_0
     bool
     prompt "2.2.0"
+    select LIBC_NEWLIB_2_2
 
 config LIBC_NEWLIB_LINARO_V_2_1_0
     bool
     prompt "Linaro 2.1.0-2014.09"
     depends on CC_NEWLIB_SHOW_LINARO
+    select LIBC_NEWLIB_2_1
 
 config LIBC_NEWLIB_V_2_1_0
     bool
     prompt "2.1.0"
+    select LIBC_NEWLIB_2_1
 
 config LIBC_NEWLIB_V_2_0_0
     bool
     prompt "2.0.0"
+    select LIBC_NEWLIB_2_0
 
 config LIBC_NEWLIB_V_1_20_0
     bool
@@ -74,12 +79,41 @@ config LIBC_NEWLIB_V_1_17_0
     bool
     prompt "1.17.0"
 
+endchoice
+
 config LIBC_NEWLIB_CUSTOM
     bool
     prompt "Custom newlib"
     depends on EXPERIMENTAL
+    help
+    The choosen library version shall be not downloaded. Instead use
+    a custom location to get the source.
 
-endchoice
+config LIBC_NEWLIB_2_2
+    bool
+    select LIBC_NEWLIB_2_2_or_later
+
+config LIBC_NEWLIB_2_1
+    bool
+    select LIBC_NEWLIB_2_1_or_later
+
+config LIBC_NEWLIB_2_0
+    bool
+    select LIBC_NEWLIB_2_0_or_later
+
+config LIBC_NEWLIB_2_2_or_later
+    bool
+    select LIBC_NEWLIB_2_1_or_later
+
+config LIBC_NEWLIB_2_1_or_later
+    bool
+    select LIBC_NEWLIB_2_0_or_later
+
+# maybe older versions of newlib will support it too, but this
+# needs to be checked
+config LIBC_NEWLIB_2_0_or_later
+    bool
+    select LIBC_PROVIDES_CXA_ATEXIT
 
 if LIBC_NEWLIB_CUSTOM
 
@@ -106,7 +140,6 @@ config LIBC_VERSION
     default "1.19.0" if LIBC_NEWLIB_V_1_19_0
     default "1.18.0" if LIBC_NEWLIB_V_1_18_0
     default "1.17.0" if LIBC_NEWLIB_V_1_17_0
-    default "custom" if LIBC_NEWLIB_CUSTOM
     help
       Enter the tag you want to use.
       Leave empty to use the 'head' of the repository.


### PR DESCRIPTION
LIBC_NEWLIB_CUSTOM is no longer part of the newlib version choice, but an
independent configuration to enable LIBC_NEWLIB_CUSTOM.
All newlib versions >=2.0.0 does provide __cxa_atexit. To enable this function
in GCC, all versions >=2.0.0 does now select LIBC_PROVIDES_CXA_ATEXIT.
Note: The patch for issue #147 needs to be applied for a working
"ct-ng menuconfig" execution!
    
Signed-off-by: Jasmin Jessich <jasmin@anw.at>
