### PR TITLE
Fix a typo in the documentation

### DIFF
--- a/docs/3 - Configuring a toolchain.txt
+++ b/docs/3 - Configuring a toolchain.txt
@@ -15,7 +15,7 @@ will support, the version of the components you want to use, etc... The
 value for those options are then stored in a configuration file.
 
 The configurator works the same way you configure your Linux kernel. It is
-assumed you now how to handle this.
+assumed you know how to handle this.
 
 To enter the menu, type:
   ct-ng menuconfig


### PR DESCRIPTION
Replace "now" with "know."