### PR TITLE
Add support for Xtensa architecture

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ env:
     - CT_SAMPLE=mips64el-n64-linux-uclibc
     - CT_SAMPLE=powerpc-e500v2-linux-gnuspe
     - CT_SAMPLE=x86_64-unknown-linux-uclibc
+    - CT_SAMPLE=xtensa-unknown-linux-uclibc
 
 # Building the standard samples
 script:

--- a/config/arch/xtensa.in
+++ b/config/arch/xtensa.in
@@ -1,0 +1,20 @@
+# xtensa specific configuration file
+
+## select ARCH_SUPPORTS_32
+## select ARCH_SUPPORTS_BOTH_MMU
+## select ARCH_DEFAULT_HAS_MMU
+##
+## help The xtensa architecture
+## help
+## help    Xtensa is a configurable and extensible processor architecture.
+## help    Supporting a specific configuration typically requires minor
+## help    modifications to a small set of configuration files in various
+## help    development tools. This process is automated and only requires
+## help    a configuration specific 'overlay' file.
+## help
+## help    For a custom configuration, select the XTENSA_CUSTOM option and
+## help    provide the name of the overlay file through the
+## help    CT_ARCH_XTENSA_CUSTOM_NAME option.
+## help
+## help    The default option (ARCH_xtensa_fsf) uses a built-in configuration,
+## help    which may or may not work for a particular Xtensa processor.

--- a/config/arch/xtensa.in.2
+++ b/config/arch/xtensa.in.2
@@ -1,0 +1,30 @@
+choice
+	prompt "Target Architecture Variant"
+	default ARCH_xtensa_fsf
+config XTENSA_CUSTOM
+	bool "Custom Xtensa processor configuration"
+
+config ARCH_xtensa_fsf
+	bool "fsf - Default configuration"
+
+endchoice
+
+config ARCH_XTENSA_CUSTOM_NAME
+	string "Custom Xtensa process configuration file name"
+	depends on XTENSA_CUSTOM
+	default ""
+	help
+	  Enter the name of the custom processor configuration
+	  overlay file or leave blank to use the default 'xtensa-overlay.tar'.
+	  For more information about this option, please also consult
+	  the 'help' section of the 'Target Architecture Variant'
+	  option above.
+
+config ARCH_XTENSA_CUSTOM_OVERLAY_LOCATION
+	string "Full path to custom Xtensa processor configurations"
+	depends on XTENSA_CUSTOM
+	default ""
+	help
+	  Enter the path to the directory for the custom processor
+	  configuration file or leave blank to use the default location:
+	  CT_CUSTOM_LOCATION_ROOT_DIR

