### PR TITLE
Fix building glibc 2.17 with gcc 5.1+

### DIFF
--- a/patches/glibc/2.17/100-Fix-ARM-build-with-GCC-trunk.patch
+++ b/patches/glibc/2.17/100-Fix-ARM-build-with-GCC-trunk.patch
@@ -1,0 +1,54 @@
+From 175cef4163dd60f95106cfd5f593b8a4e09d02c9 Mon Sep 17 00:00:00 2001
+From: Joseph Myers <joseph@codesourcery.com>
+Date: Tue, 20 May 2014 21:27:13 +0000
+Subject: [PATCH] Fix ARM build with GCC trunk.
+
+sysdeps/unix/sysv/linux/arm/unwind-resume.c and
+sysdeps/unix/sysv/linux/arm/unwind-forcedunwind.c have static
+variables that are written in C code but only read from toplevel asms.
+Current GCC trunk now optimizes away such apparently write-only static
+variables, so causing a build failure.  This patch marks those
+variables with __attribute_used__ to avoid that optimization.
+
+Tested that this fixes the build for ARM.
+
+	* sysdeps/unix/sysv/linux/arm/unwind-forcedunwind.c
+	(libgcc_s_resume): Use __attribute_used__.
+	* sysdeps/unix/sysv/linux/arm/unwind-resume.c (libgcc_s_resume):
+	Likewise.
+---
+ sysdeps/unix/sysv/linux/arm/unwind-forcedunwind.c | 3 ++-
+ sysdeps/unix/sysv/linux/arm/unwind-resume.c       | 3 ++-
+ 3 files changed, 11 insertions(+), 2 deletions(-)
+
+diff --git a/sysdeps/unix/sysv/linux/arm/unwind-forcedunwind.c b/sysdeps/unix/sysv/linux/arm/unwind-forcedunwind.c
+index 6ccd9b4..660d148 100644
+--- a/ports/sysdeps/unix/sysv/linux/arm/nptl/unwind-forcedunwind.c
++++ b/ports/sysdeps/unix/sysv/linux/arm/nptl/unwind-forcedunwind.c
+@@ -22,7 +22,8 @@
+ #include <pthreadP.h>
+ 
+ static void *libgcc_s_handle;
+-static void (*libgcc_s_resume) (struct _Unwind_Exception *exc);
++static void (*libgcc_s_resume) (struct _Unwind_Exception *exc)
++  __attribute_used__;
+ static _Unwind_Reason_Code (*libgcc_s_personality)
+   (_Unwind_State, struct _Unwind_Exception *, struct _Unwind_Context *);
+ static _Unwind_Reason_Code (*libgcc_s_forcedunwind)
+diff --git a/sysdeps/unix/sysv/linux/arm/unwind-resume.c b/sysdeps/unix/sysv/linux/arm/unwind-resume.c
+index bff3e2b..1f1eb71 100644
+--- a/ports/sysdeps/unix/sysv/linux/arm/nptl/unwind-resume.c
++++ b/ports/sysdeps/unix/sysv/linux/arm/nptl/unwind-resume.c
+@@ -20,7 +20,8 @@
+ #include <stdio.h>
+ #include <unwind.h>
+ 
+-static void (*libgcc_s_resume) (struct _Unwind_Exception *exc);
++static void (*libgcc_s_resume) (struct _Unwind_Exception *exc)
++  __attribute_used__;
+ static _Unwind_Reason_Code (*libgcc_s_personality)
+   (_Unwind_State, struct _Unwind_Exception *, struct _Unwind_Context *);
+ 
+-- 
+1.9.4
+


### PR DESCRIPTION
When building a toolchain with glibc <= 2.19 and gcc >= 5.1 the build fails with message
```
In function _Unwind_Resume: undefined reference to libgcc_s_resume
```

This commit backports a fix from glibc 2.20.
The fix may be applied to all glibc versions <= 2.19, but I did test only with glibc 2.17, where it works fine now.