### PR TITLE
Fix some cross_compile issues

### DIFF
--- a/scripts/build/kernel/linux.sh
+++ b/scripts/build/kernel/linux.sh
@@ -119,6 +119,7 @@ do_kernel_install() {
     CT_DoLog EXTRA "Installing kernel headers"
     CT_DoExecLog ALL                                    \
     make -C "${kernel_path}"                            \
+         CROSS_COMPILE="${CT_TARGET}-"                  \
          O="${CT_BUILD_DIR}/build-kernel-headers"       \
          ARCH=${kernel_arch}                            \
          INSTALL_HDR_PATH="${CT_SYSROOT_DIR}/usr"       \
@@ -129,6 +130,7 @@ do_kernel_install() {
         CT_DoLog EXTRA "Checking installed headers"
         CT_DoExecLog ALL                                    \
         make -C "${kernel_path}"                            \
+             CROSS_COMPILE="${CT_TARGET}-"                  \
              O="${CT_BUILD_DIR}/build-kernel-headers"       \
              ARCH=${kernel_arch}                            \
              INSTALL_HDR_PATH="${CT_SYSROOT_DIR}/usr"       \

--- a/scripts/build/libc/uClibc.sh
+++ b/scripts/build/libc/uClibc.sh
@@ -98,7 +98,7 @@ do_libc_start_files() {
     # newer ones that are referenced are not available
     CT_DoLog EXTRA "Applying configuration"
     CT_DoYes "" |CT_DoExecLog ALL                                   \
-                 make CROSS="${cross}"                              \
+                 make CROSS_COMPILE="${cross}"                      \
                  PREFIX="${CT_SYSROOT_DIR}/"                        \
                  LOCALE_DATA_FILENAME="${uclibc_local_tarball}.tgz" \
                  oldconfig
@@ -106,7 +106,7 @@ do_libc_start_files() {
     CT_DoLog EXTRA "Building headers"
     CT_DoExecLog ALL                                        \
     make ${CT_LIBC_UCLIBC_VERBOSITY}                        \
-         CROSS="${cross}"                                   \
+         CROSS_COMPILE="${cross}"                           \
          PREFIX="${CT_SYSROOT_DIR}/"                        \
          LOCALE_DATA_FILENAME="${uclibc_local_tarball}.tgz" \
          headers
@@ -120,7 +120,7 @@ do_libc_start_files() {
     CT_DoLog EXTRA "Installing headers"
     CT_DoExecLog ALL                                        \
     make ${CT_LIBC_UCLIBC_VERBOSITY}                        \
-         CROSS="${cross}"                                   \
+         CROSS_COMPILE="${cross}"                           \
          PREFIX="${CT_SYSROOT_DIR}/"                        \
          LOCALE_DATA_FILENAME="${uclibc_local_tarball}.tgz" \
          ${install_rule}
@@ -129,7 +129,7 @@ do_libc_start_files() {
         CT_DoLog EXTRA "Building start files"
         CT_DoExecLog ALL                                        \
         make ${CT_LIBC_UCLIBC_PARALLEL:+${JOBSFLAGS}}           \
-             CROSS="${cross}"                                   \
+             CROSS_COMPILE="${cross}"                           \
              PREFIX="${CT_SYSROOT_DIR}/"                        \
              STRIPTOOL=true                                     \
              ${CT_LIBC_UCLIBC_VERBOSITY}                        \
@@ -180,7 +180,7 @@ do_libc() {
     # use LIBC_EXTRA_CFLAGS here.
     CT_DoLog EXTRA "Applying configuration"
     CT_DoYes "" |CT_DoExecLog CFG                                   \
-                 make CROSS=${CT_TARGET}-                           \
+                 make CROSS_COMPILE=${CT_TARGET}-                   \
                  PREFIX="${CT_SYSROOT_DIR}/"                        \
                  LOCALE_DATA_FILENAME="${uclibc_local_tarball}.tgz" \
                  oldconfig
@@ -191,7 +191,7 @@ do_libc() {
     CT_DoLog EXTRA "Building C library"
     CT_DoExecLog ALL                                        \
     make -j1                                                \
-         CROSS=${CT_TARGET}-                                \
+         CROSS_COMPILE=${CT_TARGET}-                        \
          PREFIX="${CT_SYSROOT_DIR}/"                        \
          STRIPTOOL=true                                     \
          ${CT_LIBC_UCLIBC_VERBOSITY}                        \
@@ -199,7 +199,7 @@ do_libc() {
          pregen
     CT_DoExecLog ALL                                        \
     make ${CT_LIBC_UCLIBC_PARALLEL:+${JOBSFLAGS}}           \
-         CROSS=${CT_TARGET}-                                \
+         CROSS_COMPILE=${CT_TARGET}-                        \
          PREFIX="${CT_SYSROOT_DIR}/"                        \
          STRIPTOOL=true                                     \
          ${CT_LIBC_UCLIBC_VERBOSITY}                        \
@@ -222,7 +222,7 @@ do_libc() {
     #
     CT_DoLog EXTRA "Installing C library"
     CT_DoExecLog ALL                                        \
-    make CROSS=${CT_TARGET}-                                \
+    make CROSS_COMPILE=${CT_TARGET}-                        \
          PREFIX="${CT_SYSROOT_DIR}/"                        \
          STRIPTOOL=true                                     \
          ${CT_LIBC_UCLIBC_VERBOSITY}                        \
@@ -384,7 +384,7 @@ mungeuClibcConfig() {
     #  " so people may need to update their paths slightly
     quoted_kernel_source=$(echo "${CT_HEADERS_DIR}" | sed -r -e 's,/include/?$,,; s,/,\\/,g;')
     quoted_headers_dir=$(echo "${CT_HEADERS_DIR}" | sed -r -e 's,/,\\/,g;')
-    # CROSS_COMPILER_PREFIX is left as is, as the CROSS parameter is forced on the command line
+    # CROSS_COMPILER_PREFIX is left as is, as the CROSS_COMPILE parameter is forced on the command line
     # DEVEL_PREFIX is left as '/usr/' because it is post-pended to $PREFIX, wich is the correct value of ${PREFIX}/${TARGET}
     # Some (old) versions of uClibc use KERNEL_SOURCE (which is _wrong_), and
     # newer versions use KERNEL_HEADERS (which is right).


### PR DESCRIPTION
While debugging new support for uClibc-ng, I noticed issues with not yet supported arc, and blackfin architectures.

* Linux needs CROSS_COMPILE set during the install/check headers step, as some architectures (notably arc and blackfin) set a default CROSS_COMPILE if it is not set.

* uClibc build script was using a "compat" command line argument, but we should use CROSS_COMPILE instead of CROSS to define our cross compiler.