### PR TITLE
configure: fix search for gpatch for FreeBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -176,7 +176,7 @@ ACX_CHECK_PROGS_REQ([help2man], [help2man])
 #--------------------------------------------------------------------
 # Still boring, but remember the path, now...
 #--------------------------------------------------------------------
-ACX_PATH_PROGS_REQ([PATCH], [patch])
+ACX_PATH_TOOL_REQ([PATCH], [gpatch patch])
 
 #--------------------------------------------------------------------
 # And a bunch of less boring tests...


### PR DESCRIPTION
We require GNU/patch, and when we install patch with `pkg`, crosstool-ng
still only finds the BSD/patch in /usr/bin/patch.

This commit fixes that and searches for gpatch first.

Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>