### PR TITLE
Fixed issue 173 and 174.

### DIFF
--- a/config/companion_libs/isl.in
+++ b/config/companion_libs/isl.in
@@ -9,19 +9,19 @@ choice
 config ISL_V_0_15
     bool
     prompt "0.15"
-    depends on CLOOG_0_18_4_or_later
+    depends on CC_GCC_5_1_or_later
     select ISL_V_0_15_or_later
 
 config ISL_V_0_14
     bool
     prompt "0.14"
-    depends on CLOOG_0_18_4_or_later
+    depends on CLOOG_0_18_4_or_later || CC_GCC_5_1_or_later
     select ISL_V_0_14_or_later
 
 config ISL_V_0_12_2
     bool
     prompt "0.12.2"
-    depends on ! CLOOG_0_18_4_or_later
+    depends on ! CLOOG_0_18_4_or_later || CC_GCC_5_1_or_later
     select ISL_V_0_12_or_later
 
 config ISL_V_0_11_1


### PR DESCRIPTION
gcc 5.x   -> isl 0.12.2, 0.14 0.15
gcc < 5.x -> cloog < 0.18.4  -> isl 0.12.2, 0.11.1
          -> cloog >= 0.18.4 -> isl 0.14

Signed-off-by: Jasmin Jessich <jasmin@anw.at>