### PR TITLE
uClibc-ng: Fix version prompt

### DIFF
--- a/config/libc/uClibc.in
+++ b/config/libc/uClibc.in
@@ -28,7 +28,7 @@ choice
 
 config LIBC_UCLIBC_NG_V_1_0_9
     bool
-    prompt "1.0.8"
+    prompt "1.0.9"
     select LIBC_UCLIBC_NG_1_0_9_or_later
 
 config LIBC_UCLIBC_V_0_9_33_2


### PR DESCRIPTION
In commit c9704c6683ee2ddab8be390f48f6c2de412b80dc, I forgot to bump the
version in the prompt for uClibc-ng-1.0.9.

Reported-by: Reinoud Koornstra <reinoudkoornstra@gmail.com>
Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>