--- a/patches/binutils/2.25.1/905-Fix-trampolines-search-code-for-conditional-branches.patch
+++ b/patches/binutils/2.25.1/905-Fix-trampolines-search-code-for-conditional-branches.patch
@@ -1,0 +1,90 @@
+From 415480d6471e67aef97c0241d451ef2423a1da9d Mon Sep 17 00:00:00 2001
+From: Max Filippov <jcmvbkbc@gmail.com>
+Date: Tue, 25 Nov 2014 21:33:21 +0300
+Subject: [PATCH] Fix trampolines search code for conditional branches
+
+For conditional branches that need more than one trampoline to reach its
+target assembler couldn't always find suitable trampoline because
+post-loop condition check was placed inside the loop, resulting in
+premature loop termination. Move check outside the loop.
+
+This fixes the following build errors seen when assembling huge files
+produced by gcc:
+    Error: jump target out of range; no usable trampoline found
+    Error: operand 1 of 'j' has out of range value '307307'
+
+2014-11-25  Max Filippov  <jcmvbkbc@gmail.com>
+
+gas/
+	* config/tc-xtensa.c (search_trampolines): Move post-loop
+	condition check outside the search loop.
+
+gas/testsuite/
+	* gas/xtensa/trampoline.d: Add expected output for branches.
+	* gas/xtensa/trampoline.s: Add test case for branches.
+
+Signed-off-by: Max Filippov <jcmvbkbc@gmail.com>
+---
+Backported from: d92b6eece424f0ad35d96fdd85bf207295e8c4c3
+Changes to ChangeLogs are dropped.
+
+ gas/config/tc-xtensa.c                | 8 ++++----
+ gas/testsuite/gas/xtensa/trampoline.d | 9 +++++++++
+ gas/testsuite/gas/xtensa/trampoline.s | 7 +++++++
+ 3 files changed, 20 insertions(+), 4 deletions(-)
+
+diff --git a/gas/config/tc-xtensa.c b/gas/config/tc-xtensa.c
+index d11b0c7..f23ccf8 100644
+--- a/gas/config/tc-xtensa.c
++++ b/gas/config/tc-xtensa.c
+@@ -9514,11 +9514,11 @@ search_trampolines (TInsn *tinsn, fragS *fragP, bfd_boolean unreachable_only)
+ 	      if (next_addr == 0 || addr - next_addr > J_RANGE)
+ 		break;
+ 	    }
+-	  if (abs (addr - this_addr) < J_RANGE)
+-	    return tf;
+-
+-	  return NULL;
+ 	}
++      if (abs (addr - this_addr) < J_RANGE)
++	return tf;
++
++      return NULL;
+     }
+   for ( ; tf; tf = tf->next)
+     {
+diff --git a/gas/testsuite/gas/xtensa/trampoline.d b/gas/testsuite/gas/xtensa/trampoline.d
+index b4f65dc..5ae32a6 100644
+--- a/gas/testsuite/gas/xtensa/trampoline.d
++++ b/gas/testsuite/gas/xtensa/trampoline.d
+@@ -24,3 +24,12 @@
+ .*33462:.*j.0x49407
+ #...
+ .*49407:.*j.0x49407
++.*4940a:.*beqz.n.a2,.0x4940f
++.*4940c:.*j.0x693d1
++#...
++.*693d1:.*j.0x7ddd4
++#...
++.*7ddd4:.*j.0x927f5
++#...
++.*927f5:.*j.0x927f5
++#...
+diff --git a/gas/testsuite/gas/xtensa/trampoline.s b/gas/testsuite/gas/xtensa/trampoline.s
+index 259a3bb..4465786 100644
+--- a/gas/testsuite/gas/xtensa/trampoline.s
++++ b/gas/testsuite/gas/xtensa/trampoline.s
+@@ -19,3 +19,10 @@
+ 	.endr
+ 3:
+ 	j	3b
++	bnez	a2, 4f
++	.rep	50000
++	and	a2, a2, a3
++	_ret
++	.endr
++4:
++	j	4b
+-- 
+1.8.1.4
+

--- a/patches/binutils/2.25.1/906-xtensa-optimize-check_section_ebb_pcrels_fit.patch
+++ b/patches/binutils/2.25.1/906-xtensa-optimize-check_section_ebb_pcrels_fit.patch
@@ -1,0 +1,502 @@
+From 20c79baf82273a0b368587f761f152c4d3a593a4 Mon Sep 17 00:00:00 2001
+From: Max Filippov <jcmvbkbc@gmail.com>
+Date: Fri, 27 Mar 2015 07:13:55 +0300
+Subject: [PATCH 1/4] xtensa: optimize check_section_ebb_pcrels_fit
+
+The original check_section_ebb_pcrels_fit algorithm checks that text
+actions proposed for current EBB are OK for every relocation in a
+section. There's no need to check every relocation, because text actions
+for EBB can only change size of that EBB, thus only affecting
+relocations that in any way cross that EBB. In addition EBBs are
+iterated in ascending order of their VMA, making it easier to track
+relevant relocations.
+
+Introduce a structure that can track relocations that cross the range of
+VMAs of EBB and use it to only check relocations relevant to current EBB
+in check_section_ebb_pcrels_fit.
+It takes O(N log N) operations to build it and O(N) operations to move
+current EBB VMA window through its entire range, where N is the number
+of relocations in a section. The resulting complexity of
+compute_text_actions is thus reduced from O(N^2) to O(N log N + N * M),
+where M is the average number of relocations crossing each EBB.
+
+Original profile:
+
+% time    self  children    called     name
+-----------------------------------------
+         44.26   71.53    6429/6429        compute_text_actions
+  50.2   44.26   71.53    6429         check_section_ebb_pcrels_fit
+          1.16   20.12 347506666/347576152     pcrel_reloc_fits
+          2.95   16.52 347506666/348104944     get_relocation_opnd
+          2.01    9.74 347575100/361252208     r_reloc_init
+          0.55    7.53 347575100/363381467     r_reloc_get_section
+          5.76    0.02 695013332/695013332     xlate_offset_with_removed_text
+          0.68    3.89 347575100/363483827     bfd_octets_per_byte
+          0.32    0.00 347506666/349910253     is_alt_relocation
+          0.18    0.11    6391/6391        build_xlate_map
+          0.00    0.00    6429/19417168     get_xtensa_relax_info
+          0.00    0.00    6391/6391        free_xlate_map
+-----------------------------------------
+
+Same data, after optimization:
+
+% time    self  children    called     name
+-----------------------------------------
+          2.56    3.08    6429/6429        compute_text_actions
+   8.2    2.56    3.08    6429         check_section_ebb_pcrels_fit
+          0.08    0.91 17721075/17790561     pcrel_reloc_fits
+          0.17    0.47 17721075/31685977     r_reloc_init
+          0.43    0.00 35442150/35442150     xlate_offset_with_removed_text
+          0.02    0.37 17721075/33815236     r_reloc_get_section
+          0.22    0.11    6391/6391        build_xlate_map
+          0.05    0.22 17721075/33917596     bfd_octets_per_byte
+          0.03    0.00 17721075/20405299     is_alt_relocation
+          0.01    0.00    6429/6429        reloc_range_list_update_range
+          0.00    0.00    6429/19417168     get_xtensa_relax_info
+          0.00    0.00    6391/6391        free_xlate_map
+-----------------------------------------
+
+2015-04-01  Max Filippov  <jcmvbkbc@gmail.com>
+bfd/
+	* elf32-xtensa.c (reloc_range_list, reloc_range_list_entry,
+	reloc_range): new typedef.
+	(reloc_range_list_struct, reloc_range_list_entry_struct,
+	reloc_range_struct): new structures.
+	(reloc_range_compare, build_reloc_ranges,
+	reloc_range_list_append, reloc_range_list_remove,
+	reloc_range_list_update_range, free_reloc_range_list): new
+	functions.
+	(compute_text_actions): precompute relocation opcodes before the
+	loop. Add relevant_relocs variable, initialize it before the
+	loop, pass it to the check_section_ebb_pcrels_fit.
+	(check_section_ebb_pcrels_fit): add new parameter:
+	relevant_relocs. Update address range in the relevant_relocs if
+	it's non-NULL and iterate only over relevant relocations.
+
+Backported from: b2b326d246f839ee218192ac88da2384d929a072
+Signed-off-by: Max Filippov <jcmvbkbc@gmail.com>
+---
+ bfd/elf32-xtensa.c | 321 +++++++++++++++++++++++++++++++++++++++++++++++++----
+ 1 file changed, 298 insertions(+), 23 deletions(-)
+
+diff --git a/bfd/elf32-xtensa.c b/bfd/elf32-xtensa.c
+index 0b6f584..872370b 100644
+--- a/bfd/elf32-xtensa.c
++++ b/bfd/elf32-xtensa.c
+@@ -6619,8 +6619,10 @@ static bfd_boolean compute_text_actions
+   (bfd *, asection *, struct bfd_link_info *);
+ static bfd_boolean compute_ebb_proposed_actions (ebb_constraint *);
+ static bfd_boolean compute_ebb_actions (ebb_constraint *);
++typedef struct reloc_range_list_struct reloc_range_list;
+ static bfd_boolean check_section_ebb_pcrels_fit
+-  (bfd *, asection *, bfd_byte *, Elf_Internal_Rela *, const ebb_constraint *,
++  (bfd *, asection *, bfd_byte *, Elf_Internal_Rela *,
++   reloc_range_list *, const ebb_constraint *,
+    const xtensa_opcode *);
+ static bfd_boolean check_section_ebb_reduces (const ebb_constraint *);
+ static void text_action_add_proposed
+@@ -7219,6 +7221,221 @@ build_reloc_opcodes (bfd *abfd,
+   return reloc_opcodes;
+ }
+ 
++struct reloc_range_struct
++{
++  bfd_vma addr;
++  bfd_boolean add; /* TRUE if start of a range, FALSE otherwise.  */
++  /* Original irel index in the array of relocations for a section.  */
++  unsigned irel_index;
++};
++typedef struct reloc_range_struct reloc_range;
++
++typedef struct reloc_range_list_entry_struct reloc_range_list_entry;
++struct reloc_range_list_entry_struct
++{
++  reloc_range_list_entry *next;
++  reloc_range_list_entry *prev;
++  Elf_Internal_Rela *irel;
++  xtensa_opcode opcode;
++  int opnum;
++};
++
++struct reloc_range_list_struct
++{
++  /* The rest of the structure is only meaningful when ok is TRUE.  */
++  bfd_boolean ok;
++
++  unsigned n_range; /* Number of range markers.  */
++  reloc_range *range; /* Sorted range markers.  */
++
++  unsigned first; /* Index of a first range element in the list.  */
++  unsigned last; /* One past index of a last range element in the list.  */
++
++  unsigned n_list; /* Number of list elements.  */
++  reloc_range_list_entry *reloc; /*  */
++  reloc_range_list_entry list_root;
++};
++
++static int
++reloc_range_compare (const void *a, const void *b)
++{
++  const reloc_range *ra = a;
++  const reloc_range *rb = b;
++
++  if (ra->addr != rb->addr)
++    return ra->addr < rb->addr ? -1 : 1;
++  if (ra->add != rb->add)
++    return ra->add ? -1 : 1;
++  return 0;
++}
++
++static void
++build_reloc_ranges (bfd *abfd, asection *sec,
++		    bfd_byte *contents,
++		    Elf_Internal_Rela *internal_relocs,
++		    xtensa_opcode *reloc_opcodes,
++		    reloc_range_list *list)
++{
++  unsigned i;
++  size_t n = 0;
++  size_t max_n = 0;
++  reloc_range *ranges = NULL;
++  reloc_range_list_entry *reloc =
++    bfd_malloc (sec->reloc_count * sizeof (*reloc));
++
++  memset (list, 0, sizeof (*list));
++  list->ok = TRUE;
++
++  for (i = 0; i < sec->reloc_count; i++)
++    {
++      Elf_Internal_Rela *irel = &internal_relocs[i];
++      int r_type = ELF32_R_TYPE (irel->r_info);
++      reloc_howto_type *howto = &elf_howto_table[r_type];
++      r_reloc r_rel;
++
++      if (r_type == R_XTENSA_ASM_SIMPLIFY
++	  || r_type == R_XTENSA_32_PCREL
++	  || !howto->pc_relative)
++	continue;
++
++      r_reloc_init (&r_rel, abfd, irel, contents,
++		    bfd_get_section_limit (abfd, sec));
++
++      if (r_reloc_get_section (&r_rel) != sec)
++	continue;
++
++      if (n + 2 > max_n)
++	{
++	  max_n = (max_n + 2) * 2;
++	  ranges = bfd_realloc (ranges, max_n * sizeof (*ranges));
++	}
++
++      ranges[n].addr = irel->r_offset;
++      ranges[n + 1].addr = r_rel.target_offset;
++
++      ranges[n].add = ranges[n].addr < ranges[n + 1].addr;
++      ranges[n + 1].add = !ranges[n].add;
++
++      ranges[n].irel_index = i;
++      ranges[n + 1].irel_index = i;
++
++      n += 2;
++
++      reloc[i].irel = irel;
++
++      /* Every relocation won't possibly be checked in the optimized version of
++         check_section_ebb_pcrels_fit, so this needs to be done here.  */
++      if (is_alt_relocation (ELF32_R_TYPE (irel->r_info)))
++	{
++	  /* None of the current alternate relocs are PC-relative,
++	     and only PC-relative relocs matter here.  */
++	}
++      else
++	{
++	  xtensa_opcode opcode;
++	  int opnum;
++
++	  if (reloc_opcodes)
++	    opcode = reloc_opcodes[i];
++	  else
++	    opcode = get_relocation_opcode (abfd, sec, contents, irel);
++
++	  if (opcode == XTENSA_UNDEFINED)
++	    {
++	      list->ok = FALSE;
++	      break;
++	    }
++
++	  opnum = get_relocation_opnd (opcode, ELF32_R_TYPE (irel->r_info));
++	  if (opnum == XTENSA_UNDEFINED)
++	    {
++	      list->ok = FALSE;
++	      break;
++	    }
++
++	  /* Record relocation opcode and opnum as we've calculated them
++	     anyway and they won't change.  */
++	  reloc[i].opcode = opcode;
++	  reloc[i].opnum = opnum;
++	}
++    }
++
++  if (list->ok)
++    {
++      ranges = bfd_realloc (ranges, n * sizeof (*ranges));
++      qsort (ranges, n, sizeof (*ranges), reloc_range_compare);
++
++      list->n_range = n;
++      list->range = ranges;
++      list->reloc = reloc;
++      list->list_root.prev = &list->list_root;
++      list->list_root.next = &list->list_root;
++    }
++  else
++    {
++      free (ranges);
++      free (reloc);
++    }
++}
++
++static void reloc_range_list_append (reloc_range_list *list,
++				     unsigned irel_index)
++{
++  reloc_range_list_entry *entry = list->reloc + irel_index;
++
++  entry->prev = list->list_root.prev;
++  entry->next = &list->list_root;
++  entry->prev->next = entry;
++  entry->next->prev = entry;
++  ++list->n_list;
++}
++
++static void reloc_range_list_remove (reloc_range_list *list,
++				     unsigned irel_index)
++{
++  reloc_range_list_entry *entry = list->reloc + irel_index;
++
++  entry->next->prev = entry->prev;
++  entry->prev->next = entry->next;
++  --list->n_list;
++}
++
++/* Update relocation list object so that it lists all relocations that cross
++   [first; last] range.  Range bounds should not decrease with successive
++   invocations.  */
++static void reloc_range_list_update_range (reloc_range_list *list,
++					   bfd_vma first, bfd_vma last)
++{
++  /* This should not happen: EBBs are iterated from lower addresses to higher.
++     But even if that happens there's no need to break: just flush current list
++     and start from scratch.  */
++  if ((list->last > 0 && list->range[list->last - 1].addr > last) ||
++      (list->first > 0 && list->range[list->first - 1].addr >= first))
++    {
++      list->first = 0;
++      list->last = 0;
++      list->n_list = 0;
++      list->list_root.next = &list->list_root;
++      list->list_root.prev = &list->list_root;
++      fprintf (stderr, "%s: move backwards requested\n", __func__);
++    }
++
++  for (; list->last < list->n_range &&
++       list->range[list->last].addr <= last; ++list->last)
++    if (list->range[list->last].add)
++      reloc_range_list_append (list, list->range[list->last].irel_index);
++
++  for (; list->first < list->n_range &&
++       list->range[list->first].addr < first; ++list->first)
++    if (!list->range[list->first].add)
++      reloc_range_list_remove (list, list->range[list->first].irel_index);
++}
++
++static void free_reloc_range_list (reloc_range_list *list)
++{
++  free (list->range);
++  free (list->reloc);
++}
+ 
+ /* The compute_text_actions function will build a list of potential
+    transformation actions for code in the extended basic block of each
+@@ -7245,6 +7462,7 @@ compute_text_actions (bfd *abfd,
+   property_table_entry *prop_table = 0;
+   int ptblsize = 0;
+   bfd_size_type sec_size;
++  reloc_range_list relevant_relocs;
+ 
+   relax_info = get_xtensa_relax_info (sec);
+   BFD_ASSERT (relax_info);
+@@ -7277,6 +7495,12 @@ compute_text_actions (bfd *abfd,
+       goto error_return;
+     }
+ 
++  /* Precompute the opcode for each relocation.  */
++  reloc_opcodes = build_reloc_opcodes (abfd, sec, contents, internal_relocs);
++
++  build_reloc_ranges (abfd, sec, contents, internal_relocs, reloc_opcodes,
++		      &relevant_relocs);
++
+   for (i = 0; i < sec->reloc_count; i++)
+     {
+       Elf_Internal_Rela *irel = &internal_relocs[i];
+@@ -7340,17 +7564,13 @@ compute_text_actions (bfd *abfd,
+       ebb->start_reloc_idx = i;
+       ebb->end_reloc_idx = i;
+ 
+-      /* Precompute the opcode for each relocation.  */
+-      if (reloc_opcodes == NULL)
+-	reloc_opcodes = build_reloc_opcodes (abfd, sec, contents,
+-					     internal_relocs);
+-
+       if (!extend_ebb_bounds (ebb)
+ 	  || !compute_ebb_proposed_actions (&ebb_table)
+ 	  || !compute_ebb_actions (&ebb_table)
+ 	  || !check_section_ebb_pcrels_fit (abfd, sec, contents,
+-					    internal_relocs, &ebb_table,
+-					    reloc_opcodes)
++					    internal_relocs,
++					    &relevant_relocs,
++					    &ebb_table, reloc_opcodes)
+ 	  || !check_section_ebb_reduces (&ebb_table))
+ 	{
+ 	  /* If anything goes wrong or we get unlucky and something does
+@@ -7372,6 +7592,8 @@ compute_text_actions (bfd *abfd,
+       free_ebb_constraint (&ebb_table);
+     }
+ 
++  free_reloc_range_list (&relevant_relocs);
++
+ #if DEBUG
+   if (relax_info->action_list.head)
+     print_action_list (stderr, &relax_info->action_list);
+@@ -7974,14 +8196,17 @@ check_section_ebb_pcrels_fit (bfd *abfd,
+ 			      asection *sec,
+ 			      bfd_byte *contents,
+ 			      Elf_Internal_Rela *internal_relocs,
++			      reloc_range_list *relevant_relocs,
+ 			      const ebb_constraint *constraint,
+ 			      const xtensa_opcode *reloc_opcodes)
+ {
+   unsigned i, j;
++  unsigned n = sec->reloc_count;
+   Elf_Internal_Rela *irel;
+   xlate_map_t *xmap = NULL;
+   bfd_boolean ok = TRUE;
+   xtensa_relax_info *relax_info;
++  reloc_range_list_entry *entry = NULL;
+ 
+   relax_info = get_xtensa_relax_info (sec);
+ 
+@@ -7992,7 +8217,40 @@ check_section_ebb_pcrels_fit (bfd *abfd,
+ 	 can still be used.  */
+     }
+ 
+-  for (i = 0; i < sec->reloc_count; i++)
++  if (relevant_relocs && constraint->action_count)
++    {
++      if (!relevant_relocs->ok)
++	{
++	  ok = FALSE;
++	  n = 0;
++	}
++      else
++	{
++	  bfd_vma min_offset, max_offset;
++	  min_offset = max_offset = constraint->actions[0].offset;
++
++	  for (i = 1; i < constraint->action_count; ++i)
++	    {
++	      proposed_action *action = &constraint->actions[i];
++	      bfd_vma offset = action->offset;
++
++	      if (offset < min_offset)
++		min_offset = offset;
++	      if (offset > max_offset)
++		max_offset = offset;
++	    }
++	  reloc_range_list_update_range (relevant_relocs, min_offset,
++					 max_offset);
++	  n = relevant_relocs->n_list;
++	  entry = &relevant_relocs->list_root;
++	}
++    }
++  else
++    {
++      relevant_relocs = NULL;
++    }
++
++  for (i = 0; i < n; i++)
+     {
+       r_reloc r_rel;
+       bfd_vma orig_self_offset, orig_target_offset;
+@@ -8001,7 +8259,15 @@ check_section_ebb_pcrels_fit (bfd *abfd,
+       reloc_howto_type *howto;
+       int self_removed_bytes, target_removed_bytes;
+ 
+-      irel = &internal_relocs[i];
++      if (relevant_relocs)
++	{
++	  entry = entry->next;
++	  irel = entry->irel;
++	}
++      else
++	{
++	  irel = internal_relocs + i;
++	}
+       r_type = ELF32_R_TYPE (irel->r_info);
+ 
+       howto = &elf_howto_table[r_type];
+@@ -8067,21 +8333,30 @@ check_section_ebb_pcrels_fit (bfd *abfd,
+ 	  xtensa_opcode opcode;
+ 	  int opnum;
+ 
+-	  if (reloc_opcodes)
+-	    opcode = reloc_opcodes[i];
+-	  else
+-	    opcode = get_relocation_opcode (abfd, sec, contents, irel);
+-	  if (opcode == XTENSA_UNDEFINED)
++	  if (relevant_relocs)
+ 	    {
+-	      ok = FALSE;
+-	      break;
++	      opcode = entry->opcode;
++	      opnum = entry->opnum;
+ 	    }
+-
+-	  opnum = get_relocation_opnd (opcode, ELF32_R_TYPE (irel->r_info));
+-	  if (opnum == XTENSA_UNDEFINED)
++	  else
+ 	    {
+-	      ok = FALSE;
+-	      break;
++	      if (reloc_opcodes)
++		opcode = reloc_opcodes[relevant_relocs ?
++		  (unsigned)(entry - relevant_relocs->reloc) : i];
++	      else
++		opcode = get_relocation_opcode (abfd, sec, contents, irel);
++	      if (opcode == XTENSA_UNDEFINED)
++		{
++		  ok = FALSE;
++		  break;
++		}
++
++	      opnum = get_relocation_opnd (opcode, ELF32_R_TYPE (irel->r_info));
++	      if (opnum == XTENSA_UNDEFINED)
++		{
++		  ok = FALSE;
++		  break;
++		}
+ 	    }
+ 
+ 	  if (!pcrel_reloc_fits (opcode, opnum, self_offset, target_offset))
+@@ -8778,7 +9053,7 @@ move_shared_literal (asection *sec,
+   /* Check all of the PC-relative relocations to make sure they still fit.  */
+   relocs_fit = check_section_ebb_pcrels_fit (target_sec->owner, target_sec,
+ 					     target_sec_cache->contents,
+-					     target_sec_cache->relocs,
++					     target_sec_cache->relocs, NULL,
+ 					     &ebb_table, NULL);
+ 
+   if (!relocs_fit)
+-- 
+1.8.1.4
+

--- a/patches/binutils/2.25.1/907-xtensa-optimize-removed_by_actions.patch
+++ b/patches/binutils/2.25.1/907-xtensa-optimize-removed_by_actions.patch
@@ -1,0 +1,356 @@
+From 3e3f60207399ab29dd55af109e5ae9facc7d8e83 Mon Sep 17 00:00:00 2001
+From: Max Filippov <jcmvbkbc@gmail.com>
+Date: Sat, 28 Mar 2015 08:46:28 +0300
+Subject: [PATCH 2/4] xtensa: optimize removed_by_actions
+
+The function removed_by_actions iterates through text actions to
+calculate an offset applied by text actions to a given VMA. Although it
+has a parameter p_start_action that allows for incremental offset
+calculation, in many places it's used with p_start_action explicitly set
+to the first action. After the first relaxation pass when the list of
+text actions is finalized, an array of offsets sorted by VMA may be used
+to speed up this function.
+
+Original profile:
+
+% time    self  children    called     name
+-----------------------------------------
+          0.35    0.00   33872/4808961     relax_section_symbols
+          3.32    0.00  326022/4808961     relax_property_section
+         12.83    0.00 1259379/4808961     offset_with_removed_text
+         32.50    0.00 3189688/4808961     translate_reloc
+  71.5   49.00    0.00 4808961         removed_by_actions
+-----------------------------------------
+
+Same data, after optimization:
+
+% time    self  children    called     name
+-----------------------------------------
+          0.00    0.00   33872/4808537     relax_section_symbols
+          0.01    0.00  326022/4808537     relax_property_section
+          0.05    0.00 1258955/4808537     offset_with_removed_text_map
+          0.13    0.00 3189688/4808537     translate_reloc
+   1.0    0.20    0.00 4808537         removed_by_actions_map
+          0.00    0.00     120/120         map_removal_by_action
+-----------------------------------------
+
+2015-04-01  Max Filippov  <jcmvbkbc@gmail.com>
+bfd/
+	* elf32-xtensa.c (removal_by_action_entry_struct,
+	removal_by_action_map_struct): new structures.
+	(removal_by_action_entry, removal_by_action_map): new typedefs.
+	(text_action_list_struct): add new field: map.
+	(map_removal_by_action, removed_by_actions_map,
+	offset_with_removed_text_map): new functions.
+	(relax_section): replace offset_with_removed_text with
+	offset_with_removed_text_map.
+	(translate_reloc, relax_property_section, relax_section_symbols):
+	replace removed_by_actions with removed_by_actions_map.
+
+Backported from: 071aa5c98a31c966f5fbfc573fcee61350fd1936
+Signed-off-by: Max Filippov <jcmvbkbc@gmail.com>
+---
+ bfd/elf32-xtensa.c | 181 +++++++++++++++++++++++++++++++++++++++++++++--------
+ 1 file changed, 156 insertions(+), 25 deletions(-)
+
+diff --git a/bfd/elf32-xtensa.c b/bfd/elf32-xtensa.c
+index 872370b..21b2871 100644
+--- a/bfd/elf32-xtensa.c
++++ b/bfd/elf32-xtensa.c
+@@ -5420,11 +5420,28 @@ struct text_action_struct
+   text_action *next;
+ };
+ 
++struct removal_by_action_entry_struct
++{
++  bfd_vma offset;
++  int removed;
++  int eq_removed;
++  int eq_removed_before_fill;
++};
++typedef struct removal_by_action_entry_struct removal_by_action_entry;
++
++struct removal_by_action_map_struct
++{
++  unsigned n_entries;
++  removal_by_action_entry *entry;
++};
++typedef struct removal_by_action_map_struct removal_by_action_map;
++
+ 
+ /* List of all of the actions taken on a text section.  */
+ struct text_action_list_struct
+ {
+   text_action *head;
++  removal_by_action_map map;
+ };
+ 
+ 
+@@ -5636,6 +5653,101 @@ action_list_count (text_action_list *action_list)
+   return count;
+ }
+ 
++static void
++map_removal_by_action (text_action_list *action_list)
++{
++  text_action *r;
++  int removed = 0;
++  removal_by_action_map map;
++  bfd_boolean eq_complete;
++
++  map.n_entries = 0;
++  map.entry = bfd_malloc (action_list_count (action_list) *
++			  sizeof (removal_by_action_entry));
++  eq_complete = FALSE;
++
++  for (r = action_list->head; r;)
++    {
++      removal_by_action_entry *ientry = map.entry + map.n_entries;
++
++      if (map.n_entries && (ientry - 1)->offset == r->offset)
++	{
++	  --ientry;
++	}
++      else
++	{
++	  ++map.n_entries;
++	  eq_complete = FALSE;
++	  ientry->offset = r->offset;
++	  ientry->eq_removed_before_fill = removed;
++	}
++
++      if (!eq_complete)
++	{
++	  if (r->action != ta_fill || r->removed_bytes >= 0)
++	    {
++	      ientry->eq_removed = removed;
++	      eq_complete = TRUE;
++	    }
++	  else
++	    ientry->eq_removed = removed + r->removed_bytes;
++	}
++
++      removed += r->removed_bytes;
++      ientry->removed = removed;
++      r = r->next;
++    }
++  action_list->map = map;
++}
++
++static int
++removed_by_actions_map (text_action_list *action_list, bfd_vma offset,
++			bfd_boolean before_fill)
++{
++  unsigned a, b;
++
++  if (!action_list->map.entry)
++    map_removal_by_action (action_list);
++
++  if (!action_list->map.n_entries)
++    return 0;
++
++  a = 0;
++  b = action_list->map.n_entries;
++
++  while (b - a > 1)
++    {
++      unsigned c = (a + b) / 2;
++
++      if (action_list->map.entry[c].offset <= offset)
++	a = c;
++      else
++	b = c;
++    }
++
++  if (action_list->map.entry[a].offset < offset)
++    {
++      return action_list->map.entry[a].removed;
++    }
++  else if (action_list->map.entry[a].offset == offset)
++    {
++      return before_fill ?
++	action_list->map.entry[a].eq_removed_before_fill :
++	action_list->map.entry[a].eq_removed;
++    }
++  else
++    {
++      return 0;
++    }
++}
++
++static bfd_vma
++offset_with_removed_text_map (text_action_list *action_list, bfd_vma offset)
++{
++  int removed = removed_by_actions_map (action_list, offset, FALSE);
++  return offset - removed;
++}
++
+ 
+ /* The find_insn_action routine will only find non-fill actions.  */
+ 
+@@ -5909,6 +6021,9 @@ init_xtensa_relax_info (asection *sec)
+ 
+   relax_info->action_list.head = NULL;
+ 
++  relax_info->action_list.map.n_entries = 0;
++  relax_info->action_list.map.entry = NULL;
++
+   relax_info->fix_list = NULL;
+   relax_info->fix_array = NULL;
+   relax_info->fix_array_count = 0;
+@@ -9218,7 +9333,7 @@ relax_section (bfd *abfd, asection *sec, struct bfd_link_info *link_info)
+ 		  if (elf_hash_table (link_info)->dynamic_sections_created)
+ 		    shrink_dynamic_reloc_sections (link_info, abfd, sec, irel);
+ 		  irel->r_info = ELF32_R_INFO (0, R_XTENSA_NONE);
+-		  irel->r_offset = offset_with_removed_text
++		  irel->r_offset = offset_with_removed_text_map
+ 		    (&relax_info->action_list, irel->r_offset);
+ 		  continue;
+ 		}
+@@ -9255,7 +9370,7 @@ relax_section (bfd *abfd, asection *sec, struct bfd_link_info *link_info)
+ 		    }
+ 		}
+ 
+-	      source_offset = offset_with_removed_text
++	      source_offset = offset_with_removed_text_map
+ 		(&relax_info->action_list, irel->r_offset);
+ 	      irel->r_offset = source_offset;
+ 	    }
+@@ -9352,7 +9467,7 @@ relax_section (bfd *abfd, asection *sec, struct bfd_link_info *link_info)
+ 		      break;
+ 		    }
+ 
+-		  new_end_offset = offset_with_removed_text
++		  new_end_offset = offset_with_removed_text_map
+ 		    (&target_relax_info->action_list,
+ 		     r_rel.target_offset + diff_value);
+ 		  diff_value = new_end_offset - new_reloc.target_offset;
+@@ -9750,7 +9865,6 @@ translate_reloc (const r_reloc *orig_rel, r_reloc *new_rel, asection *sec)
+   xtensa_relax_info *relax_info;
+   removed_literal *removed;
+   bfd_vma target_offset, base_offset;
+-  text_action *act;
+ 
+   *new_rel = *orig_rel;
+ 
+@@ -9803,19 +9917,26 @@ translate_reloc (const r_reloc *orig_rel, r_reloc *new_rel, asection *sec)
+      offset.  */
+ 
+   base_offset = r_reloc_get_target_offset (new_rel) - new_rel->rela.r_addend;
+-  act = relax_info->action_list.head;
+   if (base_offset <= target_offset)
+     {
+-      int base_removed = removed_by_actions (&act, base_offset, FALSE);
+-      int addend_removed = removed_by_actions (&act, target_offset, FALSE);
++      int base_removed = removed_by_actions_map (&relax_info->action_list,
++						 base_offset, FALSE);
++      int addend_removed = removed_by_actions_map (&relax_info->action_list,
++						   target_offset, FALSE) -
++	base_removed;
++
+       new_rel->target_offset = target_offset - base_removed - addend_removed;
+       new_rel->rela.r_addend -= addend_removed;
+     }
+   else
+     {
+       /* Handle a negative addend.  The base offset comes first.  */
+-      int tgt_removed = removed_by_actions (&act, target_offset, FALSE);
+-      int addend_removed = removed_by_actions (&act, base_offset, FALSE);
++      int tgt_removed = removed_by_actions_map (&relax_info->action_list,
++						target_offset, FALSE);
++      int addend_removed = removed_by_actions_map (&relax_info->action_list,
++						   base_offset, FALSE) -
++	tgt_removed;
++
+       new_rel->target_offset = target_offset - tgt_removed;
+       new_rel->rela.r_addend += addend_removed;
+     }
+@@ -10138,9 +10259,10 @@ relax_property_section (bfd *abfd,
+ 	      bfd_vma old_offset = val.r_rel.target_offset;
+ 	      bfd_vma new_offset;
+ 	      long old_size, new_size;
+-	      text_action *act = target_relax_info->action_list.head;
+-	      new_offset = old_offset -
+-		removed_by_actions (&act, old_offset, FALSE);
++	      int removed_by_old_offset =
++		removed_by_actions_map (&target_relax_info->action_list,
++					old_offset, FALSE);
++	      new_offset = old_offset - removed_by_old_offset;
+ 
+ 	      /* Assert that we are not out of bounds.  */
+ 	      old_size = bfd_get_32 (abfd, size_p);
+@@ -10164,9 +10286,10 @@ relax_property_section (bfd *abfd,
+ 
+ 		      /* Recompute the new_offset, but this time don't
+ 			 include any fill inserted by relaxation.  */
+-		      act = target_relax_info->action_list.head;
+-		      new_offset = old_offset -
+-			removed_by_actions (&act, old_offset, TRUE);
++		      removed_by_old_offset =
++			removed_by_actions_map (&target_relax_info->action_list,
++						old_offset, TRUE);
++		      new_offset = old_offset - removed_by_old_offset;
+ 
+ 		      /* If it is not unreachable and we have not yet
+ 			 seen an unreachable at this address, place it
+@@ -10182,8 +10305,12 @@ relax_property_section (bfd *abfd,
+ 		    }
+ 		}
+ 	      else
+-		new_size -=
+-		    removed_by_actions (&act, old_offset + old_size, TRUE);
++		{
++		  int removed_by_old_offset_size =
++		    removed_by_actions_map (&target_relax_info->action_list,
++					    old_offset + old_size, TRUE);
++		  new_size -= removed_by_old_offset_size - removed_by_old_offset;
++		}
+ 
+ 	      if (new_size != old_size)
+ 		{
+@@ -10441,14 +10568,16 @@ relax_section_symbols (bfd *abfd, asection *sec)
+ 
+       if (isym->st_shndx == sec_shndx)
+ 	{
+-	  text_action *act = relax_info->action_list.head;
+ 	  bfd_vma orig_addr = isym->st_value;
++	  int removed = removed_by_actions_map (&relax_info->action_list,
++						orig_addr, FALSE);
+ 
+-	  isym->st_value -= removed_by_actions (&act, orig_addr, FALSE);
+-
++	  isym->st_value -= removed;
+ 	  if (ELF32_ST_TYPE (isym->st_info) == STT_FUNC)
+ 	    isym->st_size -=
+-	      removed_by_actions (&act, orig_addr + isym->st_size, FALSE);
++	      removed_by_actions_map (&relax_info->action_list,
++				      orig_addr + isym->st_size, FALSE) -
++	      removed;
+ 	}
+     }
+ 
+@@ -10466,15 +10595,17 @@ relax_section_symbols (bfd *abfd, asection *sec)
+ 	   || sym_hash->root.type == bfd_link_hash_defweak)
+ 	  && sym_hash->root.u.def.section == sec)
+ 	{
+-	  text_action *act = relax_info->action_list.head;
+ 	  bfd_vma orig_addr = sym_hash->root.u.def.value;
++	  int removed = removed_by_actions_map (&relax_info->action_list,
++						orig_addr, FALSE);
+ 
+-	  sym_hash->root.u.def.value -=
+-	    removed_by_actions (&act, orig_addr, FALSE);
++	  sym_hash->root.u.def.value -= removed;
+ 
+ 	  if (sym_hash->type == STT_FUNC)
+ 	    sym_hash->size -=
+-	      removed_by_actions (&act, orig_addr + sym_hash->size, FALSE);
++	      removed_by_actions_map (&relax_info->action_list,
++				      orig_addr + sym_hash->size, FALSE) -
++	      removed;
+ 	}
+     }
+ 
+-- 
+1.8.1.4
+

--- a/patches/binutils/2.25.1/908-xtensa-optimize-find_removed_literal.patch
+++ b/patches/binutils/2.25.1/908-xtensa-optimize-find_removed_literal.patch
@@ -1,0 +1,146 @@
+From 288c2b709e5e6841484e1a129eaccd299db36877 Mon Sep 17 00:00:00 2001
+From: Max Filippov <jcmvbkbc@gmail.com>
+Date: Sat, 4 Apr 2015 14:49:42 +0300
+Subject: [PATCH 3/4] xtensa: optimize find_removed_literal
+
+find_removed_literal uses linear search to find removed literal by its
+VMA. The list of literals is fixed at that point, build an ordered index
+array and use binary search instead.
+
+Original profile:
+
+% time    self  children    called     name
+-----------------------------------------
+         56.72    0.00  297578/669392      translate_reloc
+         70.86    0.00  371814/669392      relax_section
+  67.9  127.58    0.00  669392         find_removed_literal
+-----------------------------------------
+
+Same data, after optimization:
+
+% time    self  children    called     name
+-----------------------------------------
+          0.00    0.00  297578/669392      translate_reloc
+          0.00    0.00  371814/669392      relax_section
+   0.0    0.00    0.00  669392         find_removed_literal
+          0.00    0.00   23838/23838       map_removed_literal
+-----------------------------------------
+
+2015-04-03  Max Filippov  <jcmvbkbc@gmail.com>
+bfd/
+	* elf32-xtensa.c (removed_literal_map_entry): new typedef.
+	(removed_literal_map_entry_struct): new structure.
+	(removed_literal_list_struct): add new fields: n_map and map.
+	(map_removed_literal, removed_literal_compare): new functions.
+	(find_removed_literal): build index array for literals ordered
+	by VMA, use binary search to find removed literal.
+
+Backported from: 3439c466273378021821473d3fc84990e089ae34
+Signed-off-by: Max Filippov <jcmvbkbc@gmail.com>
+---
+ bfd/elf32-xtensa.c | 64 +++++++++++++++++++++++++++++++++++++++++++++++++-----
+ 1 file changed, 58 insertions(+), 6 deletions(-)
+
+diff --git a/bfd/elf32-xtensa.c b/bfd/elf32-xtensa.c
+index 21b2871..51733ad 100644
+--- a/bfd/elf32-xtensa.c
++++ b/bfd/elf32-xtensa.c
+@@ -5832,6 +5832,7 @@ print_action_list (FILE *fp, text_action_list *action_list)
+    by the "from" offset field.  */
+ 
+ typedef struct removed_literal_struct removed_literal;
++typedef struct removed_literal_map_entry_struct removed_literal_map_entry;
+ typedef struct removed_literal_list_struct removed_literal_list;
+ 
+ struct removed_literal_struct
+@@ -5841,10 +5842,19 @@ struct removed_literal_struct
+   removed_literal *next;
+ };
+ 
++struct removed_literal_map_entry_struct
++{
++  bfd_vma addr;
++  removed_literal *literal;
++};
++
+ struct removed_literal_list_struct
+ {
+   removed_literal *head;
+   removed_literal *tail;
++
++  unsigned n_map;
++  removed_literal_map_entry *map;
+ };
+ 
+ 
+@@ -5893,6 +5903,39 @@ add_removed_literal (removed_literal_list *removed_list,
+     }
+ }
+ 
++static void
++map_removed_literal (removed_literal_list *removed_list)
++{
++  unsigned n_map = 0;
++  unsigned i;
++  removed_literal_map_entry *map = NULL;
++  removed_literal *r = removed_list->head;
++
++  for (i = 0; r; ++i, r = r->next)
++    {
++      if (i == n_map)
++	{
++	  n_map = (n_map * 2) + 2;
++	  map = bfd_realloc (map, n_map * sizeof (*map));
++	}
++      map[i].addr = r->from.target_offset;
++      map[i].literal = r;
++    }
++  removed_list->map = map;
++  removed_list->n_map = i;
++}
++
++static int
++removed_literal_compare (const void *a, const void *b)
++{
++  const removed_literal_map_entry *pa = a;
++  const removed_literal_map_entry *pb = b;
++
++  if (pa->addr == pb->addr)
++    return 0;
++  else
++    return pa->addr < pb->addr ? -1 : 1;
++}
+ 
+ /* Check if the list of removed literals contains an entry for the
+    given address.  Return the entry if found.  */
+@@ -5900,12 +5943,21 @@ add_removed_literal (removed_literal_list *removed_list,
+ static removed_literal *
+ find_removed_literal (removed_literal_list *removed_list, bfd_vma addr)
+ {
+-  removed_literal *r = removed_list->head;
+-  while (r && r->from.target_offset < addr)
+-    r = r->next;
+-  if (r && r->from.target_offset == addr)
+-    return r;
+-  return NULL;
++  removed_literal_map_entry *p;
++  removed_literal *r = NULL;
++
++  if (removed_list->map == NULL)
++    map_removed_literal (removed_list);
++
++  p = bsearch (&addr, removed_list->map, removed_list->n_map,
++	       sizeof (*removed_list->map), removed_literal_compare);
++  if (p)
++    {
++      while (p != removed_list->map && (p - 1)->addr == addr)
++	--p;
++      r = p->literal;
++    }
++  return r;
+ }
+ 
+ 
+-- 
+1.8.1.4
+

--- a/patches/binutils/2.25.1/909-xtensa-replace-action-list-with-splay-tree.patch
+++ b/patches/binutils/2.25.1/909-xtensa-replace-action-list-with-splay-tree.patch
@@ -1,0 +1,826 @@
+From e5409aedd3ee2192855018a564650ffb75c26e60 Mon Sep 17 00:00:00 2001
+From: Max Filippov <jcmvbkbc@gmail.com>
+Date: Sun, 5 Apr 2015 17:04:22 +0300
+Subject: [PATCH 4/4] xtensa: replace action list with splay tree
+
+text_action_add uses linear list search to order text actions list by
+action VMA. The list is used at the first relaxation pass, when it's not
+fixed yet.
+Replace the list with splay tree from libiberty.
+
+Original profile:
+
+% time    self  children    called     name
+-----------------------------------------
+          0.00    0.00      14/158225      compute_text_actions
+          3.62    0.00   25211/158225      remove_dead_literal
+          8.42    0.00   58645/158225      coalesce_shared_literal
+         10.68    0.00   74355/158225      text_action_add_proposed
+  38.8   22.73    0.00  158225         text_action_add
+          0.00    0.00  144527/293246      bfd_zmalloc
+-----------------------------------------
+
+Same data, after optimization:
+
+% time    self  children    called     name
+-----------------------------------------
+          0.00    0.00      14/158225      compute_text_actions
+          0.00    0.00   25211/158225      remove_dead_literal
+          0.00    0.01   58645/158225      coalesce_shared_literal
+          0.00    0.01   74355/158225      text_action_add_proposed
+   0.1    0.00    0.02  158225         text_action_add
+          0.01    0.00  144527/144527      splay_tree_insert
+          0.00    0.00  144527/195130      splay_tree_lookup
+          0.00    0.00  144527/293246      bfd_zmalloc
+-----------------------------------------
+
+2015-04-03  Max Filippov  <jcmvbkbc@gmail.com>
+bfd/
+	* elf32-xtensa.c (splay-tree.h): include header.
+	(text_action_struct): drop next pointer.
+	(text_action_list_struct): drop head pointer, add count and
+	tree fields.
+	(find_fill_action): instead of linear search in text_action_list
+	search in the tree.
+	(text_action_compare, action_first, action_next): new functions.
+	(text_action_add, text_action_add_literal): instead of linear
+	search and insertion insert new node into the tree.
+	(removed_by_actions): pass additional parameter: action_list,
+	use it to traverse the tree.
+	(offset_with_removed_text): pass additional action_list parameter
+	to removed_by_actions.
+	(map_action_fn_context): new typedef.
+	(map_action_fn_context_struct): new structure.
+	(map_action_fn): new function.
+	(map_removal_by_action): use splay_tree_foreach to build map.
+	(find_insn_action): replace linear search in text_action_list
+	with series of splay_tree_lookups.
+	(print_action, print_action_list_fn): new functions.
+	(print_action_list): use splay_tree_foreach.
+	(init_xtensa_relax_info): drop action_list.head initialization.
+	Initialize the tree.
+	(compute_text_actions): use non-zero action_list_count instead of
+	non-NULL action list.
+	(xlate_map_context): new typedef.
+	(xlate_map_context_struct): new structure.
+	(xlate_map_fn): new function.
+	(build_xlate_map): use splay_tree_foreach to build map.
+	(action_remove_bytes_fn): new function.
+	(relax_section): use zero action_list_count instead of NULL
+	action list. Use splay_tree_foreach to count final section size.
+	Drop unused variable 'removed'.
+
+Backported from: 4c2af04fe8b4452bf51d2debf1bb467fafcd0f08
+Signed-off-by: Max Filippov <jcmvbkbc@gmail.com>
+---
+ bfd/elf32-xtensa.c | 488 +++++++++++++++++++++++++++++++----------------------
+ 1 file changed, 282 insertions(+), 206 deletions(-)
+
+diff --git a/bfd/elf32-xtensa.c b/bfd/elf32-xtensa.c
+index 51733ad..53af1c6 100644
+--- a/bfd/elf32-xtensa.c
++++ b/bfd/elf32-xtensa.c
+@@ -28,6 +28,7 @@
+ #include "libbfd.h"
+ #include "elf-bfd.h"
+ #include "elf/xtensa.h"
++#include "splay-tree.h"
+ #include "xtensa-isa.h"
+ #include "xtensa-config.h"
+ 
+@@ -5416,8 +5417,6 @@ struct text_action_struct
+   bfd_vma virtual_offset;  /* Zero except for adding literals.  */
+   int removed_bytes;
+   literal_value value;	/* Only valid when adding literals.  */
+-
+-  text_action *next;
+ };
+ 
+ struct removal_by_action_entry_struct
+@@ -5440,7 +5439,8 @@ typedef struct removal_by_action_map_struct removal_by_action_map;
+ /* List of all of the actions taken on a text section.  */
+ struct text_action_list_struct
+ {
+-  text_action *head;
++  unsigned count;
++  splay_tree tree;
+   removal_by_action_map map;
+ };
+ 
+@@ -5448,20 +5448,18 @@ struct text_action_list_struct
+ static text_action *
+ find_fill_action (text_action_list *l, asection *sec, bfd_vma offset)
+ {
+-  text_action **m_p;
++  text_action a;
+ 
+   /* It is not necessary to fill at the end of a section.  */
+   if (sec->size == offset)
+     return NULL;
+ 
+-  for (m_p = &l->head; *m_p && (*m_p)->offset <= offset; m_p = &(*m_p)->next)
+-    {
+-      text_action *t = *m_p;
+-      /* When the action is another fill at the same address,
+-	 just increase the size.  */
+-      if (t->offset == offset && t->action == ta_fill)
+-	return t;
+-    }
++  a.offset = offset;
++  a.action = ta_fill;
++
++  splay_tree_node node = splay_tree_lookup (l->tree, (splay_tree_key)&a);
++  if (node)
++    return (text_action *)node->value;
+   return NULL;
+ }
+ 
+@@ -5509,6 +5507,49 @@ adjust_fill_action (text_action *ta, int fill_diff)
+ }
+ 
+ 
++static int
++text_action_compare (splay_tree_key a, splay_tree_key b)
++{
++  text_action *pa = (text_action *)a;
++  text_action *pb = (text_action *)b;
++  static const int action_priority[] =
++    {
++      [ta_fill] = 0,
++      [ta_none] = 1,
++      [ta_convert_longcall] = 2,
++      [ta_narrow_insn] = 3,
++      [ta_remove_insn] = 4,
++      [ta_remove_longcall] = 5,
++      [ta_remove_literal] = 6,
++      [ta_widen_insn] = 7,
++      [ta_add_literal] = 8,
++    };
++
++  if (pa->offset == pb->offset)
++    {
++      if (pa->action == pb->action)
++	  return 0;
++      return action_priority[pa->action] - action_priority[pb->action];
++    }
++  else
++    return pa->offset < pb->offset ? -1 : 1;
++}
++
++static text_action *
++action_first (text_action_list *action_list)
++{
++  splay_tree_node node = splay_tree_min (action_list->tree);
++  return node ? (text_action *)node->value : NULL;
++}
++
++static text_action *
++action_next (text_action_list *action_list, text_action *action)
++{
++  splay_tree_node node = splay_tree_successor (action_list->tree,
++					       (splay_tree_key)action);
++  return node ? (text_action *)node->value : NULL;
++}
++
+ /* Add a modification action to the text.  For the case of adding or
+    removing space, modify any current fill and assume that
+    "unreachable_space" bytes can be freely contracted.  Note that a
+@@ -5521,8 +5562,8 @@ text_action_add (text_action_list *l,
+ 		 bfd_vma offset,
+ 		 int removed)
+ {
+-  text_action **m_p;
+   text_action *ta;
++  text_action a;
+ 
+   /* It is not necessary to fill at the end of a section.  */
+   if (action == ta_fill && sec->size == offset)
+@@ -5532,34 +5573,30 @@ text_action_add (text_action_list *l,
+   if (action == ta_fill && removed == 0)
+     return;
+ 
+-  for (m_p = &l->head; *m_p && (*m_p)->offset <= offset; m_p = &(*m_p)->next)
++  a.action = action;
++  a.offset = offset;
++
++  if (action == ta_fill)
+     {
+-      text_action *t = *m_p;
++      splay_tree_node node = splay_tree_lookup (l->tree, (splay_tree_key)&a);
+ 
+-      if (action == ta_fill)
++      if (node)
+ 	{
+-	  /* When the action is another fill at the same address,
+-	     just increase the size.  */
+-	  if (t->offset == offset && t->action == ta_fill)
+-	    {
+-	      t->removed_bytes += removed;
+-	      return;
+-	    }
+-	  /* Fills need to happen before widens so that we don't
+-	     insert fill bytes into the instruction stream.  */
+-	  if (t->offset == offset && t->action == ta_widen_insn)
+-	    break;
++	  ta = (text_action *)node->value;
++	  ta->removed_bytes += removed;
++	  return;
+ 	}
+     }
++  else
++    BFD_ASSERT (splay_tree_lookup (l->tree, (splay_tree_key)&a) == NULL);
+ 
+-  /* Create a new record and fill it up.  */
+   ta = (text_action *) bfd_zmalloc (sizeof (text_action));
+   ta->action = action;
+   ta->sec = sec;
+   ta->offset = offset;
+   ta->removed_bytes = removed;
+-  ta->next = (*m_p);
+-  *m_p = ta;
++  splay_tree_insert (l->tree, (splay_tree_key)ta, (splay_tree_value)ta);
++  ++l->count;
+ }
+ 
+ 
+@@ -5570,7 +5607,6 @@ text_action_add_literal (text_action_list *l,
+ 			 const literal_value *value,
+ 			 int removed)
+ {
+-  text_action **m_p;
+   text_action *ta;
+   asection *sec = r_reloc_get_section (loc);
+   bfd_vma offset = loc->target_offset;
+@@ -5578,14 +5614,6 @@ text_action_add_literal (text_action_list *l,
+ 
+   BFD_ASSERT (action == ta_add_literal);
+ 
+-  for (m_p = &l->head; *m_p != NULL; m_p = &(*m_p)->next)
+-    {
+-      if ((*m_p)->offset > offset
+-	  && ((*m_p)->offset != offset
+-	      || (*m_p)->virtual_offset > virtual_offset))
+-	break;
+-    }
+-
+   /* Create a new record and fill it up.  */
+   ta = (text_action *) bfd_zmalloc (sizeof (text_action));
+   ta->action = action;
+@@ -5594,8 +5622,10 @@ text_action_add_literal (text_action_list *l,
+   ta->virtual_offset = virtual_offset;
+   ta->value = *value;
+   ta->removed_bytes = removed;
+-  ta->next = (*m_p);
+-  *m_p = ta;
++
++  BFD_ASSERT (splay_tree_lookup (l->tree, (splay_tree_key)ta) == NULL);
++  splay_tree_insert (l->tree, (splay_tree_key)ta, (splay_tree_value)ta);
++  ++l->count;
+ }
+ 
+ 
+@@ -5606,7 +5636,8 @@ text_action_add_literal (text_action_list *l,
+    so that each search may begin where the previous one left off.  */
+ 
+ static int
+-removed_by_actions (text_action **p_start_action,
++removed_by_actions (text_action_list *action_list,
++		    text_action **p_start_action,
+ 		    bfd_vma offset,
+ 		    bfd_boolean before_fill)
+ {
+@@ -5614,6 +5645,13 @@ removed_by_actions (text_action **p_start_action,
+   int removed = 0;
+ 
+   r = *p_start_action;
++  if (r)
++    {
++      splay_tree_node node = splay_tree_lookup (action_list->tree,
++						(splay_tree_key)r);
++      BFD_ASSERT (node != NULL && r == (text_action *)node->value);
++    }
++
+   while (r)
+     {
+       if (r->offset > offset)
+@@ -5625,7 +5663,7 @@ removed_by_actions (text_action **p_start_action,
+ 
+       removed += r->removed_bytes;
+ 
+-      r = r->next;
++      r = action_next (action_list, r);
+     }
+ 
+   *p_start_action = r;
+@@ -5636,68 +5674,74 @@ removed_by_actions (text_action **p_start_action,
+ static bfd_vma
+ offset_with_removed_text (text_action_list *action_list, bfd_vma offset)
+ {
+-  text_action *r = action_list->head;
+-  return offset - removed_by_actions (&r, offset, FALSE);
++  text_action *r = action_first (action_list);
++
++  return offset - removed_by_actions (action_list, &r, offset, FALSE);
+ }
+ 
+ 
+ static unsigned
+ action_list_count (text_action_list *action_list)
+ {
+-  text_action *r = action_list->head;
+-  unsigned count = 0;
+-  for (r = action_list->head; r != NULL; r = r->next)
+-    {
+-      count++;
+-    }
+-  return count;
++  return action_list->count;
+ }
+ 
+-static void
+-map_removal_by_action (text_action_list *action_list)
++typedef struct map_action_fn_context_struct map_action_fn_context;
++struct map_action_fn_context_struct
+ {
+-  text_action *r;
+-  int removed = 0;
++  int removed;
+   removal_by_action_map map;
+   bfd_boolean eq_complete;
++};
+ 
+-  map.n_entries = 0;
+-  map.entry = bfd_malloc (action_list_count (action_list) *
+-			  sizeof (removal_by_action_entry));
+-  eq_complete = FALSE;
++static int
++map_action_fn (splay_tree_node node, void *p)
++{
++  map_action_fn_context *ctx = p;
++  text_action *r = (text_action *)node->value;
++  removal_by_action_entry *ientry = ctx->map.entry + ctx->map.n_entries;
+ 
+-  for (r = action_list->head; r;)
++  if (ctx->map.n_entries && (ientry - 1)->offset == r->offset)
+     {
+-      removal_by_action_entry *ientry = map.entry + map.n_entries;
++      --ientry;
++    }
++  else
++    {
++      ++ctx->map.n_entries;
++      ctx->eq_complete = FALSE;
++      ientry->offset = r->offset;
++      ientry->eq_removed_before_fill = ctx->removed;
++    }
+ 
+-      if (map.n_entries && (ientry - 1)->offset == r->offset)
++  if (!ctx->eq_complete)
++    {
++      if (r->action != ta_fill || r->removed_bytes >= 0)
+ 	{
+-	  --ientry;
++	  ientry->eq_removed = ctx->removed;
++	  ctx->eq_complete = TRUE;
+ 	}
+       else
+-	{
+-	  ++map.n_entries;
+-	  eq_complete = FALSE;
+-	  ientry->offset = r->offset;
+-	  ientry->eq_removed_before_fill = removed;
+-	}
++	ientry->eq_removed = ctx->removed + r->removed_bytes;
++    }
+ 
+-      if (!eq_complete)
+-	{
+-	  if (r->action != ta_fill || r->removed_bytes >= 0)
+-	    {
+-	      ientry->eq_removed = removed;
+-	      eq_complete = TRUE;
+-	    }
+-	  else
+-	    ientry->eq_removed = removed + r->removed_bytes;
+-	}
++  ctx->removed += r->removed_bytes;
++  ientry->removed = ctx->removed;
++  return 0;
++}
+ 
+-      removed += r->removed_bytes;
+-      ientry->removed = removed;
+-      r = r->next;
+-    }
+-  action_list->map = map;
++static void
++map_removal_by_action (text_action_list *action_list)
++{
++  map_action_fn_context ctx;
++
++  ctx.removed = 0;
++  ctx.map.n_entries = 0;
++  ctx.map.entry = bfd_malloc (action_list_count (action_list) *
++			      sizeof (removal_by_action_entry));
++  ctx.eq_complete = FALSE;
++
++  splay_tree_foreach (action_list->tree, map_action_fn, &ctx);
++  action_list->map = ctx.map;
+ }
+ 
+ static int
+@@ -5754,28 +5798,26 @@ offset_with_removed_text_map (text_action_list *action_list, bfd_vma offset)
+ static text_action *
+ find_insn_action (text_action_list *action_list, bfd_vma offset)
+ {
+-  text_action *t;
+-  for (t = action_list->head; t; t = t->next)
++  static const text_action_t action[] =
+     {
+-      if (t->offset == offset)
+-	{
+-	  switch (t->action)
+-	    {
+-	    case ta_none:
+-	    case ta_fill:
+-	      break;
+-	    case ta_remove_insn:
+-	    case ta_remove_longcall:
+-	    case ta_convert_longcall:
+-	    case ta_narrow_insn:
+-	    case ta_widen_insn:
+-	      return t;
+-	    case ta_remove_literal:
+-	    case ta_add_literal:
+-	      BFD_ASSERT (0);
+-	      break;
+-	    }
+-	}
++      ta_convert_longcall,
++      ta_remove_longcall,
++      ta_widen_insn,
++      ta_narrow_insn,
++      ta_remove_insn,
++    };
++  text_action a;
++  unsigned i;
++
++  a.offset = offset;
++  for (i = 0; i < sizeof (action) / sizeof (*action); ++i)
++    {
++      splay_tree_node node;
++
++      a.action = action[i];
++      node = splay_tree_lookup (action_list->tree, (splay_tree_key)&a);
++      if (node)
++	return (text_action *)node->value;
+     }
+   return NULL;
+ }
+@@ -5784,40 +5826,50 @@ find_insn_action (text_action_list *action_list, bfd_vma offset)
+ #if DEBUG
+ 
+ static void
+-print_action_list (FILE *fp, text_action_list *action_list)
++print_action (FILE *fp, text_action *r)
++{
++  const char *t = "unknown";
++  switch (r->action)
++    {
++    case ta_remove_insn:
++      t = "remove_insn"; break;
++    case ta_remove_longcall:
++      t = "remove_longcall"; break;
++    case ta_convert_longcall:
++      t = "convert_longcall"; break;
++    case ta_narrow_insn:
++      t = "narrow_insn"; break;
++    case ta_widen_insn:
++      t = "widen_insn"; break;
++    case ta_fill:
++      t = "fill"; break;
++    case ta_none:
++      t = "none"; break;
++    case ta_remove_literal:
++      t = "remove_literal"; break;
++    case ta_add_literal:
++      t = "add_literal"; break;
++    }
++
++  fprintf (fp, "%s: %s[0x%lx] \"%s\" %d\n",
++	   r->sec->owner->filename,
++	   r->sec->name, (unsigned long) r->offset, t, r->removed_bytes);
++}
++
++static int
++print_action_list_fn (splay_tree_node node, void *p)
+ {
+-  text_action *r;
++  text_action *r = (text_action *)node->value;
+ 
+-  fprintf (fp, "Text Action\n");
+-  for (r = action_list->head; r != NULL; r = r->next)
+-    {
+-      const char *t = "unknown";
+-      switch (r->action)
+-	{
+-	case ta_remove_insn:
+-	  t = "remove_insn"; break;
+-	case ta_remove_longcall:
+-	  t = "remove_longcall"; break;
+-	case ta_convert_longcall:
+-	  t = "convert_longcall"; break;
+-	case ta_narrow_insn:
+-	  t = "narrow_insn"; break;
+-	case ta_widen_insn:
+-	  t = "widen_insn"; break;
+-	case ta_fill:
+-	  t = "fill"; break;
+-	case ta_none:
+-	  t = "none"; break;
+-	case ta_remove_literal:
+-	  t = "remove_literal"; break;
+-	case ta_add_literal:
+-	  t = "add_literal"; break;
+-	}
++  print_action (p, r);
++  return 0;
++}
+ 
+-      fprintf (fp, "%s: %s[0x%lx] \"%s\" %d\n",
+-	       r->sec->owner->filename,
+-	       r->sec->name, (unsigned long) r->offset, t, r->removed_bytes);
+-    }
++static void
++print_action_list (FILE *fp, text_action_list *action_list)
++{
++  fprintf (fp, "Text Action\n");
++  splay_tree_foreach (action_list->tree, print_action_list_fn, fp);
+ }
+ 
+ #endif /* DEBUG */
+@@ -6071,8 +6123,8 @@ init_xtensa_relax_info (asection *sec)
+   relax_info->removed_list.head = NULL;
+   relax_info->removed_list.tail = NULL;
+ 
+-  relax_info->action_list.head = NULL;
+-
++  relax_info->action_list.tree = splay_tree_new (text_action_compare,
++						 NULL, NULL);
+   relax_info->action_list.map.n_entries = 0;
+   relax_info->action_list.map.entry = NULL;
+ 
+@@ -7762,7 +7814,7 @@ compute_text_actions (bfd *abfd,
+   free_reloc_range_list (&relevant_relocs);
+ 
+ #if DEBUG
+-  if (relax_info->action_list.head)
++  if (action_list_count (&relax_info->action_list))
+     print_action_list (stderr, &relax_info->action_list);
+ #endif
+ 
+@@ -8263,6 +8315,54 @@ xlate_offset_with_removed_text (const xlate_map_t *map,
+   return e->new_address - e->orig_address + offset;
+ }
+ 
++typedef struct xlate_map_context_struct xlate_map_context;
++struct xlate_map_context_struct
++{
++  xlate_map_t *map;
++  xlate_map_entry_t *current_entry;
++  int removed;
++};
++
++static int
++xlate_map_fn (splay_tree_node node, void *p)
++{
++  text_action *r = (text_action *)node->value;
++  xlate_map_context *ctx = p;
++  unsigned orig_size = 0;
++
++  switch (r->action)
++    {
++    case ta_none:
++    case ta_remove_insn:
++    case ta_convert_longcall:
++    case ta_remove_literal:
++    case ta_add_literal:
++      break;
++    case ta_remove_longcall:
++      orig_size = 6;
++      break;
++    case ta_narrow_insn:
++      orig_size = 3;
++      break;
++    case ta_widen_insn:
++      orig_size = 2;
++      break;
++    case ta_fill:
++      break;
++    }
++  ctx->current_entry->size =
++    r->offset + orig_size - ctx->current_entry->orig_address;
++  if (ctx->current_entry->size != 0)
++    {
++      ctx->current_entry++;
++      ctx->map->entry_count++;
++    }
++  ctx->current_entry->orig_address = r->offset + orig_size;
++  ctx->removed += r->removed_bytes;
++  ctx->current_entry->new_address = r->offset + orig_size - ctx->removed;
++  ctx->current_entry->size = 0;
++  return 0;
++}
+ 
+ /* Build a binary searchable offset translation map from a section's
+    action list.  */
+@@ -8270,75 +8370,40 @@ xlate_offset_with_removed_text (const xlate_map_t *map,
+ static xlate_map_t *
+ build_xlate_map (asection *sec, xtensa_relax_info *relax_info)
+ {
+-  xlate_map_t *map = (xlate_map_t *) bfd_malloc (sizeof (xlate_map_t));
+   text_action_list *action_list = &relax_info->action_list;
+   unsigned num_actions = 0;
+-  text_action *r;
+-  int removed;
+-  xlate_map_entry_t *current_entry;
++  xlate_map_context ctx;
+ 
+-  if (map == NULL)
++  ctx.map = (xlate_map_t *) bfd_malloc (sizeof (xlate_map_t));
++
++  if (ctx.map == NULL)
+     return NULL;
+ 
+   num_actions = action_list_count (action_list);
+-  map->entry = (xlate_map_entry_t *)
++  ctx.map->entry = (xlate_map_entry_t *)
+     bfd_malloc (sizeof (xlate_map_entry_t) * (num_actions + 1));
+-  if (map->entry == NULL)
++  if (ctx.map->entry == NULL)
+     {
+-      free (map);
++      free (ctx.map);
+       return NULL;
+     }
+-  map->entry_count = 0;
++  ctx.map->entry_count = 0;
+ 
+-  removed = 0;
+-  current_entry = &map->entry[0];
++  ctx.removed = 0;
++  ctx.current_entry = &ctx.map->entry[0];
+ 
+-  current_entry->orig_address = 0;
+-  current_entry->new_address = 0;
+-  current_entry->size = 0;
++  ctx.current_entry->orig_address = 0;
++  ctx.current_entry->new_address = 0;
++  ctx.current_entry->size = 0;
+ 
+-  for (r = action_list->head; r != NULL; r = r->next)
+-    {
+-      unsigned orig_size = 0;
+-      switch (r->action)
+-	{
+-	case ta_none:
+-	case ta_remove_insn:
+-	case ta_convert_longcall:
+-	case ta_remove_literal:
+-	case ta_add_literal:
+-	  break;
+-	case ta_remove_longcall:
+-	  orig_size = 6;
+-	  break;
+-	case ta_narrow_insn:
+-	  orig_size = 3;
+-	  break;
+-	case ta_widen_insn:
+-	  orig_size = 2;
+-	  break;
+-	case ta_fill:
+-	  break;
+-	}
+-      current_entry->size =
+-	r->offset + orig_size - current_entry->orig_address;
+-      if (current_entry->size != 0)
+-	{
+-	  current_entry++;
+-	  map->entry_count++;
+-	}
+-      current_entry->orig_address = r->offset + orig_size;
+-      removed += r->removed_bytes;
+-      current_entry->new_address = r->offset + orig_size - removed;
+-      current_entry->size = 0;
+-    }
++  splay_tree_foreach (action_list->tree, xlate_map_fn, &ctx);
+ 
+-  current_entry->size = (bfd_get_section_limit (sec->owner, sec)
+-			 - current_entry->orig_address);
+-  if (current_entry->size != 0)
+-    map->entry_count++;
++  ctx.current_entry->size = (bfd_get_section_limit (sec->owner, sec)
++			     - ctx.current_entry->orig_address);
++  if (ctx.current_entry->size != 0)
++    ctx.map->entry_count++;
+ 
+-  return map;
++  return ctx.map;
+ }
+ 
+ 
+@@ -9302,6 +9367,16 @@ move_shared_literal (asection *sec,
+ 
+ /* Second relaxation pass.  */
+ 
++static int
++action_remove_bytes_fn (splay_tree_node node, void *p)
++{
++  bfd_size_type *final_size = p;
++  text_action *action = (text_action *)node->value;
++
++  *final_size -= action->removed_bytes;
++  return 0;
++}
++
+ /* Modify all of the relocations to point to the right spot, and if this
+    is a relaxable section, delete the unwanted literals and fix the
+    section size.  */
+@@ -9334,7 +9409,7 @@ relax_section (bfd *abfd, asection *sec, struct bfd_link_info *link_info)
+ 
+   internal_relocs = retrieve_internal_relocs (abfd, sec,
+ 					      link_info->keep_memory);
+-  if (!internal_relocs && !relax_info->action_list.head)
++  if (!internal_relocs && !action_list_count (&relax_info->action_list))
+     return TRUE;
+ 
+   contents = retrieve_contents (abfd, sec, link_info->keep_memory);
+@@ -9412,6 +9487,12 @@ relax_section (bfd *abfd, asection *sec, struct bfd_link_info *link_info)
+ 			}
+ 		      /* Update the action so that the code that moves
+ 			 the contents will do the right thing.  */
++		      /* ta_remove_longcall and ta_remove_insn actions are
++		         grouped together in the tree as well as
++			 ta_convert_longcall and ta_none, so that changes below
++			 can be done w/o removing and reinserting action into
++			 the tree.  */
++
+ 		      if (action->action == ta_remove_longcall)
+ 			action->action = ta_remove_insn;
+ 		      else
+@@ -9584,13 +9665,12 @@ relax_section (bfd *abfd, asection *sec, struct bfd_link_info *link_info)
+ 
+   if ((relax_info->is_relaxable_literal_section
+        || relax_info->is_relaxable_asm_section)
+-      && relax_info->action_list.head)
++      && action_list_count (&relax_info->action_list))
+     {
+       /* Walk through the planned actions and build up a table
+ 	 of move, copy and fill records.  Use the move, copy and
+ 	 fill records to perform the actions once.  */
+ 
+-      int removed = 0;
+       bfd_size_type final_size, copy_size, orig_insn_size;
+       bfd_byte *scratch = NULL;
+       bfd_byte *dup_contents = NULL;
+@@ -9601,15 +9681,12 @@ relax_section (bfd *abfd, asection *sec, struct bfd_link_info *link_info)
+       bfd_vma orig_dot_vo = 0; /* Virtual offset from orig_dot.  */
+       bfd_vma dup_dot = 0;
+ 
+-      text_action *action = relax_info->action_list.head;
++      text_action *action;
+ 
+       final_size = sec->size;
+-      for (action = relax_info->action_list.head; action;
+-	   action = action->next)
+-	{
+-	  final_size -= action->removed_bytes;
+-	}
+ 
++      splay_tree_foreach (relax_info->action_list.tree,
++			  action_remove_bytes_fn, &final_size);
+       scratch = (bfd_byte *) bfd_zmalloc (final_size);
+       dup_contents = (bfd_byte *) bfd_zmalloc (final_size);
+ 
+@@ -9618,8 +9695,8 @@ relax_section (bfd *abfd, asection *sec, struct bfd_link_info *link_info)
+       print_action_list (stderr, &relax_info->action_list);
+ #endif
+ 
+-      for (action = relax_info->action_list.head; action;
+-	   action = action->next)
++      for (action = action_first (&relax_info->action_list); action;
++	   action = action_next (&relax_info->action_list, action))
+ 	{
+ 	  virtual_action = FALSE;
+ 	  if (action->offset > orig_dot)
+@@ -9748,7 +9825,6 @@ relax_section (bfd *abfd, asection *sec, struct bfd_link_info *link_info)
+ 	      break;
+ 	    }
+ 
+-	  removed += action->removed_bytes;
+ 	  BFD_ASSERT (dup_dot <= final_size);
+ 	  BFD_ASSERT (orig_dot <= orig_size);
+ 	}
+-- 
+1.8.1.4
+

--- a/patches/binutils/2.25.1/910-xtensa-optimize-trampolines-relaxation.patch
+++ b/patches/binutils/2.25.1/910-xtensa-optimize-trampolines-relaxation.patch
@@ -1,0 +1,345 @@
+From cbe53e134d4c3a656880a906738ce19fdcd38e8b Mon Sep 17 00:00:00 2001
+From: Max Filippov <jcmvbkbc@gmail.com>
+Date: Fri, 1 May 2015 11:39:12 +0300
+Subject: [PATCH] xtensa: optimize trampolines relaxation
+
+Currently every fixup in the current segment is checked when relaxing
+trampoline frag. This is very expensive. Make a searchable array of
+fixups pointing at potentially oversized jumps at the beginning of every
+relaxation pass and only check subset of this cache in the reach of
+single jump from the trampoline frag currently being relaxed.
+
+Original profile:
+
+% time    self  children    called     name
+-----------------------------------------
+        370.16  593.38 12283048/12283048     relax_segment
+  98.4  370.16  593.38 12283048         xtensa_relax_frag
+         58.91  269.26 2691463834/2699602236     xtensa_insnbuf_from_chars
+         68.35   68.17 811266668/813338977     S_GET_VALUE
+         36.85   29.51 2684369246/2685538060     xtensa_opcode_decode
+         28.34    8.84 2684369246/2685538060     xtensa_format_get_slot
+         12.39    5.94 2691463834/2699775044     xtensa_format_decode
+          0.03    4.60 4101109/4101109     relax_frag_for_align
+          0.18    1.76  994617/994617      relax_frag_immed
+          0.07    0.09 24556277/24851220     new_logical_line
+          0.06    0.00 12283048/14067410     as_where
+          0.04    0.00 7094588/15460506     xtensa_format_num_slots
+          0.00    0.00       1/712477      xtensa_insnbuf_alloc
+-----------------------------------------
+
+Same data, after optimization:
+
+% time    self  children    called     name
+-----------------------------------------
+          0.51    7.47 12283048/12283048     relax_segment
+  58.0    0.51    7.47 12283048         xtensa_relax_frag
+          0.02    4.08 4101109/4101109     relax_frag_for_align
+          0.18    1.39  994617/994617      relax_frag_immed
+          0.01    0.98     555/555         xtensa_cache_relaxable_fixups
+          0.21    0.25 7094588/16693271     xtensa_insnbuf_from_chars
+          0.06    0.12 24556277/24851220     new_logical_line
+          0.06    0.00 7094588/15460506     xtensa_format_num_slots
+          0.02    0.04 7094588/16866079     xtensa_format_decode
+          0.05    0.00 12283048/14067410     as_where
+          0.00    0.00       1/712477      xtensa_insnbuf_alloc
+          0.00    0.00   93808/93808       xtensa_find_first_cached_fixup
+-----------------------------------------
+
+2015-05-02  Max Filippov  <jcmvbkbc@gmail.com>
+gas/
+	* config/tc-xtensa.c (cached_fixupS, fixup_cacheS): New typedefs.
+	(struct cached_fixup, struct fixup_cache): New structures.
+	(fixup_order, xtensa_make_cached_fixup),
+	(xtensa_realloc_fixup_cache, xtensa_cache_relaxable_fixups),
+	(xtensa_find_first_cached_fixup, xtensa_delete_cached_fixup),
+	(xtensa_add_cached_fixup): New functions.
+	(xtensa_relax_frag): Cache fixups pointing at potentially
+	oversized jumps at the beginning of every relaxation pass. Only
+	check subset of this cache in the reach of single jump from the
+	trampoline frag currently being relaxed.
+
+Signed-off-by: Max Filippov <jcmvbkbc@gmail.com>
+---
+Backported from: b76f99d702c3501ac320396ea06bc7f9237173c3
+Changes to ChangeLog are dropped.
+
+ gas/config/tc-xtensa.c | 220 +++++++++++++++++++++++++++++++++++++++++++------
+ 1 file changed, 194 insertions(+), 26 deletions(-)
+
+diff --git a/gas/config/tc-xtensa.c b/gas/config/tc-xtensa.c
+index 3e85b69..31c0b6b 100644
+--- a/gas/config/tc-xtensa.c
++++ b/gas/config/tc-xtensa.c
+@@ -8785,6 +8785,154 @@ static long relax_frag_for_align (fragS *, long);
+ static long relax_frag_immed
+   (segT, fragS *, long, int, xtensa_format, int, int *, bfd_boolean);
+ 
++typedef struct cached_fixup cached_fixupS;
++struct cached_fixup
++{
++  int addr;
++  int target;
++  int delta;
++  fixS *fixP;
++};
++
++typedef struct fixup_cache fixup_cacheS;
++struct fixup_cache
++{
++  cached_fixupS *fixups;
++  unsigned n_fixups;
++  unsigned n_max;
++
++  segT seg;
++  fragS *first_frag;
++};
++
++static int fixup_order (const void *a, const void *b)
++{
++  const cached_fixupS *pa = a;
++  const cached_fixupS *pb = b;
++
++  if (pa->addr == pb->addr)
++    {
++      if (pa->target == pb->target)
++	{
++	  if (pa->fixP->fx_r_type == pb->fixP->fx_r_type)
++	    return 0;
++	  return pa->fixP->fx_r_type < pb->fixP->fx_r_type ?  -1 : 1;
++	}
++      return pa->target - pb->target;
++    }
++  return pa->addr - pb->addr;
++}
++
++static bfd_boolean xtensa_make_cached_fixup (cached_fixupS *o, fixS *fixP)
++{
++  xtensa_isa isa = xtensa_default_isa;
++  int addr = fixP->fx_frag->fr_address;
++  int target;
++  int delta;
++  symbolS *s = fixP->fx_addsy;
++  int slot;
++  xtensa_format fmt;
++  xtensa_opcode opcode;
++
++  if (fixP->fx_r_type < BFD_RELOC_XTENSA_SLOT0_OP ||
++      fixP->fx_r_type > BFD_RELOC_XTENSA_SLOT14_OP)
++    return FALSE;
++  target = S_GET_VALUE (s);
++  delta = target - addr;
++
++  if (abs(delta) < J_RANGE / 2)
++    return FALSE;
++
++  xtensa_insnbuf_from_chars (isa, trampoline_buf,
++			     (unsigned char *) fixP->fx_frag->fr_literal +
++			     fixP->fx_where, 0);
++  fmt = xtensa_format_decode (isa, trampoline_buf);
++  gas_assert (fmt != XTENSA_UNDEFINED);
++  slot = fixP->tc_fix_data.slot;
++  xtensa_format_get_slot (isa, fmt, slot, trampoline_buf, trampoline_slotbuf);
++  opcode = xtensa_opcode_decode (isa, fmt, slot, trampoline_slotbuf);
++  if (opcode != xtensa_j_opcode)
++    return FALSE;
++
++  o->addr = addr;
++  o->target = target;
++  o->delta = delta;
++  o->fixP = fixP;
++
++  return TRUE;
++}
++
++static void xtensa_realloc_fixup_cache (fixup_cacheS *cache, unsigned add)
++{
++  if (cache->n_fixups + add > cache->n_max)
++    {
++      cache->n_max = (cache->n_fixups + add) * 2;
++      cache->fixups = xrealloc (cache->fixups,
++				sizeof (*cache->fixups) * cache->n_max);
++    }
++}
++
++static void xtensa_cache_relaxable_fixups (fixup_cacheS *cache,
++					   segment_info_type *seginfo)
++{
++  fixS *fixP;
++
++  cache->n_fixups = 0;
++
++  for (fixP = seginfo->fix_root; fixP ; fixP = fixP->fx_next)
++    {
++      xtensa_realloc_fixup_cache (cache, 1);
++
++      if (xtensa_make_cached_fixup (cache->fixups + cache->n_fixups, fixP))
++	++cache->n_fixups;
++    }
++  qsort (cache->fixups, cache->n_fixups, sizeof (*cache->fixups), fixup_order);
++}
++
++static unsigned xtensa_find_first_cached_fixup (const fixup_cacheS *cache,
++						int addr)
++{
++  unsigned a = 0;
++  unsigned b = cache->n_fixups;
++
++  while (b - a > 1)
++    {
++      unsigned c = (a + b) / 2;
++
++      if (cache->fixups[c].addr < addr)
++	a = c;
++      else
++	b = c;
++    }
++  return a;
++}
++
++static void xtensa_delete_cached_fixup (fixup_cacheS *cache, unsigned i)
++{
++  memmove (cache->fixups + i, cache->fixups + i + 1,
++	   (cache->n_fixups - i - 1) * sizeof (*cache->fixups));
++  --cache->n_fixups;
++}
++
++static bfd_boolean xtensa_add_cached_fixup (fixup_cacheS *cache, fixS *fixP)
++{
++  cached_fixupS o;
++  unsigned i;
++
++  if (!xtensa_make_cached_fixup (&o, fixP))
++    return FALSE;
++  xtensa_realloc_fixup_cache (cache, 1);
++  i = xtensa_find_first_cached_fixup (cache, o.addr);
++  if (i < cache->n_fixups)
++    {
++      ++i;
++      memmove (cache->fixups + i + 1, cache->fixups + i,
++	       (cache->n_fixups - i) * sizeof (*cache->fixups));
++    }
++  cache->fixups[i] = o;
++  ++cache->n_fixups;
++  return TRUE;
++}
+ 
+ /* Return the number of bytes added to this fragment, given that the
+    input has been stretched already by "stretch".  */
+@@ -8896,35 +9044,42 @@ xtensa_relax_frag (fragS *fragP, long stretch, int *stretched_p)
+     case RELAX_TRAMPOLINE:
+       if (fragP->tc_frag_data.relax_seen)
+         {
+-          segment_info_type *seginfo = seg_info (now_seg);
+-          fragS *fP; /* The out-of-range jump.  */
+-          fixS *fixP;
++	  static fixup_cacheS fixup_cache;
++	  segment_info_type *seginfo = seg_info (now_seg);
++	  int trampaddr = fragP->fr_address + fragP->fr_fix;
++	  int searchaddr = trampaddr < J_RANGE ? 0 : trampaddr - J_RANGE;
++	  unsigned i;
++
++	  if (now_seg != fixup_cache.seg ||
++	      fragP == fixup_cache.first_frag ||
++	      fixup_cache.first_frag == NULL)
++	    {
++	      xtensa_cache_relaxable_fixups (&fixup_cache, seginfo);
++	      fixup_cache.seg = now_seg;
++	      fixup_cache.first_frag = fragP;
++	    }
+ 
+           /* Scan for jumps that will not reach.  */
+-          for (fixP = seginfo->fix_root; fixP ; fixP = fixP->fx_next)
++          for (i = xtensa_find_first_cached_fixup (&fixup_cache, searchaddr);
++	       i < fixup_cache.n_fixups; ++i)
++
+             {
+-              symbolS *s = fixP->fx_addsy;
+-	      xtensa_opcode opcode;
+-              int target;
+-              int addr;
+-              int delta;
+-
+-              if (fixP->fx_r_type < BFD_RELOC_XTENSA_SLOT0_OP ||
+-                  fixP->fx_r_type > BFD_RELOC_XTENSA_SLOT14_OP)
+-                continue;
+-	      xtensa_insnbuf_from_chars (isa, trampoline_buf,
+-					 (unsigned char *) fixP->fx_frag->fr_literal + fixP->fx_where,
+-					 0);
+-	      fmt = xtensa_format_decode (isa, trampoline_buf);
+-	      gas_assert (fmt != XTENSA_UNDEFINED);
+-	      slot = fixP->tc_fix_data.slot;
+-	      xtensa_format_get_slot (isa, fmt, slot, trampoline_buf, trampoline_slotbuf);
+-	      opcode = xtensa_opcode_decode (isa, fmt, slot, trampoline_slotbuf);
+-	      if (opcode != xtensa_j_opcode)
++	      fixS *fixP = fixup_cache.fixups[i].fixP;
++	      int target = fixup_cache.fixups[i].target;
++	      int addr = fixup_cache.fixups[i].addr;
++	      int delta = fixup_cache.fixups[i].delta + stretch;
++
++	      trampaddr = fragP->fr_address + fragP->fr_fix;
++
++	      if (addr + J_RANGE < trampaddr)
+ 		continue;
+-              target = S_GET_VALUE (s);
+-              addr = fixP->fx_frag->fr_address;
+-              delta = target - addr + stretch;
++	      if (addr > trampaddr + J_RANGE)
++		break;
++	      if (abs (delta) < J_RANGE)
++		continue;
++
++	      slot = fixP->tc_fix_data.slot;
++
+               if (delta > J_RANGE  || delta < -1 * J_RANGE)
+                 { /* Found an out-of-range jump; scan the list of trampolines for the best match.  */
+ 		  struct trampoline_seg *ts = find_trampoline_seg (now_seg);
+@@ -8978,14 +9133,13 @@ xtensa_relax_frag (fragS *fragP, long stretch, int *stretched_p)
+ 		    }
+ 		  if (tf->fragP == fragP)
+ 		    {
+-		      int trampaddr = fragP->fr_address + fragP->fr_fix;
+-
+ 		      if (abs (addr - trampaddr) < J_RANGE)
+ 			{ /* The trampoline is in range of original; fix it!  */
+ 			  fixS *newfixP;
+ 			  int offset;
+ 			  TInsn insn;
+ 			  symbolS *lsym;
++			  fragS *fP; /* The out-of-range jump.  */
+ 
+ 			  new_stretch += init_trampoline_frag (tf);
+ 			  offset = fragP->fr_fix; /* Where to assemble the j insn.  */
+@@ -9009,10 +9163,20 @@ xtensa_relax_frag (fragS *fragP, long stretch, int *stretched_p)
+ 			  newfixP->tc_fix_data.X_add_symbol = lsym;
+ 			  newfixP->tc_fix_data.X_add_number = offset;
+ 			  newfixP->tc_fix_data.slot = slot;
++
++			  xtensa_delete_cached_fixup (&fixup_cache, i);
++			  xtensa_add_cached_fixup (&fixup_cache, newfixP);
++
+ 			  /* Move the fix-up from the original j insn to this one.  */
+ 			  fixP->fx_frag = fragP;
+ 			  fixP->fx_where = fragP->fr_fix - 3;
+ 			  fixP->tc_fix_data.slot = 0;
++
++			  xtensa_add_cached_fixup (&fixup_cache, fixP);
++
++			  /* re-do current fixup */
++			  --i;
++
+ 			  /* Adjust the jump around this trampoline (if present).  */
+ 			  if (tf->fixP != NULL)
+ 			    {
+@@ -9027,6 +9191,8 @@ xtensa_relax_frag (fragS *fragP, long stretch, int *stretched_p)
+ 			      fragP->fr_subtype = 0;
+ 			      /* Remove from the trampoline_list.  */
+ 			      prev->next = tf->next;
++			      if (fragP == fixup_cache.first_frag)
++				fixup_cache.first_frag = NULL;
+ 			      break;
+ 			    }
+ 			}
+-- 
+1.8.1.4
+

--- a/patches/binutils/2.25.1/911-xtensa-fix-localized-symbol-refcounting-with-gc-sect.patch
+++ b/patches/binutils/2.25.1/911-xtensa-fix-localized-symbol-refcounting-with-gc-sect.patch
@@ -1,0 +1,57 @@
+From 8ec76b16f62d1bf386fb2c39af5f66c3afddc5cb Mon Sep 17 00:00:00 2001
+From: Max Filippov <jcmvbkbc@gmail.com>
+Date: Thu, 14 May 2015 05:22:55 +0300
+Subject: [PATCH] xtensa: fix localized symbol refcounting with --gc-sections
+
+elf_xtensa_gc_sweep_hook doesn't correctly unreference symbols that were
+made local, that results in link failure with the following message:
+
+  BFD (GNU Binutils) 2.24 internal error, aborting at elf32-xtensa.c line
+  3372 in elf_xtensa_finish_dynamic_sections
+
+elf_xtensa_gc_sweep_hook determines symbol reference type (PLT or GOT) by
+relocation type. Relocation types are not changed when symbol becomes
+local, but its PLT references are added to GOT references and
+plt.refcount is set to 0. Such symbol cannot be unreferences in the
+elf_xtensa_gc_sweep_hook and its extra references make calculated GOT
+relocations section size not match number of GOT relocations.
+
+Fix it by treating PLT reference as GOT reference when plt.refcount is
+not positive.
+
+2015-05-14  Max Filippov  <jcmvbkbc@gmail.com>
+bfd/
+	* elf32-xtensa.c (elf_xtensa_gc_sweep_hook): Treat PLT reference
+	as GOT reference when plt.refcount is not positive.
+
+Signed-off-by: Max Filippov <jcmvbkbc@gmail.com>
+---
+Backported from: e6c9a083ec5ae7a45bd71682b26aae1939849388
+Changes to ChangeLog are dropped.
+
+ bfd/elf32-xtensa.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/bfd/elf32-xtensa.c b/bfd/elf32-xtensa.c
+index 53af1c6..2523670 100644
+--- a/bfd/elf32-xtensa.c
++++ b/bfd/elf32-xtensa.c
+@@ -1360,10 +1360,14 @@ elf_xtensa_gc_sweep_hook (bfd *abfd,
+ 	{
+ 	  if (is_plt)
+ 	    {
++	      /* If the symbol has been localized its plt.refcount got moved
++	         to got.refcount.  Handle it as GOT.  */
+ 	      if (h->plt.refcount > 0)
+ 		h->plt.refcount--;
++	      else
++		is_got = TRUE;
+ 	    }
+-	  else if (is_got)
++	  if (is_got)
+ 	    {
+ 	      if (h->got.refcount > 0)
+ 		h->got.refcount--;
+-- 
+1.8.1.4
+

--- a/patches/binutils/2.25.1/912-xtensa-fix-gas-segfault-with-text-section-literals.patch
+++ b/patches/binutils/2.25.1/912-xtensa-fix-gas-segfault-with-text-section-literals.patch
@@ -1,0 +1,56 @@
+From 2d0522e76e4afeeb2e104e0a4332d94fa0d2fbf6 Mon Sep 17 00:00:00 2001
+From: Max Filippov <jcmvbkbc@gmail.com>
+Date: Sun, 17 May 2015 06:46:15 +0300
+Subject: [PATCH] xtensa: fix gas segfault with --text-section-literals
+
+When --text-section-literals is used and code in the .init or .fini
+emits literal in the absence of .literal_position, xtensa_move_literals
+segfaults.
+
+Check that search_frag is non-NULL in the xtensa_move_literals and
+report error otherwise.
+
+2015-05-26  Max Filippov  <jcmvbkbc@gmail.com>
+gas/
+	* config/tc-xtensa.c (xtensa_move_literals): Check that
+	search_frag is non-NULL. Report error if literal frag is not
+	found.
+
+Signed-off-by: Max Filippov <jcmvbkbc@gmail.com>
+---
+Backported from: 4de0562a4c69fef4952aa7e19d7bda359f02e8b4
+Changes to ChangeLog are dropped.
+
+ gas/config/tc-xtensa.c | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/gas/config/tc-xtensa.c b/gas/config/tc-xtensa.c
+index 31c0b6b..18307c1 100644
+--- a/gas/config/tc-xtensa.c
++++ b/gas/config/tc-xtensa.c
+@@ -10808,13 +10808,21 @@ xtensa_move_literals (void)
+       frchain_to = NULL;
+       frag_splice = &(frchain_from->frch_root);
+ 
+-      while (!search_frag->tc_frag_data.literal_frag)
++      while (search_frag && !search_frag->tc_frag_data.literal_frag)
+ 	{
+ 	  gas_assert (search_frag->fr_fix == 0
+ 		  || search_frag->fr_type == rs_align);
+ 	  search_frag = search_frag->fr_next;
+ 	}
+ 
++      if (!search_frag)
++	{
++	  search_frag = frchain_from->frch_root;
++	  as_bad_where (search_frag->fr_file, search_frag->fr_line,
++			_("literal pool location required for text-section-literals; specify with .literal_position"));
++	  continue;
++	}
++
+       gas_assert (search_frag->tc_frag_data.literal_frag->fr_subtype
+ 	      == RELAX_LITERAL_POOL_BEGIN);
+       xtensa_switch_section_emit_state (&state, segment->seg, 0);
+-- 
+1.8.1.4
+

--- a/patches/binutils/2.25.1/913-xtensa-add-auto-litpools-option.patch
+++ b/patches/binutils/2.25.1/913-xtensa-add-auto-litpools-option.patch
@@ -1,0 +1,699 @@
+From 978adaaa4cd3921842e2be8a31c05f081fb17fcf Mon Sep 17 00:00:00 2001
+From: Max Filippov <jcmvbkbc@gmail.com>
+Date: Wed, 29 Jul 2015 17:42:54 +0300
+Subject: [PATCH] xtensa: add --auto-litpools option
+
+Auto-litpools is the automated version of text-section-literals: literal
+pool candidate frags are planted every N frags and during relaxation
+they are turned into actual literal pools where literals are moved to
+become reachable for their first reference by L32R instruction.
+
+2015-08-12  David Weatherford  <weath@cadence.com>
+gas/
+	* config/tc-xtensa.c (struct litpool_frag, struct litpool_seg):
+	New structures.
+	(xtensa_maybe_create_literal_pool_frag): New function.
+	(litpool_seg_list, auto_litpools, auto_litpool_limit)
+	(litpool_buf, litpool_slotbuf): New static variables.
+	(option_auto_litpools, option_no_auto_litpools)
+	(option_auto_litpool_limit): New enum identifiers.
+	(md_longopts): Add entries for auto-litpools, no-auto-litpools
+	and auto-litpool-limit.
+	(md_parse_option): Handle option_auto_litpools,
+	option_no_auto_litpools and option_auto_litpool_limit.
+	(md_show_usage): Add help for --[no-]auto-litpools and
+	--auto-litpool-limit.
+	(xtensa_mark_literal_pool_location): Record a place for literal
+	pool with a call to xtensa_maybe_create_literal_pool_frag.
+	(get_literal_pool_location): Find highest priority literal pool
+	or convert candidate to literal pool when auto-litpools are used.
+	(xg_assemble_vliw_tokens): Create literal pool after jump
+	instruction.
+	(xtensa_check_frag_count): Create candidate literal pool every
+	auto_litpool_limit frags.
+	(xtensa_relax_frag): Add jump around literals to non-empty
+	literal pool.
+	(xtensa_move_literals): Estimate literal pool addresses and move
+	unreachable literals closer to their users, converting candidate
+	to literal pool if needed.
+	(xtensa_switch_to_non_abs_literal_fragment): Only emit error
+	about missing .literal_position in case auto-litpools are not
+	used.
+	* config/tc-xtensa.h (xtensa_relax_statesE): New relaxation
+	state: RELAX_LITERAL_POOL_CANDIDATE_BEGIN.
+
+2015-08-12  Max Filippov  <jcmvbkbc@gmail.com>
+gas/testsuite/
+	* gas/xtensa/all.exp: Add auto-litpools to the list of xtensa
+	tests.
+	* gas/xtensa/auto-litpools.s: New file: auto-litpools test.
+	* gas/xtensa/auto-litpools.s: New file: auto-litpools test
+	result pattern.
+
+Signed-off-by: Max Filippov <jcmvbkbc@gmail.com>
+---
+Backported from: b46824bd49648c575372e6d9bc6a6defeabd6ed5
+Changes to ChangeLogs and documentation are dropped.
+
+ gas/config/tc-xtensa.c                   | 432 ++++++++++++++++++++++++++++++-
+ gas/config/tc-xtensa.h                   |   1 +
+ gas/testsuite/gas/xtensa/all.exp         |   1 +
+ gas/testsuite/gas/xtensa/auto-litpools.d |  12 +
+ gas/testsuite/gas/xtensa/auto-litpools.s |  13 +
+ 5 files changed, 454 insertions(+), 5 deletions(-)
+ create mode 100644 gas/testsuite/gas/xtensa/auto-litpools.d
+ create mode 100644 gas/testsuite/gas/xtensa/auto-litpools.s
+
+diff --git a/gas/config/tc-xtensa.c b/gas/config/tc-xtensa.c
+index 7311a05..b8b1e7d 100644
+--- a/gas/config/tc-xtensa.c
++++ b/gas/config/tc-xtensa.c
+@@ -440,6 +440,29 @@ bfd_boolean directive_state[] =
+ #endif
+ };
+ 
++/* A circular list of all potential and actual literal pool locations
++   in a segment.  */
++struct litpool_frag
++{
++  struct litpool_frag *next;
++  struct litpool_frag *prev;
++  fragS *fragP;
++  addressT addr;
++  short priority; /* 1, 2, or 3 -- 1 is highest  */
++  short original_priority;
++};
++
++/* Map a segment to its litpool_frag list.  */
++struct litpool_seg
++{
++  struct litpool_seg *next;
++  asection *seg;
++  struct litpool_frag frag_list;
++  int frag_count; /* since last litpool location  */
++};
++
++static struct litpool_seg litpool_seg_list;
++
+ 
+ /* Directive functions.  */
+ 
+@@ -474,6 +497,9 @@ static void xtensa_create_trampoline_frag (bfd_boolean);
+ static void xtensa_maybe_create_trampoline_frag (void);
+ struct trampoline_frag;
+ static int init_trampoline_frag (struct trampoline_frag *);
++static void xtensa_maybe_create_literal_pool_frag (bfd_boolean, bfd_boolean);
++static bfd_boolean auto_litpools = FALSE;
++static int auto_litpool_limit = 10000;
+ 
+ /* Alignment Functions.  */
+ 
+@@ -698,6 +724,10 @@ enum
+ 
+   option_trampolines,
+   option_no_trampolines,
++
++  option_auto_litpools,
++  option_no_auto_litpools,
++  option_auto_litpool_limit,
+ };
+ 
+ const char *md_shortopts = "";
+@@ -773,6 +803,10 @@ struct option md_longopts[] =
+   { "trampolines", no_argument, NULL, option_trampolines },
+   { "no-trampolines", no_argument, NULL, option_no_trampolines },
+ 
++  { "auto-litpools", no_argument, NULL, option_auto_litpools },
++  { "no-auto-litpools", no_argument, NULL, option_no_auto_litpools },
++  { "auto-litpool-limit", required_argument, NULL, option_auto_litpool_limit },
++
+   { NULL, no_argument, NULL, 0 }
+ };
+ 
+@@ -961,6 +995,34 @@ md_parse_option (int c, char *arg)
+       use_trampolines = FALSE;
+       return 1;
+ 
++    case option_auto_litpools:
++      auto_litpools = TRUE;
++      use_literal_section = FALSE;
++      return 1;
++
++    case option_no_auto_litpools:
++      auto_litpools = FALSE;
++      auto_litpool_limit = -1;
++      return 1;
++
++    case option_auto_litpool_limit:
++      {
++	int value = 0;
++	if (auto_litpool_limit < 0)
++	  as_fatal (_("no-auto-litpools is incompatible with auto-litpool-limit"));
++	if (*arg == 0 || *arg == '-')
++	  as_fatal (_("invalid auto-litpool-limit argument"));
++	value = strtol (arg, &arg, 10);
++	if (*arg != 0)
++	  as_fatal (_("invalid auto-litpool-limit argument"));
++	if (value < 100 || value > 10000)
++	  as_fatal (_("invalid auto-litpool-limit argument (range is 100-10000)"));
++	auto_litpool_limit = value;
++	auto_litpools = TRUE;
++	use_literal_section = FALSE;
++	return 1;
++      }
++
+     default:
+       return 0;
+     }
+@@ -986,7 +1048,12 @@ Xtensa options:\n\
+                           flix bundles\n\
+   --rename-section old=new Rename section 'old' to 'new'\n\
+   --[no-]trampolines      [Do not] generate trampolines (jumps to jumps)\n\
+-                          when jumps do not reach their targets\n", stream);
++                          when jumps do not reach their targets\n\
++  --[no-]auto-litpools    [Do not] automatically create literal pools\n\
++  --auto-litpool-limit=<value>\n\
++                          (range 100-10000) Maximum number of blocks of\n\
++                          instructions to emit between literal pool\n\
++                          locations; implies --auto-litpools flag\n", stream);
+ }
+ 
+ 
+@@ -4728,6 +4795,8 @@ xtensa_mark_literal_pool_location (void)
+   pool_location = frag_now;
+   frag_now->tc_frag_data.lit_frchain = frchain_now;
+   frag_now->tc_frag_data.literal_frag = frag_now;
++  /* Just record this frag.  */
++  xtensa_maybe_create_literal_pool_frag (FALSE, FALSE);
+   frag_variant (rs_machine_dependent, 0, 0,
+ 		RELAX_LITERAL_POOL_BEGIN, NULL, 0, NULL);
+   xtensa_set_frag_assembly_state (frag_now);
+@@ -4832,6 +4901,31 @@ get_expanded_loop_offset (xtensa_opcode opcode)
+ static fragS *
+ get_literal_pool_location (segT seg)
+ {
++  struct litpool_seg *lps = litpool_seg_list.next;
++  struct litpool_frag *lpf;
++  for ( ; lps && lps->seg->id != seg->id; lps = lps->next)
++    ;
++  if (lps)
++    {
++      for (lpf = lps->frag_list.prev; lpf->fragP; lpf = lpf->prev)
++	{ /* Skip "candidates" for now.  */
++	  if (lpf->fragP->fr_subtype == RELAX_LITERAL_POOL_BEGIN &&
++	      lpf->priority == 1)
++	    return lpf->fragP;
++	}
++      /* Must convert a lower-priority pool.  */
++      for (lpf = lps->frag_list.prev; lpf->fragP; lpf = lpf->prev)
++	{
++	  if (lpf->fragP->fr_subtype == RELAX_LITERAL_POOL_BEGIN)
++	    return lpf->fragP;
++	}
++      /* Still no match -- try for a low priority pool.  */
++      for (lpf = lps->frag_list.prev; lpf->fragP; lpf = lpf->prev)
++	{
++	  if (lpf->fragP->fr_subtype == RELAX_LITERAL_POOL_CANDIDATE_BEGIN)
++	    return lpf->fragP;
++	}
++    }
+   return seg_info (seg)->tc_segment_info_data.literal_pool_loc;
+ }
+ 
+@@ -7098,6 +7192,11 @@ xg_assemble_vliw_tokens (vliw_insn *vinsn)
+       frag_now->tc_frag_data.slot_symbols[slot] = tinsn->symbol;
+       frag_now->tc_frag_data.slot_offsets[slot] = tinsn->offset;
+       frag_now->tc_frag_data.literal_frags[slot] = tinsn->literal_frag;
++      if (tinsn->opcode == xtensa_l32r_opcode)
++	{
++	  frag_now->tc_frag_data.literal_frags[slot] =
++		  tinsn->tok[1].X_add_symbol->sy_frag;
++	}
+       if (tinsn->literal_space != 0)
+ 	xg_assemble_literal_space (tinsn->literal_space, slot);
+       frag_now->tc_frag_data.free_reg[slot] = tinsn->extra_arg;
+@@ -7170,6 +7269,8 @@ xg_assemble_vliw_tokens (vliw_insn *vinsn)
+ 		    frag_now->fr_symbol, frag_now->fr_offset, NULL);
+ 	  xtensa_set_frag_assembly_state (frag_now);
+ 	  xtensa_maybe_create_trampoline_frag ();
++	  /* Always create one here.  */
++	  xtensa_maybe_create_literal_pool_frag (TRUE, FALSE);
+ 	}
+       else if (is_branch && do_align_targets ())
+ 	{
+@@ -7314,11 +7415,18 @@ xtensa_check_frag_count (void)
+       clear_frag_count ();
+       unreachable_count = 0;
+     }
++
++  /* We create an area for a possible literal pool every N (default 5000)
++     frags or so.  */
++  xtensa_maybe_create_literal_pool_frag (TRUE, TRUE);
+ }
+ 
+ static xtensa_insnbuf trampoline_buf = NULL;
+ static xtensa_insnbuf trampoline_slotbuf = NULL;
+ 
++static xtensa_insnbuf litpool_buf = NULL;
++static xtensa_insnbuf litpool_slotbuf = NULL;
++
+ #define TRAMPOLINE_FRAG_SIZE 3000
+ 
+ static void
+@@ -7410,6 +7518,135 @@ dump_trampolines (void)
+     }
+ }
+ 
++static void dump_litpools (void) __attribute__ ((unused));
++
++static void
++dump_litpools (void)
++{
++  struct litpool_seg *lps = litpool_seg_list.next;
++  struct litpool_frag *lpf;
++
++  for ( ; lps ; lps = lps->next )
++    {
++      printf("litpool seg %s\n", lps->seg->name);
++      for ( lpf = lps->frag_list.next; lpf->fragP; lpf = lpf->next )
++	{
++	  fragS *litfrag = lpf->fragP->fr_next;
++	  int count = 0;
++	  while (litfrag && litfrag->fr_subtype != RELAX_LITERAL_POOL_END)
++	    {
++	      if (litfrag->fr_fix == 4)
++		count++;
++	      litfrag = litfrag->fr_next;
++	    }
++	  printf("   %ld <%d:%d> (%d) [%d]: ",
++		 lpf->addr, lpf->priority, lpf->original_priority,
++		 lpf->fragP->fr_line, count);
++	  //dump_frag(lpf->fragP);
++	}
++    }
++}
++
++static void
++xtensa_maybe_create_literal_pool_frag (bfd_boolean create,
++				       bfd_boolean only_if_needed)
++{
++  struct litpool_seg *lps = litpool_seg_list.next;
++  fragS *fragP;
++  struct litpool_frag *lpf;
++  bfd_boolean needed = FALSE;
++
++  if (use_literal_section || !auto_litpools)
++    return;
++
++  for ( ; lps ; lps = lps->next )
++    {
++      if (lps->seg == now_seg)
++	break;
++    }
++
++  if (lps == NULL)
++    {
++      lps = (struct litpool_seg *)xcalloc (sizeof (struct litpool_seg), 1);
++      lps->next = litpool_seg_list.next;
++      litpool_seg_list.next = lps;
++      lps->seg = now_seg;
++      lps->frag_list.next = &lps->frag_list;
++      lps->frag_list.prev = &lps->frag_list;
++    }
++
++  lps->frag_count++;
++
++  if (create)
++    {
++      if (only_if_needed)
++	{
++	  if (past_xtensa_end || !use_transform() ||
++	      frag_now->tc_frag_data.is_no_transform)
++	    {
++	      return;
++	    }
++	  if (auto_litpool_limit <= 0)
++	    {
++	      /* Don't create a litpool based only on frag count.  */
++	      return;
++	    }
++	  else if (lps->frag_count > auto_litpool_limit)
++	    {
++	      needed = TRUE;
++	    }
++	  else
++	    {
++	      return;
++	    }
++	}
++      else
++	{
++	  needed = TRUE;
++	}
++    }
++
++  if (needed)
++    {
++      int size = (only_if_needed) ? 3 : 0; /* Space for a "j" insn.  */
++      /* Create a potential site for a literal pool.  */
++      frag_wane (frag_now);
++      frag_new (0);
++      xtensa_set_frag_assembly_state (frag_now);
++      fragP = frag_now;
++      fragP->tc_frag_data.lit_frchain = frchain_now;
++      fragP->tc_frag_data.literal_frag = fragP;
++      frag_var (rs_machine_dependent, size, size,
++		    (only_if_needed) ?
++		        RELAX_LITERAL_POOL_CANDIDATE_BEGIN :
++		        RELAX_LITERAL_POOL_BEGIN,
++		    NULL, 0, NULL);
++      frag_now->tc_frag_data.lit_seg = now_seg;
++      frag_variant (rs_machine_dependent, 0, 0,
++		    RELAX_LITERAL_POOL_END, NULL, 0, NULL);
++      xtensa_set_frag_assembly_state (frag_now);
++    }
++  else
++    {
++      /* RELAX_LITERAL_POOL_BEGIN frag is being created;
++	 just record it here.  */
++      fragP = frag_now;
++    }
++
++  lpf = (struct litpool_frag *)xmalloc(sizeof (struct litpool_frag));
++  /* Insert at tail of circular list.  */
++  lpf->addr = 0;
++  lps->frag_list.prev->next = lpf;
++  lpf->next = &lps->frag_list;
++  lpf->prev = lps->frag_list.prev;
++  lps->frag_list.prev = lpf;
++  lpf->fragP = fragP;
++  lpf->priority = (needed) ? (only_if_needed) ? 3 : 2 : 1;
++  lpf->original_priority = lpf->priority;
++
++  lps->frag_count = 0;
++}
++
+ static void
+ xtensa_cleanup_align_frags (void)
+ {
+@@ -9029,7 +9266,41 @@ xtensa_relax_frag (fragS *fragP, long stretch, int *stretched_p)
+       break;
+ 
+     case RELAX_LITERAL_POOL_BEGIN:
++      if (fragP->fr_var != 0)
++	{
++	  /* We have a converted "candidate" literal pool;
++	     assemble a jump around it.  */
++	  TInsn insn;
++	  if (!litpool_slotbuf)
++	    {
++	      litpool_buf = xtensa_insnbuf_alloc (isa);
++	      litpool_slotbuf = xtensa_insnbuf_alloc (isa);
++	    }
++	  new_stretch += 3;
++	  fragP->tc_frag_data.relax_seen = FALSE; /* Need another pass.  */
++	  fragP->tc_frag_data.is_insn = TRUE;
++	  tinsn_init (&insn);
++	  insn.insn_type = ITYPE_INSN;
++	  insn.opcode = xtensa_j_opcode;
++	  insn.ntok = 1;
++	  set_expr_symbol_offset (&insn.tok[0], fragP->fr_symbol,
++				  fragP->fr_fix);
++	  fmt = xg_get_single_format (xtensa_j_opcode);
++	  tinsn_to_slotbuf (fmt, 0, &insn, litpool_slotbuf);
++	  xtensa_format_set_slot (isa, fmt, 0, litpool_buf, litpool_slotbuf);
++	  xtensa_insnbuf_to_chars (isa, litpool_buf,
++				   (unsigned char *)fragP->fr_literal +
++				   fragP->fr_fix, 3);
++	  fragP->fr_fix += 3;
++	  fragP->fr_var -= 3;
++	  /* Add a fix-up.  */
++	  fix_new (fragP, 0, 3, fragP->fr_symbol, 0, TRUE,
++		   BFD_RELOC_XTENSA_SLOT0_OP);
++	}
++      break;
++
+     case RELAX_LITERAL_POOL_END:
++    case RELAX_LITERAL_POOL_CANDIDATE_BEGIN:
+     case RELAX_MAYBE_UNREACHABLE:
+     case RELAX_MAYBE_DESIRE_ALIGN:
+       /* No relaxation required.  */
+@@ -10789,12 +11060,115 @@ xtensa_move_literals (void)
+   segT dest_seg;
+   fixS *fix, *next_fix, **fix_splice;
+   sym_list *lit;
++  struct litpool_seg *lps;
+ 
+   mark_literal_frags (literal_head->next);
+ 
+   if (use_literal_section)
+     return;
+ 
++  /* Assign addresses (rough estimates) to the potential literal pool locations
++     and create new ones if the gaps are too large.  */
++
++  for (lps = litpool_seg_list.next; lps; lps = lps->next)
++    {
++      frchainS *frchP = seg_info (lps->seg)->frchainP;
++      struct litpool_frag *lpf = lps->frag_list.next;
++      addressT addr = 0;
++
++      for ( ; frchP; frchP = frchP->frch_next)
++	{
++	  fragS *fragP;
++	  for (fragP = frchP->frch_root; fragP; fragP = fragP->fr_next)
++	    {
++	      if (lpf && fragP == lpf->fragP)
++		{
++		  gas_assert(fragP->fr_type == rs_machine_dependent &&
++			     (fragP->fr_subtype == RELAX_LITERAL_POOL_BEGIN ||
++			      fragP->fr_subtype == RELAX_LITERAL_POOL_CANDIDATE_BEGIN));
++		  /* Found a litpool location.  */
++		  lpf->addr = addr;
++		  lpf = lpf->next;
++		}
++	      if (fragP->fr_type == rs_machine_dependent &&
++		  fragP->fr_subtype == RELAX_SLOTS)
++		{
++		  int slot;
++		  for (slot = 0; slot < MAX_SLOTS; slot++)
++		    {
++		      if (fragP->tc_frag_data.literal_frags[slot])
++			{
++			  /* L32R; point its literal to the nearest litpool
++			     preferring non-"candidate" positions to avoid
++			     the jump-around.  */
++			  fragS *litfrag = fragP->tc_frag_data.literal_frags[slot];
++			  struct litpool_frag *lp = lpf->prev;
++			  if (!lp->fragP)
++			    {
++			      break;
++			    }
++			  while (lp->fragP->fr_subtype ==
++				 RELAX_LITERAL_POOL_CANDIDATE_BEGIN)
++			    {
++			      lp = lp->prev;
++			      if (lp->fragP == NULL)
++				{
++				  /* End of list; have to bite the bullet.
++				     Take the nearest.  */
++				  lp = lpf->prev;
++				  break;
++				}
++			      /* Does it (conservatively) reach?  */
++			      if (addr - lp->addr <= 128 * 1024)
++				{
++				  if (lp->fragP->fr_subtype == RELAX_LITERAL_POOL_BEGIN)
++				    {
++				      /* Found a good one.  */
++				      break;
++				    }
++				  else if (lp->prev->fragP &&
++					   addr - lp->prev->addr > 128 * 1024)
++				    {
++				      /* This is still a "candidate" but the next one
++				         will be too far away, so revert to the nearest
++					 one, convert it and add the jump around.  */
++				      fragS *poolbeg;
++				      fragS *poolend;
++				      symbolS *lsym;
++				      char label[10 + 2 * sizeof (fragS *)];
++				      lp = lpf->prev;
++				      poolbeg = lp->fragP;
++				      lp->priority = 1;
++				      poolbeg->fr_subtype = RELAX_LITERAL_POOL_BEGIN;
++				      poolend = poolbeg->fr_next;
++				      gas_assert (poolend->fr_type == rs_machine_dependent &&
++						  poolend->fr_subtype == RELAX_LITERAL_POOL_END);
++				      /* Create a local symbol pointing to the
++				         end of the pool.  */
++				      sprintf (label, ".L0_LT_%p", poolbeg);
++				      lsym = (symbolS *)local_symbol_make (label, lps->seg,
++									   0, poolend);
++				      poolbeg->fr_symbol = lsym;
++				      /* Rest is done in xtensa_relax_frag.  */
++				    }
++				}
++			    }
++			  if (! litfrag->tc_frag_data.literal_frag)
++			    {
++			      /* Take earliest use of this literal to avoid
++				 forward refs.  */
++			      litfrag->tc_frag_data.literal_frag = lp->fragP;
++			    }
++			}
++		    }
++		}
++	      addr += fragP->fr_fix;
++	      if (fragP->fr_type == rs_fill)
++		addr += fragP->fr_offset;
++	    }
++	}
++    }
++
+   for (segment = literal_head->next; segment; segment = segment->next)
+     {
+       /* Keep the literals for .init and .fini in separate sections.  */
+@@ -10839,9 +11213,6 @@ xtensa_move_literals (void)
+       while (search_frag != frag_now)
+ 	{
+ 	  next_frag = search_frag->fr_next;
+-
+-	  /* First, move the frag out of the literal section and
+-	     to the appropriate place.  */
+ 	  if (search_frag->tc_frag_data.literal_frag)
+ 	    {
+ 	      literal_pool = search_frag->tc_frag_data.literal_frag;
+@@ -10849,8 +11220,56 @@ xtensa_move_literals (void)
+ 	      frchain_to = literal_pool->tc_frag_data.lit_frchain;
+ 	      gas_assert (frchain_to);
+ 	    }
++
++	  if (search_frag->fr_type == rs_fill && search_frag->fr_fix == 0)
++	    {
++	      /* Skip empty fill frags.  */
++	      *frag_splice = next_frag;
++	      search_frag = next_frag;
++	      continue;
++	    }
++
++	  if (search_frag->fr_type == rs_align)
++	    {
++	      /* Skip alignment frags, because the pool as a whole will be
++	         aligned if used, and we don't want to force alignment if the
++		 pool is unused.  */
++	      *frag_splice = next_frag;
++	      search_frag = next_frag;
++	      continue;
++	    }
++
++	  /* First, move the frag out of the literal section and
++	     to the appropriate place.  */
++
++	  /* Insert an aligmnent frag at start of pool.  */
++	  if (literal_pool->fr_next->fr_type == rs_machine_dependent &&
++	      literal_pool->fr_next->fr_subtype == RELAX_LITERAL_POOL_END)
++	    {
++	      segT pool_seg = literal_pool->fr_next->tc_frag_data.lit_seg;
++	      emit_state prev_state;
++	      fragS *prev_frag;
++	      fragS *align_frag;
++	      xtensa_switch_section_emit_state (&prev_state, pool_seg, 0);
++	      prev_frag = frag_now;
++	      frag_variant (rs_fill, 0, 0, 0, NULL, 0, NULL);
++	      align_frag = frag_now;
++	      frag_align (2, 0, 0);
++	      /* Splice it into the right place.  */
++	      prev_frag->fr_next = align_frag->fr_next;
++	      align_frag->fr_next = literal_pool->fr_next;
++	      literal_pool->fr_next = align_frag;
++	      /* Insert after this one.  */
++	      literal_pool->tc_frag_data.literal_frag = align_frag;
++	      xtensa_restore_emit_state (&prev_state);
++	    }
+ 	  insert_after = literal_pool->tc_frag_data.literal_frag;
+ 	  dest_seg = insert_after->fr_next->tc_frag_data.lit_seg;
++	  /* Skip align frag.  */
++	  if (insert_after->fr_next->fr_type == rs_align)
++	    {
++	      insert_after = insert_after->fr_next;
++	    }
+ 
+ 	  *frag_splice = next_frag;
+ 	  search_frag->fr_next = insert_after->fr_next;
+@@ -11014,7 +11433,10 @@ xtensa_switch_to_non_abs_literal_fragment (emit_state *result)
+       && !recursive
+       && !is_init && ! is_fini)
+     {
+-      as_bad (_("literal pool location required for text-section-literals; specify with .literal_position"));
++      if (!auto_litpools)
++	{
++	  as_bad (_("literal pool location required for text-section-literals; specify with .literal_position"));
++	}
+ 
+       /* When we mark a literal pool location, we want to put a frag in
+ 	 the literal pool that points to it.  But to do that, we want to
+diff --git a/gas/config/tc-xtensa.h b/gas/config/tc-xtensa.h
+index b2e43fa..290d902 100644
+--- a/gas/config/tc-xtensa.h
++++ b/gas/config/tc-xtensa.h
+@@ -124,6 +124,7 @@ enum xtensa_relax_statesE
+ 
+   RELAX_LITERAL_POOL_BEGIN,
+   RELAX_LITERAL_POOL_END,
++  RELAX_LITERAL_POOL_CANDIDATE_BEGIN,
+   /* Technically these are not relaxations at all but mark a location
+      to store literals later.  Note that fr_var stores the frchain for
+      BEGIN frags and fr_var stores now_seg for END frags.  */
+diff --git a/gas/testsuite/gas/xtensa/all.exp b/gas/testsuite/gas/xtensa/all.exp
+index d197ec8..db39629 100644
+--- a/gas/testsuite/gas/xtensa/all.exp
++++ b/gas/testsuite/gas/xtensa/all.exp
+@@ -100,6 +100,7 @@ if [istarget xtensa*-*-*] then {
+     run_dump_test "jlong"
+     run_dump_test "trampoline"
+     run_dump_test "first_frag_align"
++    run_dump_test "auto-litpools"
+ }
+ 
+ if [info exists errorInfo] then {
+diff --git a/gas/testsuite/gas/xtensa/auto-litpools.d b/gas/testsuite/gas/xtensa/auto-litpools.d
+new file mode 100644
+index 0000000..4d1a690
+--- /dev/null
++++ b/gas/testsuite/gas/xtensa/auto-litpools.d
+@@ -0,0 +1,12 @@
++#as: --auto-litpools
++#objdump: -d
++#name: auto literal pool placement
++
++.*: +file format .*xtensa.*
++#...
++.*4:.*l32r.a2, 0 .*
++#...
++.*3e437:.*j.3e440 .*
++#...
++.*40750:.*l32r.a2, 3e43c .*
++#...
+diff --git a/gas/testsuite/gas/xtensa/auto-litpools.s b/gas/testsuite/gas/xtensa/auto-litpools.s
+new file mode 100644
+index 0000000..9a5b26b
+--- /dev/null
++++ b/gas/testsuite/gas/xtensa/auto-litpools.s
+@@ -0,0 +1,13 @@
++	.text
++	.align	4
++	.literal	.L0, 0x12345
++	.literal	.L1, 0x12345
++
++f:
++	l32r	a2, .L0
++	.rep	44000
++	_nop
++	_nop
++	.endr
++	l32r	a2, .L1
++	ret
+-- 
+1.8.1.4
+

--- a/patches/gcc/5.2.0/110-xtensa-implement-trap-pattern.patch
+++ b/patches/gcc/5.2.0/110-xtensa-implement-trap-pattern.patch
@@ -1,0 +1,64 @@
+From d462e776df56a72f68545054f6d722bf447f0519 Mon Sep 17 00:00:00 2001
+From: Max Filippov <jcmvbkbc@gmail.com>
+Date: Mon, 8 Jun 2015 22:29:11 +0300
+Subject: [PATCH] xtensa: implement trap pattern
+
+gcc/
+	* config/xtensa/xtensa.h (TARGET_DEBUG): New definition.
+	* config/xtensa/xtensa.md (define_attr "type"): New type "trap".
+	(define_insn "trap"): New definition.
+
+Signed-off-by: Max Filippov <jcmvbkbc@gmail.com>
+---
+ gcc/config/xtensa/xtensa.h  |  1 +
+ gcc/config/xtensa/xtensa.md | 15 ++++++++++++++-
+ 2 files changed, 15 insertions(+), 1 deletion(-)
+
+diff --git a/gcc/config/xtensa/xtensa.h b/gcc/config/xtensa/xtensa.h
+index 011411c..584080b 100644
+--- a/gcc/config/xtensa/xtensa.h
++++ b/gcc/config/xtensa/xtensa.h
+@@ -67,6 +67,7 @@ extern unsigned xtensa_current_frame_size;
+ #define TARGET_THREADPTR	XCHAL_HAVE_THREADPTR
+ #define TARGET_LOOPS	        XCHAL_HAVE_LOOPS
+ #define TARGET_WINDOWED_ABI	(XSHAL_ABI == XTHAL_ABI_WINDOWED)
++#define TARGET_DEBUG		XCHAL_HAVE_DEBUG
+ 
+ #define TARGET_DEFAULT \
+   ((XCHAL_HAVE_L32R	? 0 : MASK_CONST16) |				\
+diff --git a/gcc/config/xtensa/xtensa.md b/gcc/config/xtensa/xtensa.md
+index 6d84384..a577aa3 100644
+--- a/gcc/config/xtensa/xtensa.md
++++ b/gcc/config/xtensa/xtensa.md
+@@ -86,7 +86,7 @@
+ ;; Attributes.
+ 
+ (define_attr "type"
+-  "unknown,jump,call,load,store,move,arith,multi,nop,farith,fmadd,fconv,fload,fstore,mul16,mul32,div32,mac16,rsr,wsr,entry"
++  "unknown,jump,call,load,store,move,arith,multi,nop,farith,fmadd,fconv,fload,fstore,mul16,mul32,div32,mac16,rsr,wsr,entry,trap"
+   (const_string "unknown"))
+ 
+ (define_attr "mode"
+@@ -1764,6 +1764,19 @@
+   [(set_attr "length" "0")
+    (set_attr "type" "nop")])
+ 
++(define_insn "trap"
++  [(trap_if (const_int 1) (const_int 0))]
++  ""
++{
++  if (TARGET_DEBUG)
++    return "break\t1, 15";
++  else
++    return (TARGET_DENSITY ? "ill.n" : "ill");
++}
++  [(set_attr "type"	"trap")
++   (set_attr "mode"	"none")
++   (set_attr "length"	"3")])
++
+ ;; Setting up a frame pointer is tricky for Xtensa because GCC doesn't
+ ;; know if a frame pointer is required until the reload pass, and
+ ;; because there may be an incoming argument value in the hard frame
+-- 
+1.8.1.4
+

--- a/patches/gdb/7.10/110-xtensa-initialize-call_abi-in-xtensa_tdep.patch
+++ b/patches/gdb/7.10/110-xtensa-initialize-call_abi-in-xtensa_tdep.patch
@@ -1,0 +1,39 @@
+From 7f8c0d8984bf5754807d3bb543cbc3ffc634e9e4 Mon Sep 17 00:00:00 2001
+From: Max Filippov <jcmvbkbc@gmail.com>
+Date: Sat, 30 May 2015 13:00:32 +0300
+Subject: [PATCH] xtensa: initialize call_abi in xtensa_tdep
+
+Use XSHAL_ABI value provided by xtensa-config.h to correctly initialize
+xtensa_tdep.call_abi
+This fixes calls to functions from GDB that otherwise fail with the
+following assertion in call0 configuration:
+
+  gdb/regcache.c:602: internal-error: regcache_raw_read: Assertion
+  `regnum >= 0 && regnum < regcache->descr->nr_raw_registers' failed.
+
+gdb/
+	* xtensa-tdep.h (XTENSA_GDBARCH_TDEP_INSTANTIATE): Initialize
+	call_abi using XSHAL_ABI macro.
+
+Signed-off-by: Max Filippov <jcmvbkbc@gmail.com>
+---
+ gdb/xtensa-tdep.h | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/gdb/xtensa-tdep.h b/gdb/xtensa-tdep.h
+index adacaf8..3b6ea66 100644
+--- a/gdb/xtensa-tdep.h
++++ b/gdb/xtensa-tdep.h
+@@ -246,7 +246,8 @@ struct gdbarch_tdep
+ 	  .spill_location = -1,					\
+ 	  .spill_size = (spillsz),				\
+ 	  .unused = 0,						\
+-	  .call_abi = 0,					\
++	  .call_abi = (XSHAL_ABI == XTHAL_ABI_CALL0) ?		\
++		CallAbiCall0Only : CallAbiDefault,		\
+ 	  .debug_interrupt_level = XCHAL_DEBUGLEVEL,		\
+ 	  .icache_line_bytes = XCHAL_ICACHE_LINESIZE,		\
+ 	  .dcache_line_bytes = XCHAL_DCACHE_LINESIZE,		\
+-- 
+1.8.1.4
+

--- a/patches/gdb/7.10/111-xtensa-make-sure-ar_base-is-initialized.patch
+++ b/patches/gdb/7.10/111-xtensa-make-sure-ar_base-is-initialized.patch
@@ -1,0 +1,35 @@
+From 208ea73d38c9c16cf983b6419f58050dbadcb6a9 Mon Sep 17 00:00:00 2001
+From: Max Filippov <jcmvbkbc@gmail.com>
+Date: Sun, 7 Jun 2015 22:43:49 +0300
+Subject: [PATCH 2/2] xtensa: make sure ar_base is initialized
+
+ar_base is uninitialized for cores w/o windowed registers as their
+regmap doesn't have register 0x0100.
+Check that ar_base is initialized and if not initialize it with a0_base.
+
+gdb/
+	* xtensa-tdep.c (xtensa_derive_tdep): Make sure ar_base is
+	initialized.
+
+Signed-off-by: Max Filippov <jcmvbkbc@gmail.com>
+---
+ gdb/xtensa-tdep.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/gdb/xtensa-tdep.c b/gdb/xtensa-tdep.c
+index 55e7d98..41f5ec1 100644
+--- a/gdb/xtensa-tdep.c
++++ b/gdb/xtensa-tdep.c
+@@ -3175,6 +3175,9 @@ xtensa_derive_tdep (struct gdbarch_tdep *tdep)
+ 	tdep->num_regs = n;
+     }
+ 
++  if (tdep->ar_base == -1)
++    tdep->ar_base = tdep->a0_base;
++
+   /* Number of pseudo registers.  */
+   tdep->num_pseudo_regs = n - tdep->num_regs;
+ 
+-- 
+1.8.1.4
+

--- a/patches/gdb/7.10/112-WIP-end-of-prologue-detection-hack.patch
+++ b/patches/gdb/7.10/112-WIP-end-of-prologue-detection-hack.patch
@@ -1,0 +1,31 @@
+From 7f8eacbb468575fb67db7fd1155a3aedaa91911b Mon Sep 17 00:00:00 2001
+From: Max Filippov <jcmvbkbc@gmail.com>
+Date: Sun, 7 Jun 2015 23:15:39 +0300
+Subject: [PATCH] WIP: *end of prologue* detection hack
+
+see
+  http://www.esp8266.com/viewtopic.php?p=18461#p18461
+  http://www.esp8266.com/viewtopic.php?p=19026#p19026
+  http://www.esp8266.com/viewtopic.php?p=19683#p19683
+
+Signed-off-by: Max Filippov <jcmvbkbc@gmail.com>
+---
+ gdb/xtensa-tdep.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gdb/xtensa-tdep.c b/gdb/xtensa-tdep.c
+index 41f5ec1..6a7dba7 100644
+--- a/gdb/xtensa-tdep.c
++++ b/gdb/xtensa-tdep.c
+@@ -2410,7 +2410,7 @@ call0_analyze_prologue (struct gdbarch *gdbarch,
+   /* Find out, if we have an information about the prologue from DWARF.  */
+   prologue_sal = find_pc_line (start, 0);
+   if (prologue_sal.line != 0) /* Found debug info.  */
+-    body_pc = prologue_sal.end;
++    body_pc = prologue_sal.end + 40;
+ 
+   /* If we are going to analyze the prologue in general without knowing about
+      the current PC, make the best assumtion for the end of the prologue.  */
+-- 
+1.8.1.4
+

--- a/samples/xtensa-unknown-linux-uclibc/crosstool.config
+++ b/samples/xtensa-unknown-linux-uclibc/crosstool.config
@@ -1,0 +1,7 @@
+CT_LOCAL_TARBALLS_DIR="${HOME}/src"
+CT_ARCH_xtensa=y
+CT_KERNEL_linux=y
+CT_LIBC_uClibc=y
+CT_LIBC_UCLIBC_WCHAR=y
+CT_CC_LANG_CXX=y
+CT_DEBUG_gdb=y

--- a/samples/xtensa-unknown-linux-uclibc/reported.by
+++ b/samples/xtensa-unknown-linux-uclibc/reported.by
@@ -1,0 +1,3 @@
+reporter_name="Max Filippov"
+reporter_url="http://wiki.linux-xtensa.org/index.php/Crosstool-NG"
+reporter_comment="Xtensa default toolchain"

--- a/scripts/build/arch/xtensa.sh
+++ b/scripts/build/arch/xtensa.sh
@@ -1,0 +1,78 @@
+# Compute Xtensa-specific values
+
+CT_DoArchTupleValues() {
+    # The architecture part of the tuple:
+    CT_TARGET_ARCH="${CT_ARCH}${CT_ARCH_SUFFIX}"
+    # The system part of the tuple:
+    case "${CT_LIBC}" in
+        *glibc)   CT_TARGET_SYS=gnu;;
+        uClibc)   CT_TARGET_SYS=uclibc;;
+    esac
+}
+
+# This function updates the specified component (binutils, gcc, gdb, etc.)
+# with the processor specific configuration.
+CT_ConfigureXtensa() {
+    local component="${1}"
+    local version="${2}"
+    local custom_overlay="xtensa_${CT_ARCH_XTENSA_CUSTOM_NAME}.tar"
+    local custom_location="${CT_ARCH_XTENSA_CUSTOM_OVERLAY_LOCATION}"
+
+    if [ -z "${CT_ARCH_XTENSA_CUSTOM_NAME}" ]; then
+        custom_overlay="xtensa-overlay.tar"
+    fi
+
+    if [ -n "${CT_CUSTOM_LOCATION_ROOT_DIR}" \
+         -a -z "${custom_location}" ]; then
+             custom_location="${CT_CUSTOM_LOCATION_ROOT_DIR}"
+    fi
+
+    CT_TestAndAbort "${custom_overlay}: CT_CUSTOM_LOCATION_ROOT_DIR or CT_ARCH_XTENSA_CUSTOM_OVERLAY_LOCATION must be set." \
+        -z "${CT_CUSTOM_LOCATION_ROOT_DIR}" -a -z "${custom_location}"
+
+    local full_file="${custom_location}/${custom_overlay}"
+    local basename="${component}-${version}"
+    local ext
+
+    ext=${full_file/*./.}
+
+    if [ -z "${ext}" ] ; then
+        CT_DoLog WARN "'${full_file}' not found"
+        return 1
+    fi
+
+    if [ -e "${CT_SRC_DIR}/.${basename}.configuring" ]; then
+        CT_DoLog ERROR "The '${basename}' source were partially configured."
+        CT_DoLog ERROR "Please remove first:"
+        CT_DoLog ERROR " - the source dir for '${basename}', in '${CT_SRC_DIR}'"
+        CT_DoLog ERROR " - the file '${CT_SRC_DIR}/.${basename}.extracted'"
+        CT_DoLog ERROR " - the file '${CT_SRC_DIR}/.${basename}.patch'"
+        CT_DoLog ERROR " - the file '${CT_SRC_DIR}/.${basename}.configuring'"
+        CT_Abort
+    fi
+
+    CT_DoLog EXTRA "Using '${custom_overlay}' from ${custom_location}"
+    CT_DoExecLog DEBUG ln -sf "${custom_location}/${custom_overlay}" \
+                              "${CT_TARBALLS_DIR}/${custom_overlay}"
+
+    CT_DoExecLog DEBUG touch "${CT_SRC_DIR}/.${basename}.configuring"
+
+    CT_Pushd "${CT_SRC_DIR}/${basename}"
+
+    tar_opts=( "--strip-components=1" )
+    tar_opts+=( "-xv" )
+
+    case "${ext}" in
+        .tar)           CT_DoExecLog FILE tar "${tar_opts[@]}" -f "${full_file}" "${component}";;
+        .gz|.tgz)       gzip -dc "${full_file}" | CT_DoExecLog FILE tar "${tar_opts[@]}" -f - "${component}";;
+        .bz2)           bzip2 -dc "${full_file}" | CT_DoExecLog FILE tar "${tar_opts[@]}" -f - "${component}";;
+        *)              CT_DoLog WARN "Don't know how to handle '${basename}${ext}': unknown extension"
+                        return 1
+                        ;;
+    esac
+
+    CT_DoExecLog DEBUG touch "${CT_SRC_DIR}/.${basename}.configured"
+    CT_DoExecLog DEBUG rm -f "${CT_SRC_DIR}/.${basename}.configuring"
+
+    CT_Popd
+}

--- a/scripts/build/binutils/binutils.sh
+++ b/scripts/build/binutils/binutils.sh
@@ -46,6 +46,10 @@ do_binutils_extract() {
             CT_Patch "elf2flt" "${CT_ELF2FLT_GIT_CSET}"
         fi
     fi
+
+    if [ -n "${CT_ARCH_XTENSA_CUSTOM_NAME}" ]; then
+        CT_ConfigureXtensa "binutils" "${CT_BINUTILS_VERSION}"
+    fi
 }
 
 # Build binutils for build -> target

--- a/scripts/build/cc/100-gcc.sh
+++ b/scripts/build/cc/100-gcc.sh
@@ -63,6 +63,10 @@ do_gcc_extract() {
        ]; then
         CT_DoExecLog ALL cp -v "${CT_TARBALLS_DIR}/ecj-latest.jar" "${CT_SRC_DIR}/gcc-${CT_CC_GCC_VERSION}/ecj.jar"
     fi
+
+    if [ -n "${CT_ARCH_XTENSA_CUSTOM_NAME}" ]; then
+        CT_ConfigureXtensa "gcc" "${CT_CC_GCC_VERSION}"
+    fi
 }
 
 #------------------------------------------------------------------------------

--- a/scripts/build/debug/300-gdb.sh
+++ b/scripts/build/debug/300-gdb.sh
@@ -100,6 +100,10 @@ do_debug_gdb_extract() {
         CT_Extract "expat-${CT_DEBUG_GDB_EXPAT_VERSION}"
         CT_Patch "expat" "${CT_DEBUG_GDB_EXPAT_VERSION}"
     fi
+
+    if [ -n "${CT_ARCH_XTENSA_CUSTOM_NAME}" ]; then
+        CT_ConfigureXtensa "gdb" "${CT_GDB_VERSION}"
+    fi
 }
 
 do_debug_gdb_build() {

--- a/scripts/build/libc/newlib.sh
+++ b/scripts/build/libc/newlib.sh
@@ -38,6 +38,10 @@ do_libc_extract() {
 
     CT_Extract "newlib-${CT_LIBC_VERSION}"
     CT_Patch "newlib" "${CT_LIBC_VERSION}"
+
+    if [ -n "${CT_ARCH_XTENSA_CUSTOM_NAME}" ]; then
+        CT_ConfigureXtensa "newlib" "${CT_LIBC_VERSION}"
+    fi
 }
 
 do_libc_check_config() {
@@ -48,6 +52,11 @@ do_libc_start_files() {
     CT_DoStep INFO "Installing C library headers & start files"
     CT_DoExecLog ALL cp -a "${CT_SRC_DIR}/newlib-${CT_LIBC_VERSION}/newlib/libc/include/." \
     "${CT_HEADERS_DIR}"
+    if [ "${CT_ARCH_xtensa}" = "y" ]; then
+        CT_DoLog EXTRA "Installing Xtensa headers"
+        CT_DoExecLog ALL cp -r "${CT_SRC_DIR}/newlib-${CT_LIBC_VERSION}/newlib/libc/sys/xtensa/include/."   \
+                               "${CT_HEADERS_DIR}"
+    fi
     CT_EndStep
 }
 


### PR DESCRIPTION
Hi Bryan,

this series adds support for Xtensa architecture to crosstool-NG (issue #243).
There are architecture-specific patches for the latest binutils, gcc and gdb.
Patch for the newlib is not ready for mainline and needs more work.
Please let me know what you think.