### PR TITLE
Remove isl 0.15

### DIFF
--- a/config/companion_libs/isl.in
+++ b/config/companion_libs/isl.in
@@ -6,12 +6,6 @@ choice
 # Don't remove next line
 # CT_INSERT_VERSION_BELOW
 
-config ISL_V_0_15
-    bool
-    prompt "0.15"
-    depends on CC_GCC_5_1_or_later
-    select ISL_V_0_15_or_later
-
 config ISL_V_0_14
     bool
     prompt "0.14"
@@ -32,10 +26,6 @@ config ISL_V_0_11_1
 
 endchoice
 
-config ISL_V_0_15_or_later
-    bool
-    select ISL_V_0_14_or_later
-
 config ISL_V_0_14_or_later
     bool
     select ISL_V_0_12_or_later
@@ -47,7 +37,6 @@ config ISL_VERSION
     string
 # Don't remove next line
 # CT_INSERT_VERSION_STRING_BELOW
-    default "0.15" if ISL_V_0_15
     default "0.14" if ISL_V_0_14
     default "0.12.2" if ISL_V_0_12_2
     default "0.11.1" if ISL_V_0_11_1


### PR DESCRIPTION
Remove isl 0.15, because it will not compile with gcc 5.2.0 without patching gcc.

Signed-off-by: Jasmin Jessich <jasmin@anw.at>