### PR TITLE
mpfr: Swap primary mirror to gnu.org

### DIFF
--- a/scripts/build/companion_libs/110-mpfr.sh
+++ b/scripts/build/companion_libs/110-mpfr.sh
@@ -13,8 +13,8 @@ if [ "${CT_MPFR}" = "y" ]; then
 # Download MPFR
 do_mpfr_get() {
     CT_GetFile "mpfr-${CT_MPFR_VERSION}"            \
-        http://www.mpfr.org/mpfr-${CT_MPFR_VERSION} \
-        {http,ftp,https}://ftp.gnu.org/gnu/mpfr
+        {https,http,ftp}://ftp.gnu.org/gnu/mpfr     \
+        http://www.mpfr.org/mpfr-${CT_MPFR_VERSION}
 }
 
 # Extract MPFR


### PR DESCRIPTION
mpfr.org has been less then reliable, so lets make gnu.org the primary
instead of the secondary source.

This closes #250

Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>