### PR TITLE
Use install-strip target for gcc optionally

### DIFF
--- a/config/global/paths.in
+++ b/config/global/paths.in
@@ -117,12 +117,22 @@ config INSTALL_DIR_RO
       
       Useful for toolchains destined for production.
 
-config STRIP_ALL_TOOLCHAIN_EXECUTABLES
+config STRIP_HOST_TOOLCHAIN_EXECUTABLES
     bool
-    prompt "Strip all toolchain executables"
+    prompt "Strip host toolchain executables"
     default y
     help
       All build host executables contain a lot of unnecessary info.
-      By stripping all executables it slightly speeds up the compilation
+      By stripping host executables it slightly speeds up the compilation
       of large projects.
       NOTE: It does NOT strip the target libraries, only HOST executables
+
+config STRIP_TARGET_TOOLCHAIN_EXECUTABLES
+    bool
+    prompt "Strip target toolchain executables"
+    depends on CC_GCC_4_6_or_later
+    help
+      It means using install-strip target for GCC 4.6 or later.
+      An install-strip make target is provided that installs stripped
+      executables, and may install libraries with unneeded or debugging
+      sections stripped. 

--- a/scripts/build/cc/100-gcc.sh
+++ b/scripts/build/cc/100-gcc.sh
@@ -940,7 +940,11 @@ do_gcc_backend() {
     CT_DoExecLog ALL make ${JOBSFLAGS} all
 
     CT_DoLog EXTRA "Installing final gcc compiler"
-    CT_DoExecLog ALL make ${JOBSFLAGS} install
+    if [ "${CT_STRIP_TARGET_TOOLCHAIN_EXECUTABLES}" = "y" ]; then
+        CT_DoExecLog ALL make ${JOBSFLAGS} install-strip
+    else
+        CT_DoExecLog ALL make ${JOBSFLAGS} install
+    fi
 
     # Remove the libtool "pseudo-libraries": having them in the installed
     # tree makes the libtoolized utilities that are built next assume

--- a/scripts/build/internals.sh
+++ b/scripts/build/internals.sh
@@ -11,7 +11,7 @@ do_finish() {
 
     CT_DoStep INFO "Cleaning-up the toolchain's directory"
 
-    if [ "${CT_STRIP_ALL_TOOLCHAIN_EXECUTABLES}" = "y" ]; then
+    if [ "${CT_STRIP_HOST_TOOLCHAIN_EXECUTABLES}" = "y" ]; then
         case "$CT_HOST" in
             *darwin*)
                 strip_args=""

--- a/scripts/crosstool-NG.sh.in
+++ b/scripts/crosstool-NG.sh.in
@@ -458,7 +458,7 @@ if [ -z "${CT_RESTART}" ]; then
                         CT_TestAndAbort "Missing: '${t}${tool}${!s}' or '${t}${tool}' or '${tool}' : either needed!" "${CT_CC_LANG_JAVA}" = "y"
                         ;;
                     strip)
-                        CT_TestAndAbort "Missing: '${t}${tool}${!s}' or '${t}${tool}' or '${tool}' : either needed!" "${CT_STRIP_ALL_TOOLCHAIN_EXECUTABLES}" = "y"
+                        CT_TestAndAbort "Missing: '${t}${tool}${!s}' or '${t}${tool}' or '${tool}' : either needed!" "${CT_STRIP_HOST_TOOLCHAIN_EXECUTABLES}" = "y"
                         ;;
                     # If any other is missing, only warn at low level
                     *)


### PR DESCRIPTION
Starting from GCC 4.6 there is an install-strip target in Makefile which is provided for stripping GCC executables and libraries. The most important for me is that this option allows to strip libstdc++.a so that I can use static libcstdc++ without debugging symbols.