### PR TITLE
configure: Add automated build option

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -46,6 +46,7 @@ all: Makefile build
 # Stuff found by ./configure
 export DATE            := @DATE@
 export LOCAL           := @enable_local@
+export AUTOMATED       := @enable_automated@
 export PROG_SED        := @program_transform_name@
 export PACKAGE_TARNAME := @PACKAGE_TARNAME@
 export VERSION         := @PACKAGE_VERSION@

--- a/config/global/logging.in
+++ b/config/global/logging.in
@@ -11,6 +11,7 @@ choice
 config LOG_ERROR
     bool
     prompt "ERROR"
+    depends on ! CONFIGURE_has_automated
     help
       The build will be silent.
       Only if there is an error will you see a message.
@@ -18,24 +19,28 @@ config LOG_ERROR
 config LOG_WARN
     bool
     prompt "WARN"
+    depends on ! CONFIGURE_has_automated
     help
       The same as above, plus warnings.
 
 config LOG_INFO
     bool
     prompt "INFO"
+    depends on ! CONFIGURE_has_automated
     help
       The same as above, plus informational messages (main steps).
 
 config LOG_EXTRA
     bool
     prompt "EXTRA"
+    depends on ! CONFIGURE_has_automated
     help
       The same as above, plus extra messages (sub-steps).
 
 config LOG_ALL
     bool
     prompt "ALL"
+    depends on ! CONFIGURE_has_automated
     help
       The same as above, plus all components build messages (very noisy!).
 
@@ -74,7 +79,7 @@ config LOG_PROGRESS_BAR
     bool
     prompt "Progress bar"
     default y
-    depends on ! LOG_ALL && ! LOG_DEBUG
+    depends on ! LOG_ALL && ! LOG_DEBUG && ! AUTOMATED_BUILD
     help
       If you say 'y' here, you'll be able to see the elapsed time.
       
@@ -104,3 +109,10 @@ config LOG_FILE_COMPRESS
     depends on LOG_TO_FILE
     help
       Compress the log file once the toolchain is successfully built.
+
+config AUTOMATED_BUILD
+    bool
+    default y
+    depends on CONFIGURE_has_automated
+    select LOG_DEBUG
+    select LOG_SEE_TOOLS_WARN

--- a/configure.ac
+++ b/configure.ac
@@ -67,6 +67,16 @@ AC_ARG_ENABLE(
         [do not install, and use current directory])])
 AC_SUBST([enable_local], [${enable_local:-no}])
 AC_ARG_ENABLE(
+    [automated],
+    [AS_HELP_STRING(
+        [--enable-automated],
+        [Tell ct-ng that this is an automated build])],
+        [if test "x$automated" = "x" -o "x$automated" = "xyes"; then
+             automated=y
+         fi])
+AC_SUBST([enable_automated], [${enable_automated:-no}])
+ACX_SET_KCONFIG_OPTION([automated])
+AC_ARG_ENABLE(
     [shared],
     [AS_HELP_STRING(
         [--enable-shared],


### PR DESCRIPTION
This commit introduces a configure time option to let the build know
that this is going to be an automated build.

This forces the build to disable the progress bar, log tool warnings,
and force the log level to debug.

Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>