### PR TITLE
Doubled setting of --disable-libmudflap removed.

### DIFF
--- a/scripts/build/cc/100-gcc.sh
+++ b/scripts/build/cc/100-gcc.sh
@@ -390,7 +390,6 @@ do_gcc_core_backend() {
         --target=${CT_TARGET}                          \
         --prefix="${prefix}"                           \
         --with-local-prefix="${CT_SYSROOT_DIR}"        \
-        --disable-libmudflap                           \
         ${CC_CORE_SYSROOT_ARG}                         \
         "${extra_config[@]}"                           \
         --enable-languages="${lang_list}"              \


### PR DESCRIPTION
Removed doubled setting of --disable-libmudflap in do_gcc_core_backend.
Signed-off-by: Jasmin Jessich <jasmin@anw.at>