### PR TITLE
config: MIPS64 is no longer experimental

### DIFF
--- a/config/arch/mips.in
+++ b/config/arch/mips.in
@@ -1,7 +1,7 @@
 # MIPS specific config options
 
 ## select ARCH_SUPPORTS_32
-## select ARCH_SUPPORTS_64 if EXPERIMENTAL
+## select ARCH_SUPPORTS_64
 ## select ARCH_DEFAULT_32
 ## select ARCH_USE_MMU
 ## select ARCH_SUPPORTS_BOTH_ENDIAN


### PR DESCRIPTION
This is a weird artifact from when mips64 was first introduced to ct-ng
and was never removed from experimental.

If you have problems building a mips64 toolchain, please report on the
mailing list or on github issues.

Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>