### PR TITLE
Fixed travis-ci environment setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,17 @@
 # Using container-based infrastructure
 sudo: false
 
-# Using C GCC compiler only
-language: c
-compiler: gcc
+# 'bash' will define a generic environment without interfering environment
+# settings like "CC=gcc"
+language: bash
 
 # Only build the master branch
 branches:
     only:
         - master
 
-# Caching the downloaded src packages between several builds
+# Caching the downloaded src packages between several builds to save travis-ci
+# download time and bandwidth
 cache:
     directories:
         - $HOME/src
@@ -47,3 +48,4 @@ script:
 # On failure displaying the last lines of the log file
 after_failure:
     - tail -n 200 build.log
+


### PR DESCRIPTION
Set language to 'bash' to get rid of interfering environment variable CC=gcc.

Signed-off-by: Jasmin Jessich <jasmin@anw.at>