### PR TITLE
Remove BINUTILS_CUSTOM from the version choice

### DIFF
--- a/config/binutils/binutils.in
+++ b/config/binutils/binutils.in
@@ -87,13 +87,12 @@ config BINUTILS_V_2_18a
     prompt "2.18a"
     select BINUTILS_2_18_or_later
 
+endchoice
+
 config BINUTILS_CUSTOM
     bool
     prompt "Custom binutils"
     depends on EXPERIMENTAL
-    select BINUTILS_2_22_or_later
-
-endchoice
 
 if BINUTILS_CUSTOM
 
@@ -123,7 +122,6 @@ config BINUTILS_VERSION
     default "2.20.1a" if BINUTILS_V_2_20_1a
     default "2.19.1a" if BINUTILS_V_2_19_1a
     default "2.18a" if BINUTILS_V_2_18a
-    default "custom" if BINUTILS_CUSTOM
 
 config BINUTILS_2_25_or_later
     bool


### PR DESCRIPTION
BINUTILS_CUSTOM is no longer part of the binutils version choice, but an
independent configuration to enable BINUTILS_CUSTOM.
    
Signed-off-by: Jasmin Jessich <jasmin@anw.at>
