### PR TITLE
Adding CLooG/isl constraint

### DIFF
--- a/config/companion_libs/cloog.in
+++ b/config/companion_libs/cloog.in
@@ -9,6 +9,11 @@ if ISL
 # Don't remove next line
 # CT_INSERT_VERSION_BELOW
 
+config CLOOG_V_0_18_4
+    bool
+    prompt "0.18.4"
+    select CLOOG_0_18_4_or_later
+
 config CLOOG_V_0_18_1
     bool
     prompt "0.18.1"
@@ -36,9 +41,14 @@ config CLOOG_VERSION
     string
 # Don't remove next line
 # CT_INSERT_VERSION_STRING_BELOW
+    default "0.18.4" if CLOOG_V_0_18_4
     default "0.18.1" if CLOOG_V_0_18_1
     default "0.18.0" if CLOOG_V_0_18_0
     default "0.15.11" if CLOOG_V_0_15_11
+
+config CLOOG_0_18_4_or_later
+    bool
+    select CLOOG_0_18_or_later
 
 config CLOOG_0_18_or_later
     bool

--- a/config/companion_libs/isl.in
+++ b/config/companion_libs/isl.in
@@ -6,22 +6,35 @@ choice
 # Don't remove next line
 # CT_INSERT_VERSION_BELOW
 
+config ISL_V_0_15
+    bool
+    prompt "0.15"
+    depends on CLOOG_0_18_4_or_later
+    select ISL_V_0_15_or_later
+
 config ISL_V_0_14
     bool
     prompt "0.14"
+    depends on CLOOG_0_18_4_or_later
     select ISL_V_0_14_or_later
 
 config ISL_V_0_12_2
     bool
     prompt "0.12.2"
+    depends on ! CLOOG_0_18_4_or_later
     select ISL_V_0_12_or_later
 
 config ISL_V_0_11_1
     bool
     prompt "0.11.1"
+    depends on ! CLOOG_0_18_4_or_later
     depends on ! CC_GCC_5_1_or_later
 
 endchoice
+
+config ISL_V_0_15_or_later
+    bool
+    select ISL_V_0_14_or_later
 
 config ISL_V_0_14_or_later
     bool
@@ -34,6 +47,7 @@ config ISL_VERSION
     string
 # Don't remove next line
 # CT_INSERT_VERSION_STRING_BELOW
+    default "0.15" if ISL_V_0_15
     default "0.14" if ISL_V_0_14
     default "0.12.2" if ISL_V_0_12_2
     default "0.11.1" if ISL_V_0_11_1


### PR DESCRIPTION
Adding isl 0.15.
Added following constrains:
   isl 0.14 and 0.15 require  CLooG 0.18.4 or later.
   isl 0.11.1 and 0.12.2 require CLoog older than 0.18.4.

Signed-off-by: Jasmin Jessich <jasmin@anw.at>