### PR TITLE
binutils: Gold conflicts with Static Toolchain

### DIFF
--- a/config/binutils/binutils.in
+++ b/config/binutils/binutils.in
@@ -180,6 +180,13 @@ config BINUTILS_GOLD_SUPPORTS_ARCH
     default y if ARCH_arm
     default y if ARCH_x86
 
+config BINUTILS_GOLD_SUPPORT
+    bool
+    default y
+    depends on BINUTILS_HAS_GOLD
+    depends on BINUTILS_GOLD_SUPPORTS_ARCH
+    depends on ! STATIC_TOOLCHAIN
+
 config BINUTILS_HAS_PLUGINS
     bool
 
@@ -205,8 +212,7 @@ config BINUTILS_LINKER_LD
 config BINUTILS_LINKER_GOLD
     bool
     prompt "gold"
-    depends on BINUTILS_HAS_GOLD
-    depends on BINUTILS_GOLD_SUPPORTS_ARCH
+    depends on BINUTILS_GOLD_SUPPORT
     depends on ! BINUTILS_FORCE_LD_BFD
     select BINUTILS_GOLD_INSTALLED
     help
@@ -218,8 +224,7 @@ config BINUTILS_LINKER_GOLD
 config BINUTILS_LINKER_LD_GOLD
     bool
     prompt "ld, gold"
-    depends on BINUTILS_HAS_GOLD
-    depends on BINUTILS_GOLD_SUPPORTS_ARCH
+    depends on BINUTILS_GOLD_SUPPORT
     select BINUTILS_GOLD_INSTALLED
     select BINUTILS_LINKER_BOTH
     help
@@ -231,8 +236,7 @@ config BINUTILS_LINKER_LD_GOLD
 config BINUTILS_LINKER_GOLD_LD
     bool
     prompt "gold, ld"
-    depends on BINUTILS_HAS_GOLD
-    depends on BINUTILS_GOLD_SUPPORTS_ARCH
+    depends on BINUTILS_GOLD_SUPPORT
     select BINUTILS_GOLD_INSTALLED
     select BINUTILS_LINKER_BOTH
     select BINUTILS_LD_WRAPPER if BINUTILS_FORCE_LD_BFD


### PR DESCRIPTION
The gold linker cannot currently be built in a static toolchain build.
This may get fixed in a future version of crosstool-NG.

Also, there is a bit of weirdness here. versions of binutils >= 2.21
have GOLD (BINUTILS_HAS_GOLD), but that doesn't mean it should be used.
For instance, if the architecture is not supported.

So with that, we create a new hidden option: BINUTILS_GOLD_SUPPORT
Which in turn depends on BINUTILS_GOLD_SUPPORTS_ARCH, BINUTILS_HAS_GOLD,
and not STATIC_TOOLCHAIN... then replace anything that previously
depended on BINUTILS_HAS_GOLD with our new BINUTILS_GOLD_SUPPORT option.

This closes #210

Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>