### PR TITLE
Fix tristate Kconfig options

### DIFF
--- a/config/global.in
+++ b/config/global.in
@@ -3,6 +3,7 @@
 # Allow unconditional usage of tristates
 config MODULES
     bool
+    option modules
     default y
 
 menu "Paths and misc options"


### PR DESCRIPTION
After the Kconfig update (Issue "Update kconfig version" #127) tristate Kconfig configuration options can be set only to enabled ("y") or disabled ("n"). Tristates can not be set to module ("m") any more.

See for example "C compiler / Use sjlj for exceptions", which is no longer a tristate option.

Fix: The "option modules" setting must be set on the MODULES configuration option to enable tristates again.

Signed-off-by: Philipp Kirchhofer <philipp@familie-kirchhofer.de>