### PR TITLE
Manage travis-ci restrictions

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,0 +1,43 @@
+# Add current directory to PATH
+export PATH="$(pwd):$PATH"
+
+# Manage the travis build
+ct-ng_travis_build()
+{
+	# Override the log behaviour
+	sed -i	-e 's/^.*\(CT_LOG_ERROR\).*$/# \1 is not set/' \
+		-e 's/^.*\(CT_LOG_WARN\).*$/# \1 is not set/' \
+		-e 's/^.*\(CT_LOG_INFO\).*$/# \1 is not set/' \
+		-e 's/^.*\(CT_LOG_EXTRA\).*$/\1=y/' \
+		-e 's/^.*\(CT_LOG_ALL\).*$/# \1 is not set/' \
+		-e 's/^.*\(CT_LOG_DEBUG\).*$/# \1 is not set/' \
+		-e 's/^.*\(CT_LOG_LEVEL_MAX\).*$/\1="EXTRA"/' \
+		-e 's/^.*\(CT_LOG_PROGRESS_BAR\).*$/# \1 is not set/' \
+		.config
+
+	# Build the sample
+	ct-ng build &
+	local build_pid=$!
+
+	# Start a runner task to print a "still running" line every 5 minutes
+	# to avoid travis to think that the build is stuck
+	{
+		while true
+		do
+			sleep 300
+			printf "Crosstool-NG is still running ...\r"
+		done
+	} &
+	local runner_pid=$!
+
+	# Wait for the build to finish and get the result
+	wait $build_pid 2>/dev/null
+	local result=$?
+
+	# Stop the runner task
+	kill $runner_pid
+	wait $runner_pid 2>/dev/null
+
+	# Return the result
+	return $result
+}

--- a/.travis.sh
+++ b/.travis.sh
@@ -16,7 +16,7 @@ ct-ng_travis_build()
 		.config
 
 	# Build the sample
-	ct-ng build &
+	ct-ng build.2 &
 	local build_pid=$!
 
 	# Start a runner task to print a "still running" line every 5 minutes

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,8 +42,9 @@ env:
 
 # Building the standard samples
 script:
-    - ./ct-ng $CT_SAMPLE
-    - CT_LOG_DEBUG=y CT_LOG_LEVEL_MAX="DEBUG" ./ct-ng build.2
+    - . ./.travis.sh      # Load the travis environment
+    - ct-ng $CT_SAMPLE    # Configure the build
+    - ct-ng_travis_build  # Build the sample
 
 # On failure displaying the last lines of the log file
 after_failure:

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,5 +48,4 @@ script:
 
 # On failure displaying the last lines of the log file
 after_failure:
-    - tail -n 200 build.log
-
+    - tail -n 500 build.log


### PR DESCRIPTION
I've been working on a script to manage travis-ci timming restrictions and other stuff.

I've seen that you recently push another solution with these two patches:

 * 4f266e1a8c78cec2c425b17784576db56125bbbd
 * d6413fe29fbdcd72a04b3d5820ba2e134dbaf558

My idea was also to manage the `CC=` stuff in this script to be able to test both `gcc` and `clang` compilers.

Note that there is something wrong because I have this error on some builds:

    g++: internal compiler error: Killed (program cc1plus)

which means that we are out of memory ... so It's still under development.