### PR TITLE
config: Tone down automated build logs

### DIFF
--- a/config/global/logging.in
+++ b/config/global/logging.in
@@ -11,7 +11,6 @@ choice
 config LOG_ERROR
     bool
     prompt "ERROR"
-    depends on ! CONFIGURE_has_automated
     help
       The build will be silent.
       Only if there is an error will you see a message.
@@ -19,28 +18,24 @@ config LOG_ERROR
 config LOG_WARN
     bool
     prompt "WARN"
-    depends on ! CONFIGURE_has_automated
     help
       The same as above, plus warnings.
 
 config LOG_INFO
     bool
     prompt "INFO"
-    depends on ! CONFIGURE_has_automated
     help
       The same as above, plus informational messages (main steps).
 
 config LOG_EXTRA
     bool
     prompt "EXTRA"
-    depends on ! CONFIGURE_has_automated
     help
       The same as above, plus extra messages (sub-steps).
 
 config LOG_ALL
     bool
     prompt "ALL"
-    depends on ! CONFIGURE_has_automated
     help
       The same as above, plus all components build messages (very noisy!).
 
@@ -114,5 +109,3 @@ config AUTOMATED_BUILD
     bool
     default y
     depends on CONFIGURE_has_automated
-    select LOG_DEBUG
-    select LOG_SEE_TOOLS_WARN


### PR DESCRIPTION
I forgot that the logs must stay small, and if they fail we'll grab the
last few hundered lines.

Note, the logs must stay smaller then 4M.

Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>