### PR TITLE
Add additional environment variables for gcc build.

### DIFF
--- a/config/cc/gcc.in.2
+++ b/config/cc/gcc.in.2
@@ -37,6 +37,16 @@ config CC_GCC_EXTRA_CONFIG_ARRAY
       if they are properly quoted (or escaped, but prefer quotes). Eg.:
           --with-foo="1st arg with 4 spaces" --with-bar=2nd-arg-without-space
 
+config CC_GCC_EXTRA_ENV_ARRAY
+    string
+    prompt "Extra env variables to set for make"
+    default ""
+    help
+      Used to add specific env variables on the make command line for the
+      gcc build (eg. INHIBIT_LIBC_CFLAGS='-DUSE_TM_CLONE_REGISTRY=0')
+
+      Leave blank if you don't know better.
+
 config STATIC_TOOLCHAIN
     select CC_GCC_STATIC_LIBSTDCXX if CC_GCC_4_4_or_later
 

--- a/scripts/build/cc/100-gcc.sh
+++ b/scripts/build/cc/100-gcc.sh
@@ -194,6 +194,7 @@ do_gcc_core_backend() {
     local -a core_LDFLAGS
     local -a core_targets
     local -a extra_user_config
+    local -a extra_user_env
     local arg
 
     for arg in "$@"; do
@@ -376,6 +377,10 @@ do_gcc_core_backend() {
         extra_config+=("--disable-multilib")
     fi
 
+    if [ "x${CT_CC_GCC_EXTRA_ENV_ARRAY}" != "x" ]; then
+        extra_user_env=( "${CT_CC_GCC_EXTRA_ENV_ARRAY[@]}" )
+    fi
+
     CT_DoLog DEBUG "Extra config passed: '${extra_config[*]}'"
 
     # Use --with-local-prefix so older gccs don't look in /usr/local (http://gcc.gnu.org/PR10532)
@@ -456,7 +461,7 @@ do_gcc_core_backend() {
             repair_cc=""
         fi
 
-        CT_DoExecLog ALL make ${JOBSFLAGS} -C gcc ${libgcc_rule} \
+        CT_DoExecLog ALL make ${JOBSFLAGS} ${extra_user_env} -C gcc ${libgcc_rule} \
                               ${repair_cc}
         sed -r -i -e 's@-lc@@g' gcc/${libgcc_rule}
     else # build_libgcc
@@ -475,7 +480,7 @@ do_gcc_core_backend() {
     fi
 
     CT_DoLog EXTRA "Building gcc"
-    CT_DoExecLog ALL make ${JOBSFLAGS} "${core_targets[@]/#/all-}"
+    CT_DoExecLog ALL make ${JOBSFLAGS} ${extra_user_env} "${core_targets[@]/#/all-}"
 
     CT_DoLog EXTRA "Installing gcc"
     CT_DoExecLog ALL make ${JOBSFLAGS} "${core_targets[@]/#/install-}"


### PR DESCRIPTION
Add additional environment variables for gcc build (make) with new option
GCC_EXTRA_ENV_ARRAY.

Signed-off-by: Jasmin Jessich <jasmin@anw.at>