### PR TITLE
Synchronize CC_GCC_USE_LTO parameter setting.

### DIFF
--- a/scripts/build/cc/100-gcc.sh
+++ b/scripts/build/cc/100-gcc.sh
@@ -307,10 +307,8 @@ do_gcc_core_backend() {
     fi
     if [ "${CT_CC_GCC_USE_LTO}" = "y" ]; then
         extra_config+=("--with-libelf=${complibs}")
-        extra_config+=("--enable-lto")
     elif [ "${CT_CC_GCC_HAS_LTO}" = "y" ]; then
         extra_config+=("--with-libelf=no")
-        extra_config+=("--disable-lto")
     fi
 
     if [ ${#host_libstdcxx_flags[@]} -ne 0 ]; then


### PR DESCRIPTION
Synchronize CT_CC_GCC_USE_LTO parameter setting in do_gcc_core_backend with the
one from do_gcc_backend, by removing "--enable-lto"/"--disable-lto".

Signed-off-by: Jasmin Jessich <jasmin@anw.at>