### PR TITLE
Look for tigetnum after {n,}curses{w,}

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -338,16 +338,6 @@ AC_SEARCH_LIBS(bindtextdomain, intl, [test "$ac_res" = "none required" || INTL_L
 LIBS=$SAVE_LIBS
 AC_SUBST([INTL_LIBS])
 
-#----------------------------------------
-# Check for tinfo, for the kconfig frontends
-AC_SEARCH_LIBS(
-    [tigetnum],
-    [tinfo],
-    [ac_ct_tinfo_lib_found=yes; break])
-AS_IF(
-    [test -z "$ac_ct_tinfo_lib_found"],
-    [AC_MSG_ERROR([could not find tinfo library, required for the kconfig frontends])])
-
 # Check for ncurses, for the kconfig frontends
 AC_SUBST([ac_ct_curses_hdr])
 AC_CHECK_HEADERS(
@@ -363,6 +353,17 @@ AC_SEARCH_LIBS(
 AS_IF(
     [test -z "$ac_ct_curses_lib_found"],
     [AC_MSG_ERROR([could not find curses library, required for the kconfig frontends])])
+
+#----------------------------------------
+# Check for tinfo, for the kconfig frontends
+# .. may already have been found in {n,}curses{w,}
+AC_SEARCH_LIBS(
+    [tigetnum],
+    [tinfo],
+    [ac_ct_tigetnum_found=yes; break])
+AS_IF(
+    [test -z "$ac_ct_tigetnum_found"],
+    [AC_MSG_ERROR([could not find tigetnum function, required for the kconfig frontends])])
 
 #--------------------------------------------------------------------
 # Lastly, take care of crosstool-NG internal values


### PR DESCRIPTION
Often it's built into {n,}curses{w,} so this
arrangement fixes a build failure for systems
that don't have libtinfo.so.

Signed-off-by: Ray Donnelly <mingw.android@gmail.com>