### PR TITLE
ctng source

### DIFF
--- a/ct-ng.in
+++ b/ct-ng.in
@@ -104,6 +104,7 @@ help-tail::
 	@echo  'See "man 1 $(notdir $(CT_NG))" for some help as well'
 
 help-build::
+	@echo  '  source             - Download sources for currently configured toolchain'
 	@echo  '  build[.#]          - Build the currently configured toolchain'
 
 help-clean::
@@ -143,6 +144,9 @@ show-tuple: .config.2
 	$(SILENT)$(bash) $(CT_LIB_DIR)/scripts/showTuple.sh
 
 # Actual build
+source: .config.2
+	$(SILENT)CT_SOURCE=y $(CT_LIB_DIR)/scripts/crosstool-NG.sh
+
 build: .config.2
 	$(SILENT)$(CT_LIB_DIR)/scripts/crosstool-NG.sh
 

--- a/ct-ng.in
+++ b/ct-ng.in
@@ -151,7 +151,7 @@ build: .config.2
 	$(SILENT)$(CT_LIB_DIR)/scripts/crosstool-NG.sh
 
 build.%:
-	$(SILENT)$(MAKE) -rf $(CT_NG) $(shell echo "$(@)" |$(sed) -r -e 's|^([^.]+)\.([[:digit:]]+)$$|\1 CT_JOBS=\2|;')
+	$(SILENT)$(MAKE) -rf $(CT_NG) build CT_JOBS=$*
 
 PHONY += version
 version:

--- a/samples/samples.mk
+++ b/samples/samples.mk
@@ -204,5 +204,5 @@ build-all: $(patsubst %,build-%,$(CT_SAMPLES))
 
 # Build all samples, overiding the number of // jobs per sample
 build-all.%:
-	$(SILENT)$(MAKE) -rf $(CT_NG) V=$(V) $(shell echo "$(@)" |$(sed) -r -e 's|^([^.]+)\.([[:digit:]]+)$$|\1 CT_JOBS=\2|;')
+	$(SILENT)$(MAKE) -rf $(CT_NG) build-all CT_JOBS=$*
 

--- a/scripts/crosstool-NG.sh.in
+++ b/scripts/crosstool-NG.sh.in
@@ -524,6 +524,9 @@ if [ -z "${CT_RESTART}" ]; then
     [ ${CT_PARALLEL_JOBS} -gt 0 ] && JOBSFLAGS="${JOBSFLAGS} -j${CT_PARALLEL_JOBS}"
     JOBSFLAGS="${JOBSFLAGS} -l${CT_LOAD}"
 
+    # Override 'download only' option
+    [ -n "${CT_SOURCE}" ] && CT_ONLY_DOWNLOAD=y
+
     # Now that we've set up $PATH and $CT_CFLAGS_FOR_HOST, sanity test that gcc
     # is runnable so that the user can troubleshoot problems if not.
     CT_DoStep DEBUG "Checking that we can run gcc -v"

--- a/scripts/crosstool-NG.sh.in
+++ b/scripts/crosstool-NG.sh.in
@@ -516,7 +516,12 @@ if [ -z "${CT_RESTART}" ]; then
     # And help make go faster
     JOBSFLAGS=
     # Override the configured jobs with what's been given on the command line
-    [ -n "${CT_JOBS}" ] && CT_PARALLEL_JOBS="${CT_JOBS}"
+    if [ -n "${CT_JOBS}" ]; then
+        if [ ! -z "`echo "${CT_JOBS}" | sed 's/[0-9]//g'`" ]; then
+            CT_Abort "Number of parallel jobs must be integer."
+        fi
+        CT_PARALLEL_JOBS="${CT_JOBS}"
+    fi
     # Use the number of processors+1 when automatically setting the number of
     # parallel jobs.  Fall back to 1 if the host doesn't use GLIBC.
     AUTO_JOBS=$((`getconf _NPROCESSORS_ONLN 2> /dev/null || echo 0` + 1))


### PR DESCRIPTION
Add `ct-ng source` to just fetch the sources and stop (without the need to change options in .config).