### PR TITLE
configure: Correctly search for tinfo for kconfig

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -339,15 +339,6 @@ LIBS=$SAVE_LIBS
 AC_SUBST([INTL_LIBS])
 
 #----------------------------------------
-# Check for tinfo, for the kconfig frontends
-AC_SEARCH_LIBS(
-    [tigetnum],
-    [tinfo],
-    [ac_ct_tinfo_lib_found=yes; break])
-AS_IF(
-    [test -z "$ac_ct_tinfo_lib_found"],
-    [AC_MSG_ERROR([could not find tinfo library, required for the kconfig frontends])])
-
 # Check for ncurses, for the kconfig frontends
 AC_SUBST([ac_ct_curses_hdr])
 AC_CHECK_HEADERS(
@@ -363,6 +354,9 @@ AC_SEARCH_LIBS(
 AS_IF(
     [test -z "$ac_ct_curses_lib_found"],
     [AC_MSG_ERROR([could not find curses library, required for the kconfig frontends])])
+AC_SEARCH_LIBS(
+    [tgetent],
+    [termcap tinfo ncursesw ncurses curses])
 
 #--------------------------------------------------------------------
 # Lastly, take care of crosstool-NG internal values

--- a/kconfig/Makefile
+++ b/kconfig/Makefile
@@ -48,7 +48,7 @@ nconf_SRC = nconf.c nconf.gui.c
 nconf_OBJ = $(patsubst %.c,%.o,$(nconf_SRC))
 nconf_DEP = $(patsubst %.c,%.dep,$(nconf_SRC))
 $(nconf_OBJ) $(nconf_DEP): CFLAGS += $(INTL_CFLAGS) -I/usr/include/ncurses
-nconf: LDFLAGS += -lmenu -lpanel -lncurses
+nconf: LDFLAGS += -lmenu -lpanel $(LIBS)
 
 # These are generated files:
 ALL_OBJS = $(sort $(COMMON_OBJ) $(LX_OBJ) $(conf_OBJ) $(mconf_OBJ) $(nconf_OBJ))


### PR DESCRIPTION
I previously thought that tinfo could only be a link to libncurses in
modern ncurses installations. I was wrong.

Now we check for ncurses, then check for tinfo. If tinfo is a link to
ncurses, it is then not required to link against. But if libtinfo is
providing tgetent, and not libncurses, then we must add it to LIBS as
well.

Also, kconfig shouldn't hardcode -lncurses, it should use what is in
$(LIBS).

Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>