### PR TITLE
Using "all" and "install" targets in do_gcc_core_backend if configured

### DIFF
--- a/config/cc/gcc.in.2
+++ b/config/cc/gcc.in.2
@@ -47,6 +47,17 @@ config CC_GCC_EXTRA_ENV_ARRAY
 
       Leave blank if you don't know better.
 
+config CC_GCC_TARGET_FINAL
+    bool
+    prompt "Use the default targets all and install for the final compiler"
+    default n
+    depends on BARE_METAL
+    help
+      The final GCC for a bare metal system is built by the core gcc script.
+      This script does a lot of tricks to build the core gcc, which are not
+      required for the final gcc build. If you set this flag to true, all the
+      tricks are not done and the compiler is build with all/install.
+
 config STATIC_TOOLCHAIN
     select CC_GCC_STATIC_LIBSTDCXX if CC_GCC_4_4_or_later
 


### PR DESCRIPTION
Using "all" and "install" targets in do_gcc_core_backend if configured
- New configurations:
  - CC_GCC_TARGET_FINAL:
    Use the default targets "all" and "install" for the final compiler for
    bare metal.
- Adding parameter "build_step" to function do_gcc_core_backend:
  do_gcc_core_backend is used for the core compiler and in case of bare metal
  for the final compiler, too. To have better control over the parameters for
  the final compiler "build_step" is used.
  - Used for proper logging.
  - Use CT_CC_GCC_CORE_EXTRA_CONFIG_ARRAY or CT_CC_GCC_EXTRA_CONFIG_ARRAY.
  - If CT_CC_GCC_TARGET_FINAL is set and the final compiler is build then the
    make targets for the final compiler are used ("all", "install").

  Signed-off-by: Jasmin Jessich <jasmin@anw.at>