### PR TITLE
consistency: Use exported variables of required tools

### DIFF
--- a/scripts/build/binutils/binutils.sh
+++ b/scripts/build/binutils/binutils.sh
@@ -8,7 +8,7 @@ do_binutils_get() {
         CT_GetCustom "binutils" "${CT_BINUTILS_VERSION}" \
                      "${CT_BINUTILS_CUSTOM_LOCATION}"
     else
-        if echo ${CT_BINUTILS_VERSION} |grep -q linaro; then
+        if echo ${CT_BINUTILS_VERSION} |${grep} -q linaro; then
             YYMM=`echo ${CT_BINUTILS_VERSION} |cut -d- -f3 |${sed} -e 's,^..,,'`
             CT_GetFile "binutils-${CT_BINUTILS_VERSION}"                                        \
                        https://releases.linaro.org/${YYMM}/components/toolchain/binutils-linaro \
@@ -233,14 +233,14 @@ do_binutils_backend() {
     if [ "${static_build}" = "y" ]; then
         extra_make_flags+=("LDFLAGS=-all-static")
         CT_DoLog EXTRA "Prepare binutils for static build"
-        CT_DoExecLog ALL make ${JOBSFLAGS} configure-host
+        CT_DoExecLog ALL ${make} ${JOBSFLAGS} configure-host
     fi
 
     CT_DoLog EXTRA "Building binutils"
-    CT_DoExecLog ALL make "${extra_make_flags[@]}" ${JOBSFLAGS}
+    CT_DoExecLog ALL ${make} "${extra_make_flags[@]}" ${JOBSFLAGS}
 
     CT_DoLog EXTRA "Installing binutils"
-    CT_DoExecLog ALL make install
+    CT_DoExecLog ALL ${make} install
 
     if [ "${build_manuals}" = "y" ]; then
         CT_DoLog EXTRA "Building and installing the binutils manuals"
@@ -250,8 +250,8 @@ do_binutils_backend() {
         fi
         manuals_install=( "${manuals_for[@]/#/install-pdf-}" )
         manuals_install+=( "${manuals_for[@]/#/install-html-}" )
-        CT_DoExecLog ALL make ${JOBSFLAGS} pdf html
-        CT_DoExecLog ALL make "${manuals_install[@]}"
+        CT_DoExecLog ALL ${make} ${JOBSFLAGS} pdf html
+        CT_DoExecLog ALL ${make} "${manuals_install[@]}"
     fi
 
     # Install the wrapper if needed
@@ -259,8 +259,8 @@ do_binutils_backend() {
         CT_DoLog EXTRA "Installing ld wrapper"
         rm -f "${prefix}/bin/${CT_TARGET}-ld"
         rm -f "${prefix}/${CT_TARGET}/bin/ld"
-        sed -r -e "s/@@DEFAULT_LD@@/${CT_BINUTILS_LINKER_DEFAULT}/" \
-            "${CT_LIB_DIR}/scripts/build/binutils/binutils-ld.in"   \
+        ${sed} -r -e "s/@@DEFAULT_LD@@/${CT_BINUTILS_LINKER_DEFAULT}/" \
+            "${CT_LIB_DIR}/scripts/build/binutils/binutils-ld.in"      \
             >"${prefix}/bin/${CT_TARGET}-ld"
         chmod +x "${prefix}/bin/${CT_TARGET}-ld"
         cp -a "${prefix}/bin/${CT_TARGET}-ld"   \
@@ -316,10 +316,10 @@ do_elf2flt_backend() {
         "${CT_ELF2FLT_EXTRA_CONFIG_ARRAY[@]}"
 
     CT_DoLog EXTRA "Building elf2flt"
-    CT_DoExecLog ALL make ${JOBSFLAGS}
+    CT_DoExecLog ALL ${make} ${JOBSFLAGS}
 
     CT_DoLog EXTRA "Installing elf2flt"
-    CT_DoExecLog ALL make install
+    CT_DoExecLog ALL ${make} install
 }
 
 # Now on for the target libraries
@@ -370,9 +370,9 @@ do_binutils_for_target() {
             "${CT_BINUTILS_EXTRA_CONFIG_ARRAY[@]}"
 
         CT_DoLog EXTRA "Building binutils' libraries (${targets[*]}) for target"
-        CT_DoExecLog ALL make ${JOBSFLAGS} "${build_targets[@]}"
+        CT_DoExecLog ALL ${make} ${JOBSFLAGS} "${build_targets[@]}"
         CT_DoLog EXTRA "Installing binutils' libraries (${targets[*]}) for target"
-        CT_DoExecLog ALL make DESTDIR="${CT_SYSROOT_DIR}" "${install_targets[@]}"
+        CT_DoExecLog ALL ${make} DESTDIR="${CT_SYSROOT_DIR}" "${install_targets[@]}"
 
         CT_Popd
         CT_EndStep

--- a/scripts/build/cc/100-gcc.sh
+++ b/scripts/build/cc/100-gcc.sh
@@ -461,23 +461,23 @@ do_gcc_core_backend() {
         # Next we have to configure gcc, create libgcc.mk then edit it...
         # So much easier if we just edit the source tree, but hey...
         if [ ! -f "${CT_SRC_DIR}/gcc-${CT_CC_GCC_VERSION}/gcc/BASE-VER" ]; then
-            CT_DoExecLog CFG make ${JOBSFLAGS} configure-libiberty
-            CT_DoExecLog ALL make ${JOBSFLAGS} -C libiberty libiberty.a
-            CT_DoExecLog CFG make ${JOBSFLAGS} configure-gcc configure-libcpp
-            CT_DoExecLog ALL make ${JOBSFLAGS} all-libcpp
+            CT_DoExecLog CFG ${make} ${JOBSFLAGS} configure-libiberty
+            CT_DoExecLog ALL ${make} ${JOBSFLAGS} -C libiberty libiberty.a
+            CT_DoExecLog CFG ${make} ${JOBSFLAGS} configure-gcc configure-libcpp
+            CT_DoExecLog ALL ${make} ${JOBSFLAGS} all-libcpp
         else
-            CT_DoExecLog CFG make ${JOBSFLAGS} configure-gcc configure-libcpp configure-build-libiberty
-            CT_DoExecLog ALL make ${JOBSFLAGS} all-libcpp all-build-libiberty
+            CT_DoExecLog CFG ${make} ${JOBSFLAGS} configure-gcc configure-libcpp configure-build-libiberty
+            CT_DoExecLog ALL ${make} ${JOBSFLAGS} all-libcpp all-build-libiberty
         fi
         # HACK: gcc-4.2 uses libdecnumber to build libgcc.mk, so build it here.
         if [ -d "${CT_SRC_DIR}/gcc-${CT_CC_GCC_VERSION}/libdecnumber" ]; then
-            CT_DoExecLog CFG make ${JOBSFLAGS} configure-libdecnumber
-            CT_DoExecLog ALL make ${JOBSFLAGS} -C libdecnumber libdecnumber.a
+            CT_DoExecLog CFG ${make} ${JOBSFLAGS} configure-libdecnumber
+            CT_DoExecLog ALL ${make} ${JOBSFLAGS} -C libdecnumber libdecnumber.a
         fi
         # HACK: gcc-4.8 uses libbacktrace to make libgcc.mvars, so make it here.
         if [ -d "${CT_SRC_DIR}/gcc-${CT_CC_GCC_VERSION}/libbacktrace" ]; then
-            CT_DoExecLog CFG make ${JOBSFLAGS} configure-libbacktrace
-            CT_DoExecLog ALL make ${JOBSFLAGS} -C libbacktrace
+            CT_DoExecLog CFG ${make} ${JOBSFLAGS} configure-libbacktrace
+            CT_DoExecLog ALL ${make} ${JOBSFLAGS} -C libbacktrace
         fi
 
         # Starting with GCC 4.3, libgcc.mk is no longer built,
@@ -503,9 +503,9 @@ do_gcc_core_backend() {
             repair_cc=""
         fi
 
-        CT_DoExecLog ALL make ${JOBSFLAGS} ${extra_user_env} -C gcc ${libgcc_rule} \
+        CT_DoExecLog ALL ${make} ${JOBSFLAGS} ${extra_user_env} -C gcc ${libgcc_rule} \
                               ${repair_cc}
-        sed -r -i -e 's@-lc@@g' gcc/${libgcc_rule}
+        ${sed} -r -i -e 's@-lc@@g' gcc/${libgcc_rule}
     else # build_libgcc
         core_targets=( gcc )
     fi   # ! build libgcc
@@ -534,10 +534,10 @@ do_gcc_core_backend() {
     esac
 
     CT_DoLog EXTRA "Building ${log_txt}"
-    CT_DoExecLog ALL make ${JOBSFLAGS} ${extra_user_env} ${core_targets_all}
+    CT_DoExecLog ALL ${make} ${JOBSFLAGS} ${extra_user_env} ${core_targets_all}
 
     CT_DoLog EXTRA "Installing ${log_txt}"
-    CT_DoExecLog ALL make ${JOBSFLAGS} ${extra_user_env} ${core_targets_install}
+    CT_DoExecLog ALL ${make} ${JOBSFLAGS} ${extra_user_env} ${core_targets_install}
 
     # Remove the libtool "pseudo-libraries": having them in the installed
     # tree makes the libtoolized utilities that are built next assume
@@ -551,9 +551,9 @@ do_gcc_core_backend() {
 
     if [ "${build_manuals}" = "yes" ]; then
         CT_DoLog EXTRA "Building the GCC manuals"
-        CT_DoExecLog ALL make pdf html
+        CT_DoExecLog ALL ${make} pdf html
         CT_DoLog EXTRA "Installing the GCC manuals"
-        CT_DoExecLog ALL make install-{pdf,html}-gcc
+        CT_DoExecLog ALL ${make} install-{pdf,html}-gcc
     fi
 
     # Create a symlink ${CT_TARGET}-cc to ${CT_TARGET}-gcc to always be able
@@ -937,17 +937,17 @@ do_gcc_backend() {
 
     if [ "${CT_CANADIAN}" = "y" ]; then
         CT_DoLog EXTRA "Building libiberty"
-        CT_DoExecLog ALL make ${JOBSFLAGS} all-build-libiberty
+        CT_DoExecLog ALL ${make} ${JOBSFLAGS} all-build-libiberty
     fi
 
     CT_DoLog EXTRA "Building final gcc compiler"
-    CT_DoExecLog ALL make ${JOBSFLAGS} all
+    CT_DoExecLog ALL ${make} ${JOBSFLAGS} all
 
     CT_DoLog EXTRA "Installing final gcc compiler"
     if [ "${CT_STRIP_TARGET_TOOLCHAIN_EXECUTABLES}" = "y" ]; then
-        CT_DoExecLog ALL make ${JOBSFLAGS} install-strip
+        CT_DoExecLog ALL ${make} ${JOBSFLAGS} install-strip
     else
-        CT_DoExecLog ALL make ${JOBSFLAGS} install
+        CT_DoExecLog ALL ${make} ${JOBSFLAGS} install
     fi
 
     # Remove the libtool "pseudo-libraries": having them in the installed
@@ -961,9 +961,9 @@ do_gcc_backend() {
 
     if [ "${build_manuals}" = "yes" ]; then
         CT_DoLog EXTRA "Building the GCC manuals"
-        CT_DoExecLog ALL make pdf html
+        CT_DoExecLog ALL ${make} pdf html
         CT_DoLog EXTRA "Installing the GCC manuals"
-        CT_DoExecLog ALL make install-{pdf,html}-gcc
+        CT_DoExecLog ALL ${make} install-{pdf,html}-gcc
     fi
 
     # Create a symlink ${CT_TARGET}-cc to ${CT_TARGET}-gcc to always be able

--- a/scripts/build/companion_libs/100-gmp.sh
+++ b/scripts/build/companion_libs/100-gmp.sh
@@ -103,15 +103,15 @@ do_gmp_backend() {
         "${extra_config}"
 
     CT_DoLog EXTRA "Building GMP"
-    CT_DoExecLog ALL make ${JOBSFLAGS}
+    CT_DoExecLog ALL ${make} ${JOBSFLAGS}
 
     if [ "${CT_COMPLIBS_CHECK}" = "y" ]; then
         CT_DoLog EXTRA "Checking GMP"
-        CT_DoExecLog ALL make ${JOBSFLAGS} -s check
+        CT_DoExecLog ALL ${make} ${JOBSFLAGS} -s check
     fi
 
     CT_DoLog EXTRA "Installing GMP"
-    CT_DoExecLog ALL make install
+    CT_DoExecLog ALL ${make} install
 }
 
 fi # CT_GMP

--- a/scripts/build/companion_libs/110-mpfr.sh
+++ b/scripts/build/companion_libs/110-mpfr.sh
@@ -53,12 +53,12 @@ do_mpfr_extract() {
                 # See: http://sourceware.org/ml/crossgcc/2008-11/msg00046.html
                 # and: http://sourceware.org/ml/crossgcc/2008-11/msg00048.html
                 libtoolize_opt=
-                case "$(libtoolize --version |head -n 1 |awk '{ print $(NF); }')" in
+                case "$(${libtoolize} --version |head -n 1 |${awk} '{ print $(NF); }')" in
                     0.*)    ;;
                     1.*)    ;;
                     *)      libtoolize_opt=-i;;
                 esac
-                CT_DoExecLog ALL libtoolize -f ${libtoolize_opt}
+                CT_DoExecLog ALL ${libtoolize} -f ${libtoolize_opt}
                 touch .autotools.ct-ng
             fi
             CT_Popd
@@ -146,15 +146,15 @@ do_mpfr_backend() {
         --enable-static
 
     CT_DoLog EXTRA "Building MPFR"
-    CT_DoExecLog ALL make ${JOBSFLAGS}
+    CT_DoExecLog ALL ${make} ${JOBSFLAGS}
 
     if [ "${CT_COMPLIBS_CHECK}" = "y" ]; then
         CT_DoLog EXTRA "Checking MPFR"
-        CT_DoExecLog ALL make ${JOBSFLAGS} -s check
+        CT_DoExecLog ALL ${make} ${JOBSFLAGS} -s check
     fi
 
     CT_DoLog EXTRA "Installing MPFR"
-    CT_DoExecLog ALL make install
+    CT_DoExecLog ALL ${make} install
 }
 
 fi # CT_MPFR

--- a/scripts/build/companion_libs/120-ppl.sh
+++ b/scripts/build/companion_libs/120-ppl.sh
@@ -127,15 +127,15 @@ do_ppl_backend() {
     # --enable-optimization=speed  or sspeed (yes, with 2 's')
 
     CT_DoLog EXTRA "Building PPL"
-    CT_DoExecLog ALL make ${JOBSFLAGS}
+    CT_DoExecLog ALL ${make} ${JOBSFLAGS}
 
     if [ "${CT_COMPLIBS_CHECK}" = "y" ]; then
         CT_DoLog EXTRA "Checking PPL"
-        CT_DoExecLog ALL make ${JOBSFLAGS} -s check
+        CT_DoExecLog ALL ${make} ${JOBSFLAGS} -s check
     fi
 
     CT_DoLog EXTRA "Installing PPL"
-    CT_DoExecLog ALL make install
+    CT_DoExecLog ALL ${make} install
 
     # Remove spuriously installed file
     CT_DoExecLog ALL rm -f "${prefix}/bin/ppl-config"

--- a/scripts/build/companion_libs/121-isl.sh
+++ b/scripts/build/companion_libs/121-isl.sh
@@ -122,15 +122,15 @@ do_isl_backend() {
         --with-clang=no
 
     CT_DoLog EXTRA "Building ISL"
-    CT_DoExecLog ALL make ${JOBSFLAGS}
+    CT_DoExecLog ALL ${make} ${JOBSFLAGS}
 
     if [ "${CT_COMPLIBS_CHECK}" = "y" ]; then
         CT_DoLog EXTRA "Checking ISL"
-        CT_DoExecLog ALL make ${JOBSFLAGS} -s check
+        CT_DoExecLog ALL ${make} ${JOBSFLAGS} -s check
     fi
 
     CT_DoLog EXTRA "Installing ISL"
-    CT_DoExecLog ALL make install
+    CT_DoExecLog ALL ${make} install
 }
 
 fi # CT_ISL

--- a/scripts/build/companion_libs/130-cloog.sh
+++ b/scripts/build/companion_libs/130-cloog.sh
@@ -142,15 +142,15 @@ do_cloog_backend() {
         "${cloog_opts[@]}"
 
     CT_DoLog EXTRA "Building CLooG"
-    CT_DoExecLog ALL make ${JOBSFLAGS} "${cloog_targets[@]}"
+    CT_DoExecLog ALL ${make} ${JOBSFLAGS} "${cloog_targets[@]}"
 
     if [ "${CT_COMPLIBS_CHECK}" = "y" ]; then
         CT_DoLog EXTRA "Checking CLooG"
-        CT_DoExecLog ALL make ${JOBSFLAGS} -s check
+        CT_DoExecLog ALL ${make} ${JOBSFLAGS} -s check
     fi
 
     CT_DoLog EXTRA "Installing CLooG"
-    CT_DoExecLog ALL make "${cloog_install_targets[@]}"
+    CT_DoExecLog ALL ${make} "${cloog_install_targets[@]}"
 }
 
 fi # CT_CLOOG

--- a/scripts/build/companion_libs/140-mpc.sh
+++ b/scripts/build/companion_libs/140-mpc.sh
@@ -97,15 +97,15 @@ do_mpc_backend() {
         --enable-static
 
     CT_DoLog EXTRA "Building MPC"
-    CT_DoExecLog ALL make ${JOBSFLAGS}
+    CT_DoExecLog ALL ${make} ${JOBSFLAGS}
 
     if [ "${CT_COMPLIBS_CHECK}" = "y" ]; then
         CT_DoLog EXTRA "Checking MPC"
-        CT_DoExecLog ALL make ${JOBSFLAGS} -s check
+        CT_DoExecLog ALL ${make} ${JOBSFLAGS} -s check
     fi
 
     CT_DoLog EXTRA "Installing MPC"
-    CT_DoExecLog ALL make install
+    CT_DoExecLog ALL ${make} install
 }
 
 fi # CT_MPC

--- a/scripts/build/companion_libs/200-libelf.sh
+++ b/scripts/build/companion_libs/200-libelf.sh
@@ -132,10 +132,10 @@ do_libelf_backend() {
         "${extra_config[@]}"
 
     CT_DoLog EXTRA "Building libelf"
-    CT_DoExecLog ALL make
+    CT_DoExecLog ALL ${make}
 
     CT_DoLog EXTRA "Installing libelf"
-    CT_DoExecLog ALL make instroot="${destdir}" install
+    CT_DoExecLog ALL ${make} instroot="${destdir}" install
 }
 
 fi # CT_LIBELF || CT_LIBELF_TARGET

--- a/scripts/build/companion_libs/210-expat.sh
+++ b/scripts/build/companion_libs/210-expat.sh
@@ -78,9 +78,9 @@ do_expat_backend() {
         --disable-shared
 
     CT_DoLog EXTRA "Building expat"
-    CT_DoExecLog ALL make ${JOBSFLAGS}
+    CT_DoExecLog ALL ${make} ${JOBSFLAGS}
     CT_DoLog EXTRA "Installing expat"
-    CT_DoExecLog ALL make install INSTALL_ROOT="${destdir}"
+    CT_DoExecLog ALL ${make} install INSTALL_ROOT="${destdir}"
 }
 
 fi

--- a/scripts/build/companion_libs/220-ncurses.sh
+++ b/scripts/build/companion_libs/220-ncurses.sh
@@ -144,9 +144,9 @@ do_ncurses_backend() {
     # it also builds ncurses anyway, and dedicated targets (install.includes and
     # install.progs) do not do well with parallel make (-jX).
     CT_DoLog EXTRA "Building ncurses"
-    CT_DoExecLog ALL make ${JOBSFLAGS}
+    CT_DoExecLog ALL ${make} ${JOBSFLAGS}
     CT_DoLog EXTRA "Installing ncurses"
-    CT_DoExecLog ALL make install
+    CT_DoExecLog ALL ${make} install
 }
 
 fi

--- a/scripts/build/companion_libs/320-libiconv.sh
+++ b/scripts/build/companion_libs/320-libiconv.sh
@@ -105,10 +105,10 @@ do_libiconv_backend() {
         "${extra_config[@]}"                                  \
 
     CT_DoLog EXTRA "Building libiconv"
-    CT_DoExecLog ALL make CC="${host}-gcc ${cflags}" ${JOBSFLAGS}
+    CT_DoExecLog ALL ${make} CC="${host}-gcc ${cflags}" ${JOBSFLAGS}
 
     CT_DoLog EXTRA "Installing libiconv"
-    CT_DoExecLog ALL make install CC="${host}-gcc ${cflags}"
+    CT_DoExecLog ALL ${make} install CC="${host}-gcc ${cflags}"
 }
 
 fi

--- a/scripts/build/companion_libs/330-gettext.sh
+++ b/scripts/build/companion_libs/330-gettext.sh
@@ -128,10 +128,10 @@ do_gettext_backend() {
         "${extra_config[@]}"
 
     CT_DoLog EXTRA "Building gettext"
-    CT_DoExecLog ALL make ${JOBSFLAGS}
+    CT_DoExecLog ALL ${make} ${JOBSFLAGS}
 
     CT_DoLog EXTRA "Installing gettext"
-    CT_DoExecLog ALL make install
+    CT_DoExecLog ALL ${make} install
 }
 
 fi

--- a/scripts/build/companion_tools/050-make.sh
+++ b/scripts/build/companion_tools/050-make.sh
@@ -20,10 +20,10 @@ do_companion_tools_make_build() {
 
     CT_DoExecLog CFG "${CT_SRC_DIR}/make-${CT_MAKE_VERSION}/configure" \
                      --prefix="${CT_BUILDTOOLS_PREFIX_DIR}"
-    CT_DoExecLog ALL make
-    CT_DoExecLog ALL make install
+    CT_DoExecLog ALL ${make}
+    CT_DoExecLog ALL ${make} install
     if [ "${CT_COMP_TOOLS_make_gmake}" = "y" ]; then
-        CT_DoExecLog ALL ln -sv make "${CT_BUILDTOOLS_PREFIX_DIR}/bin/gmake"
+        CT_DoExecLog ALL ln -sv ${make} "${CT_BUILDTOOLS_PREFIX_DIR}/bin/gmake"
     fi
     CT_Popd
     CT_EndStep

--- a/scripts/build/companion_tools/100-m4.sh
+++ b/scripts/build/companion_tools/100-m4.sh
@@ -20,8 +20,8 @@ do_companion_tools_m4_build() {
     CT_DoExecLog CFG \
     "${CT_SRC_DIR}/m4-${CT_M4_VERSION}/configure" \
         --prefix="${CT_BUILDTOOLS_PREFIX_DIR}"
-    CT_DoExecLog ALL make
-    CT_DoExecLog ALL make install
+    CT_DoExecLog ALL ${make}
+    CT_DoExecLog ALL ${make} install
     CT_Popd
     CT_EndStep
 }

--- a/scripts/build/companion_tools/200-autoconf.sh
+++ b/scripts/build/companion_tools/200-autoconf.sh
@@ -26,8 +26,8 @@ do_companion_tools_autoconf_build() {
     CT_DoExecLog CFG ${CONFIG_SHELL} \
     "${CT_SRC_DIR}/autoconf-${CT_AUTOCONF_VERSION}/configure" \
         --prefix="${CT_BUILDTOOLS_PREFIX_DIR}"
-    CT_DoExecLog ALL make
-    CT_DoExecLog ALL make install
+    CT_DoExecLog ALL ${make}
+    CT_DoExecLog ALL ${make} install
     CT_Popd
     CT_EndStep
 }

--- a/scripts/build/companion_tools/300-automake.sh
+++ b/scripts/build/companion_tools/300-automake.sh
@@ -21,8 +21,8 @@ do_companion_tools_automake_build() {
     CT_DoExecLog CFG \
     "${CT_SRC_DIR}/automake-${CT_AUTOMAKE_VERSION}/configure" \
         --prefix="${CT_BUILDTOOLS_PREFIX_DIR}"
-    CT_DoExecLog ALL make
-    CT_DoExecLog ALL make install
+    CT_DoExecLog ALL ${make}
+    CT_DoExecLog ALL ${make} install
     CT_Popd
     CT_EndStep
 }

--- a/scripts/build/companion_tools/400-libtool.sh
+++ b/scripts/build/companion_tools/400-libtool.sh
@@ -21,8 +21,8 @@ do_companion_tools_libtool_build() {
     CT_DoExecLog CFG \
     "${CT_SRC_DIR}/libtool-${CT_LIBTOOL_VERSION}/configure" \
         --prefix="${CT_BUILDTOOLS_PREFIX_DIR}"
-    CT_DoExecLog ALL make
-    CT_DoExecLog ALL make install
+    CT_DoExecLog ALL ${make}
+    CT_DoExecLog ALL ${make} install
     CT_Popd
     CT_EndStep
 }

--- a/scripts/build/debug/000-template.sh
+++ b/scripts/build/debug/000-template.sh
@@ -26,8 +26,8 @@ do_debug_foobar_build() {
     #     --host=${CT_TARGET}                                 \
     #     --prefix=/usr                                       \
     #     --foobar-options
-    # CT_DoExecLog ALL make
-    # CT_DoExecLog ALL make DESTDIR="${CT_SYSROOT_DIR}" install
+    # CT_DoExecLog ALL ${make}
+    # CT_DoExecLog ALL ${make} DESTDIR="${CT_SYSROOT_DIR}" install
     # CT_Popd
     :
 }

--- a/scripts/build/debug/100-dmalloc.sh
+++ b/scripts/build/debug/100-dmalloc.sh
@@ -47,11 +47,11 @@ do_debug_dmalloc_build() {
         "${extra_config[@]}"
 
     CT_DoLog EXTRA "Building dmalloc"
-    CT_DoExecLog ALL make
+    CT_DoExecLog ALL ${make}
 
     CT_DoLog EXTRA "Installing dmalloc"
-    CT_DoExecLog ALL make DESTDIR="${CT_SYSROOT_DIR}" installincs installlib
-    CT_DoExecLog ALL make DESTDIR="${CT_DEBUGROOT_DIR}" installutil
+    CT_DoExecLog ALL ${make} DESTDIR="${CT_SYSROOT_DIR}" installincs installlib
+    CT_DoExecLog ALL ${make} DESTDIR="${CT_DEBUGROOT_DIR}" installutil
 
     CT_EndStep
 }

--- a/scripts/build/debug/200-duma.sh
+++ b/scripts/build/debug/200-duma.sh
@@ -32,7 +32,7 @@ do_debug_duma_build() {
 
     # The shared library needs some love: some version have libduma.so.0.0,
     # while others have libduma.so.0.0.0
-    duma_so=$(make -n -p 2>&1 |grep -E '^libduma.so[^:]*:' |head -n 1 |cut -d : -f 1)
+    duma_so=$(${make} -n -p 2>&1 |${grep} -E '^libduma.so[^:]*:' |head -n 1 |cut -d : -f 1)
 
     libs=
     [ "${CT_DUMA_A}" = "y" ] && libs="${libs} libduma.a"
@@ -40,22 +40,22 @@ do_debug_duma_build() {
     libs="${libs# }"
     CT_DoLog EXTRA "Building libraries '${libs}'"
     CT_DoExecLog ALL                    \
-    make HOSTCC="${CT_BUILD}-gcc"       \
+    ${make} HOSTCC="${CT_BUILD}-gcc"    \
          CC="${CT_TARGET}-gcc"          \
          CXX="${CT_TARGET}-gcc"         \
          RANLIB="${CT_TARGET}-ranlib"   \
          DUMA_CPP="${DUMA_CPP}"         \
          ${libs}
     CT_DoLog EXTRA "Installing libraries '${libs}'"
-    CT_DoExecLog ALL install -m 644 ${libs} "${CT_SYSROOT_DIR}/usr/lib"
+    CT_DoExecLog ALL ${install} -m 644 ${libs} "${CT_SYSROOT_DIR}/usr/lib"
     if [ "${CT_DUMA_SO}" = "y" ]; then
         CT_DoLog EXTRA "Installing shared library link"
         ln -vsf ${duma_so} "${CT_SYSROOT_DIR}/usr/lib/libduma.so"   2>&1 |CT_DoLog ALL
         CT_DoLog EXTRA "Installing wrapper script"
         mkdir -p "${CT_DEBUGROOT_DIR}/usr/bin"
         # Install a simpler, smaller, safer wrapper than the one provided by D.U.M.A.
-        sed -r -e 's:^LIBDUMA_SO=.*:LIBDUMA_SO=/usr/lib/'"${duma_so}"':;'   \
-            "${CT_LIB_DIR}/scripts/build/debug/duma.in"                     \
+        ${sed} -r -e 's:^LIBDUMA_SO=.*:LIBDUMA_SO=/usr/lib/'"${duma_so}"':;'   \
+            "${CT_LIB_DIR}/scripts/build/debug/duma.in"                        \
             >"${CT_DEBUGROOT_DIR}/usr/bin/duma"
         chmod 755 "${CT_DEBUGROOT_DIR}/usr/bin/duma"
     fi

--- a/scripts/build/debug/300-gdb.sh
+++ b/scripts/build/debug/300-gdb.sh
@@ -117,15 +117,15 @@ do_debug_gdb_build() {
             "${CT_GDB_CROSS_EXTRA_CONFIG_ARRAY[@]}"
 
         CT_DoLog EXTRA "Building cross-gdb"
-        CT_DoExecLog ALL make ${JOBSFLAGS}
+        CT_DoExecLog ALL ${make} ${JOBSFLAGS}
 
         CT_DoLog EXTRA "Installing cross-gdb"
-        CT_DoExecLog ALL make install
+        CT_DoExecLog ALL ${make} install
 
         if [ "${CT_BUILD_MANUALS}" = "y" ]; then
             CT_DoLog EXTRA "Building and installing the cross-GDB manuals"
-            CT_DoExecLog ALL make ${JOBSFLAGS} pdf html
-            CT_DoExecLog ALL make install-{pdf,html}-gdb
+            CT_DoExecLog ALL ${make} ${JOBSFLAGS} pdf html
+            CT_DoExecLog ALL ${make} install-{pdf,html}-gdb
         fi
 
         if [ "${CT_GDB_INSTALL_GDBINIT}" = "y" ]; then
@@ -134,7 +134,7 @@ do_debug_gdb_build() {
             if [ -f "${CT_SRC_DIR}/gcc-${CT_CC_GCC_VERSION}/gcc/BASE-VER" ]; then
                 gcc_version=$( cat "${CT_SRC_DIR}/gcc-${CT_CC_GCC_VERSION}/gcc/BASE-VER" )
             else
-                gcc_version=$( sed -r -e '/version_string/!d; s/^.+= "([^"]+)".*$/\1/;'     \
+                gcc_version=$(${sed} -r -e '/version_string/!d; s/^.+= "([^"]+)".*$/\1/;'   \
                                    "${CT_SRC_DIR}/gcc-${CT_CC_GCC_VERSION}/gcc/version.c"   \
                              )
             fi
@@ -209,10 +209,10 @@ do_debug_gdb_build() {
             "${native_extra_config[@]}"
 
         CT_DoLog EXTRA "Building native gdb"
-        CT_DoExecLog ALL make ${JOBSFLAGS} CC=${CT_TARGET}-${CT_CC}
+        CT_DoExecLog ALL ${make} ${JOBSFLAGS} CC=${CT_TARGET}-${CT_CC}
 
         CT_DoLog EXTRA "Installing native gdb"
-        CT_DoExecLog ALL make DESTDIR="${CT_DEBUGROOT_DIR}" install
+        CT_DoExecLog ALL ${make} DESTDIR="${CT_DEBUGROOT_DIR}" install
 
         # Building a native gdb also builds a gdbserver
         find "${CT_DEBUGROOT_DIR}" -type f -name gdbserver -exec rm -fv {} \; 2>&1 |CT_DoLog ALL
@@ -276,10 +276,10 @@ do_debug_gdb_build() {
             "${gdbserver_extra_config[@]}"
 
         CT_DoLog EXTRA "Building gdbserver"
-        CT_DoExecLog ALL make ${JOBSFLAGS} CC=${CT_TARGET}-${CT_CC}
+        CT_DoExecLog ALL ${make} ${JOBSFLAGS} CC=${CT_TARGET}-${CT_CC}
 
         CT_DoLog EXTRA "Installing gdbserver"
-        CT_DoExecLog ALL make DESTDIR="${CT_DEBUGROOT_DIR}" install
+        CT_DoExecLog ALL ${make} DESTDIR="${CT_DEBUGROOT_DIR}" install
 
         CT_EndStep
     fi

--- a/scripts/build/debug/400-ltrace.sh
+++ b/scripts/build/debug/400-ltrace.sh
@@ -52,10 +52,10 @@ do_debug_ltrace_build() {
     fi
 
     CT_DoLog EXTRA "Building ltrace"
-    CT_DoExecLog ALL make
+    CT_DoExecLog ALL ${make}
 
     CT_DoLog EXTRA "Installing ltrace"
-    CT_DoExecLog ALL make DESTDIR="${CT_DEBUGROOT_DIR}" install
+    CT_DoExecLog ALL ${make} DESTDIR="${CT_DEBUGROOT_DIR}" install
 
     CT_Popd
     CT_EndStep

--- a/scripts/build/debug/500-strace.sh
+++ b/scripts/build/debug/500-strace.sh
@@ -28,10 +28,10 @@ do_debug_strace_build() {
         --prefix=/usr
 
     CT_DoLog EXTRA "Building strace"
-    CT_DoExecLog ALL make
+    CT_DoExecLog ALL ${make}
 
     CT_DoLog EXTRA "Installing strace"
-    CT_DoExecLog ALL make DESTDIR="${CT_DEBUGROOT_DIR}" install
+    CT_DoExecLog ALL ${make} DESTDIR="${CT_DEBUGROOT_DIR}" install
 
     CT_Popd
     CT_EndStep

--- a/scripts/build/internals.sh
+++ b/scripts/build/internals.sh
@@ -38,8 +38,8 @@ do_finish() {
             if [ -f "${CT_SRC_DIR}/gcc-${CT_CC_GCC_VERSION}/gcc/BASE-VER" ]; then
                 gcc_version=$( cat "${CT_SRC_DIR}/gcc-${CT_CC_GCC_VERSION}/gcc/BASE-VER" )
             else
-                gcc_version=$( sed -r -e '/version_string/!d; s/^.+= "([^"]+)".*$/\1/;'     \
-                                   "${CT_SRC_DIR}/gcc-${CT_CC_GCC_VERSION}/gcc/version.c"   \
+                gcc_version=$(${sed} -r -e '/version_string/!d; s/^.+= "([^"]+)".*$/\1/;' \
+                                   "${CT_SRC_DIR}/gcc-${CT_CC_GCC_VERSION}/gcc/version.c" \
                              )
             fi
             for _t in "bin/${CT_TARGET}-"*                                      \
@@ -62,28 +62,28 @@ do_finish() {
 
     if [ "${CT_BARE_METAL}" != "y" ]; then
         CT_DoLog EXTRA "Installing the populate helper"
-        sed -r -e 's|@@CT_TARGET@@|'"${CT_TARGET}"'|g;' \
-               -e 's|@@CT_install@@|'"${install}"'|g;'  \
-               -e 's|@@CT_bash@@|'"${bash}"'|g;'        \
-               -e 's|@@CT_grep@@|'"${grep}"'|g;'        \
-               -e 's|@@CT_make@@|'"${make}"'|g;'        \
-               -e 's|@@CT_sed@@|'"${sed}"'|g;'          \
-               "${CT_LIB_DIR}/scripts/populate.in"      \
+        ${sed} -r -e 's|@@CT_TARGET@@|'"${CT_TARGET}"'|g;' \
+               -e 's|@@CT_install@@|'"${install}"'|g;'     \
+               -e 's|@@CT_bash@@|'"${bash}"'|g;'           \
+               -e 's|@@CT_grep@@|'"${grep}"'|g;'           \
+               -e 's|@@CT_make@@|'"${make}"'|g;'           \
+               -e 's|@@CT_sed@@|'"${sed}"'|g;'             \
+               "${CT_LIB_DIR}/scripts/populate.in"         \
                >"${CT_PREFIX_DIR}/bin/${CT_TARGET}-populate"
         CT_DoExecLog ALL chmod 755 "${CT_PREFIX_DIR}/bin/${CT_TARGET}-populate"
     fi
 
     if [ "${CT_LIBC_XLDD}" = "y" ]; then
         CT_DoLog EXTRA "Installing a cross-ldd helper"
-        sed -r -e 's|@@CT_VERSION@@|'"${CT_VERSION}"'|g;'   \
-               -e 's|@@CT_TARGET@@|'"${CT_TARGET}"'|g;'     \
-               -e 's|@@CT_BITS@@|'"${CT_ARCH_BITNESS}"'|g;' \
-               -e 's|@@CT_install@@|'"${install}"'|g;'      \
-               -e 's|@@CT_bash@@|'"${bash}"'|g;'            \
-               -e 's|@@CT_grep@@|'"${grep}"'|g;'            \
-               -e 's|@@CT_make@@|'"${make}"'|g;'            \
-               -e 's|@@CT_sed@@|'"${sed}"'|g;'              \
-               "${CT_LIB_DIR}/scripts/xldd.in"              \
+        ${sed} -r -e 's|@@CT_VERSION@@|'"${CT_VERSION}"'|g;' \
+               -e 's|@@CT_TARGET@@|'"${CT_TARGET}"'|g;'      \
+               -e 's|@@CT_BITS@@|'"${CT_ARCH_BITNESS}"'|g;'  \
+               -e 's|@@CT_install@@|'"${install}"'|g;'       \
+               -e 's|@@CT_bash@@|'"${bash}"'|g;'             \
+               -e 's|@@CT_grep@@|'"${grep}"'|g;'             \
+               -e 's|@@CT_make@@|'"${make}"'|g;'             \
+               -e 's|@@CT_sed@@|'"${sed}"'|g;'               \
+               "${CT_LIB_DIR}/scripts/xldd.in"               \
                >"${CT_PREFIX_DIR}/bin/${CT_TARGET}-ldd"
         CT_DoExecLog ALL chmod 755 "${CT_PREFIX_DIR}/bin/${CT_TARGET}-ldd"
     fi
@@ -93,11 +93,11 @@ do_finish() {
     CT_Pushd "${CT_PREFIX_DIR}/bin"
     for t in "${CT_TARGET}-"*; do
         if [ -n "${CT_TARGET_ALIAS}" ]; then
-            _t=$(echo "$t" |sed -r -e 's/^'"${CT_TARGET}"'-/'"${CT_TARGET_ALIAS}"'-/;')
+            _t=$(echo "$t" |${sed} -r -e 's/^'"${CT_TARGET}"'-/'"${CT_TARGET_ALIAS}"'-/;')
             CT_DoExecLog ALL ln -sfv "${t}" "${_t}"
         fi
         if [ -n "${CT_TARGET_ALIAS_SED_EXPR}" ]; then
-            _t=$(echo "$t" |sed -r -e "${CT_TARGET_ALIAS_SED_EXPR}")
+            _t=$(echo "$t" |${sed} -r -e "${CT_TARGET_ALIAS_SED_EXPR}")
             if [ "${_t}" = "${t}" ]; then
                 CT_DoLog WARN "The sed expression '${CT_TARGET_ALIAS_SED_EXPR}' has no effect on '${t}'"
             else

--- a/scripts/build/kernel/linux.sh
+++ b/scripts/build/kernel/linux.sh
@@ -117,7 +117,7 @@ do_kernel_install() {
 
     CT_DoLog EXTRA "Installing kernel headers"
     CT_DoExecLog ALL                                    \
-    make -C "${kernel_path}"                            \
+    ${make} -C "${kernel_path}"                         \
          CROSS_COMPILE="${CT_TARGET}-"                  \
          O="${CT_BUILD_DIR}/build-kernel-headers"       \
          ARCH=${kernel_arch}                            \
@@ -128,7 +128,7 @@ do_kernel_install() {
     if [ "${CT_KERNEL_LINUX_INSTALL_CHECK}" = "y" ]; then
         CT_DoLog EXTRA "Checking installed headers"
         CT_DoExecLog ALL                                    \
-        make -C "${kernel_path}"                            \
+        ${make} -C "${kernel_path}"                         \
              CROSS_COMPILE="${CT_TARGET}-"                  \
              O="${CT_BUILD_DIR}/build-kernel-headers"       \
              ARCH=${kernel_arch}                            \

--- a/scripts/build/libc/avr-libc.sh
+++ b/scripts/build/libc/avr-libc.sh
@@ -62,10 +62,10 @@ do_libc_post_cc() {
     do_libc_configure
 
     CT_DoLog EXTRA "Building C library"
-    CT_DoExecLog ALL make ${JOBSFLAGS}
+    CT_DoExecLog ALL ${make} ${JOBSFLAGS}
 
     CT_DoLog EXTRA "Installing C library"
-    CT_DoExecLog ALL make install
+    CT_DoExecLog ALL ${make} install
 
     CT_EndStep
 }

--- a/scripts/build/libc/glibc.sh
+++ b/scripts/build/libc/glibc.sh
@@ -396,7 +396,7 @@ do_libc_backend_once() {
 
         # use the 'install-headers' makefile target to install the
         # headers
-        CT_DoExecLog ALL make ${JOBSFLAGS}                          \
+        CT_DoExecLog ALL ${make} ${JOBSFLAGS}                       \
                          install_root=${CT_SYSROOT_DIR}${extra_dir} \
                          install-bootstrap-headers=yes              \
                          "${extra_make_args[@]}"                    \
@@ -447,8 +447,8 @@ do_libc_backend_once() {
             # there are a few object files needed to link shared libraries,
             # which we build and install by hand
             CT_DoExecLog ALL mkdir -p "${CT_SYSROOT_DIR}${extra_dir}/usr/lib"
-            CT_DoExecLog ALL make ${JOBSFLAGS}  \
-                        "${extra_make_args[@]}" \
+            CT_DoExecLog ALL ${make} ${JOBSFLAGS} \
+                        "${extra_make_args[@]}"   \
                         csu/subdir_lib
             CT_DoExecLog ALL cp csu/crt1.o csu/crti.o csu/crtn.o    \
                                 "${CT_SYSROOT_DIR}${extra_dir}/usr/lib"
@@ -467,12 +467,12 @@ do_libc_backend_once() {
 
     if [ "${libc_full}" = "y" ]; then
         CT_DoLog EXTRA "Building C library"
-        CT_DoExecLog ALL make ${JOBSFLAGS}              \
-                              "${extra_make_args[@]}"   \
+        CT_DoExecLog ALL ${make} ${JOBSFLAGS}         \
+                              "${extra_make_args[@]}" \
                               all
 
         CT_DoLog EXTRA "Installing C library"
-        CT_DoExecLog ALL make ${JOBSFLAGS}                                  \
+        CT_DoExecLog ALL ${make} ${JOBSFLAGS}                               \
                               "${extra_make_args[@]}"                       \
                               install_root="${CT_SYSROOT_DIR}${extra_dir}"  \
                               install
@@ -481,7 +481,7 @@ do_libc_backend_once() {
             CT_DoLog EXTRA "Building and installing the C library manual"
             # Omit JOBSFLAGS as GLIBC has problems building the
             # manuals in parallel
-            CT_DoExecLog ALL make pdf html
+            CT_DoExecLog ALL ${make} pdf html
             CT_DoExecLog ALL mkdir -p ${CT_PREFIX_DIR}/share/doc
             CT_DoExecLog ALL cp -av ${src_dir}/manual/*.pdf    \
                                     ${src_dir}/manual/libc     \
@@ -497,8 +497,8 @@ do_libc_backend_once() {
 # Build up the addons list, separated with $1
 do_libc_add_ons_list() {
     local sep="$1"
-    local addons_list="$( echo "${CT_LIBC_ADDONS_LIST}"         \
-                          |sed -r -e "s/[[:space:],]/${sep}/g;" \
+    local addons_list="$( echo "${CT_LIBC_ADDONS_LIST}"            \
+                          |${sed} -r -e "s/[[:space:],]/${sep}/g;" \
                         )"
     if [ "${CT_LIBC_GLIBC_2_20_or_later}" != "y" ]; then
         case "${CT_THREADS}" in
@@ -508,7 +508,7 @@ do_libc_add_ons_list() {
     fi
     [ "${CT_LIBC_GLIBC_USE_PORTS}" = "y" ] && addons_list="${addons_list}${sep}ports"
     # Remove duplicate, leading and trailing separators
-    echo "${addons_list}" |sed -r -e "s/${sep}+/${sep}/g; s/^${sep}//; s/${sep}\$//;"
+    echo "${addons_list}" |${sed} -r -e "s/${sep}+/${sep}/g; s/^${sep}//; s/${sep}\$//;"
 }
 
 # Compute up the minimum supported Linux kernel version
@@ -527,8 +527,8 @@ do_libc_min_kernel_config() {
                 if [ ! -f "${version_code_file}" -o ! -r "${version_code_file}" ]; then
                     CT_Abort "Linux version is unavailable in installed headers files"
                 fi
-                version_code="$( grep -E LINUX_VERSION_CODE "${version_code_file}"  \
-                                 |cut -d ' ' -f 3                                   \
+                version_code="$(${grep} -E LINUX_VERSION_CODE "${version_code_file}"  \
+                                 |cut -d' ' -f 3                                      \
                                )"
                 version=$(((version_code>>16)&0xFF))
                 patchlevel=$(((version_code>>8)&0xFF))
@@ -536,8 +536,8 @@ do_libc_min_kernel_config() {
                 min_kernel_config="${version}.${patchlevel}.${sublevel}"
             elif [ "${CT_LIBC_GLIBC_KERNEL_VERSION_CHOSEN}" = "y" ]; then
                 # Trim the fourth part of the linux version, keeping only the first three numbers
-                min_kernel_config="$( echo "${CT_LIBC_GLIBC_MIN_KERNEL_VERSION}"            \
-                                      |sed -r -e 's/^([^.]+\.[^.]+\.[^.]+)(|\.[^.]+)$/\1/;' \
+                min_kernel_config="$( echo "${CT_LIBC_GLIBC_MIN_KERNEL_VERSION}"               \
+                                      |${sed} -r -e 's/^([^.]+\.[^.]+\.[^.]+)(|\.[^.]+)$/\1/;' \
                                     )"
             fi
             echo "--enable-kernel=${min_kernel_config}"
@@ -558,7 +558,7 @@ do_libc_get() {
         CT_GetCustom "glibc" "${CT_LIBC_VERSION}" "${CT_LIBC_GLIBC_CUSTOM_LOCATION}"
         CT_LIBC_CUSTOM_LOCATION="${CT_SRC_DIR}/glibc-${CT_LIBC_VERSION}"
     else
-        if echo ${CT_LIBC_VERSION} |grep -q linaro; then
+        if echo ${CT_LIBC_VERSION} |${grep} -q linaro; then
             # Linaro glibc releases come from regular downloads...
             YYMM=`echo ${CT_LIBC_VERSION} |cut -d- -f3 |${sed} -e 's,^..,,'`
             CT_GetFile "glibc-${CT_LIBC_VERSION}" \
@@ -657,19 +657,19 @@ do_libc_locales() {
 
     # Configure with --prefix the way we want it on the target...
 
-    CT_DoExecLog CFG                                                \
-    CFLAGS="${glibc_cflags}"                                        \
-    "${src_dir}/configure"                                          \
-        --prefix=/usr                                               \
-        --cache-file="$(pwd)/config.cache"                          \
-        --without-cvs                                               \
-        --disable-profile                                           \
-        --without-gd                                                \
-        --disable-debug                                             \
+    CT_DoExecLog CFG                       \
+    CFLAGS="${glibc_cflags}"               \
+    "${src_dir}/configure"                 \
+        --prefix=/usr                      \
+        --cache-file="$(pwd)/config.cache" \
+        --without-cvs                      \
+        --disable-profile                  \
+        --without-gd                       \
+        --disable-debug                    \
         "${extra_config[@]}"
 
     CT_DoLog EXTRA "Building C library localedef"
-    CT_DoExecLog ALL make ${JOBSFLAGS}
+    CT_DoExecLog ALL ${make} ${JOBSFLAGS}
 
     # The target's endianness and uint32_t alignment should be passed as options
     # to localedef, but glibc's localedef does not support these options, which
@@ -677,8 +677,8 @@ do_libc_locales() {
     # only if it has the same endianness and uint32_t alignment as the host's.
 
     CT_DoLog EXTRA "Installing C library locales"
-    CT_DoExecLog ALL make ${JOBSFLAGS}                              \
-                          install_root="${CT_SYSROOT_DIR}"          \
+    CT_DoExecLog ALL ${make} ${JOBSFLAGS}                  \
+                          install_root="${CT_SYSROOT_DIR}" \
                           localedata/install-locales
 }
 

--- a/scripts/build/libc/mingw.sh
+++ b/scripts/build/libc/mingw.sh
@@ -59,10 +59,10 @@ do_libc_start_files() {
         "${sdk_opts[@]}"
 
     CT_DoLog EXTRA "Compile Headers"
-    CT_DoExecLog ALL make
+    CT_DoExecLog ALL ${make}
 
     CT_DoLog EXTRA "Installing Headers"
-    CT_DoExecLog ALL make install DESTDIR=${CT_SYSROOT_DIR}
+    CT_DoExecLog ALL ${make} install DESTDIR=${CT_SYSROOT_DIR}
 
     CT_Popd
 
@@ -108,10 +108,10 @@ do_libc() {
     # parallel build. See https://github.com/crosstool-ng/crosstool-ng/issues/246
     # Do not pass ${JOBSFLAGS} - build serially.
     CT_DoLog EXTRA "Building mingw-w64-crt"
-    CT_DoExecLog ALL make
+    CT_DoExecLog ALL ${make}
 
     CT_DoLog EXTRA "Installing mingw-w64-crt"
-    CT_DoExecLog ALL make install DESTDIR=${CT_SYSROOT_DIR}
+    CT_DoExecLog ALL ${make} install DESTDIR=${CT_SYSROOT_DIR}
 
     CT_EndStep
 }

--- a/scripts/build/libc/musl.sh
+++ b/scripts/build/libc/musl.sh
@@ -84,9 +84,9 @@ do_libc_start_files() {
     do_libc_configure
 
     CT_DoLog EXTRA "Installing headers"
-    CT_DoExecLog ALL make DESTDIR="${CT_SYSROOT_DIR}" install-headers
+    CT_DoExecLog ALL ${make} DESTDIR="${CT_SYSROOT_DIR}" install-headers
 
-    CT_DoExecLog ALL make DESTDIR="${CT_SYSROOT_DIR}" \
+    CT_DoExecLog ALL ${make} DESTDIR="${CT_SYSROOT_DIR}" \
         crt/crt1.o crt/crti.o crt/crtn.o
     CT_DoExecLog ALL cp -av crt/crt*.o "${CT_SYSROOT_DIR}/usr/lib"
     CT_DoExecLog ALL ${CT_TARGET}-gcc -nostdlib \
@@ -106,10 +106,10 @@ do_libc() {
     do_libc_configure
 
     CT_DoLog EXTRA "Building C library"
-    CT_DoExecLog ALL make ${JOBSFLAGS}
+    CT_DoExecLog ALL ${make} ${JOBSFLAGS}
 
     CT_DoLog EXTRA "Installing C library"
-    CT_DoExecLog ALL make DESTDIR="${CT_SYSROOT_DIR}" install
+    CT_DoExecLog ALL ${make} DESTDIR="${CT_SYSROOT_DIR}" install
 
     CT_EndStep
 }

--- a/scripts/build/libc/newlib.sh
+++ b/scripts/build/libc/newlib.sh
@@ -17,7 +17,7 @@ do_libc_get() {
         CT_GetCustom "newlib" "${CT_LIBC_VERSION}"      \
                      "${CT_LIBC_NEWLIB_CUSTOM_LOCATION}"
     else # ! custom location
-        if echo ${CT_LIBC_VERSION} |grep -q linaro; then
+        if echo ${CT_LIBC_VERSION} |${grep} -q linaro; then
             YYMM=`echo ${CT_LIBC_VERSION} |cut -d- -f3 |${sed} -e 's,^..,,'`
             CT_GetFile "newlib-${CT_LIBC_VERSION}" ${libc_src} \
                        https://releases.linaro.org/${YYMM}/components/toolchain/newlib-linaro \
@@ -120,16 +120,16 @@ do_libc() {
         "${CT_LIBC_NEWLIB_EXTRA_CONFIG_ARRAY[@]}"
 
     CT_DoLog EXTRA "Building C library"
-    CT_DoExecLog ALL make ${JOBSFLAGS}
+    CT_DoExecLog ALL ${make} ${JOBSFLAGS}
 
     CT_DoLog EXTRA "Installing C library"
-    CT_DoExecLog ALL make install install_root="${CT_SYSROOT_DIR}"
+    CT_DoExecLog ALL ${make} install install_root="${CT_SYSROOT_DIR}"
 
     if [ "${CT_BUILD_MANUALS}" = "y" ]; then
         local -a doc_dir="${CT_BUILD_DIR}/build-libc/${CT_TARGET}"
 
         CT_DoLog EXTRA "Building and installing the C library manual"
-        CT_DoExecLog ALL make pdf html
+        CT_DoExecLog ALL ${make} pdf html
 
         # NEWLIB install-{pdf.html} fail for some versions
         CT_DoExecLog ALL mkdir -p "${CT_PREFIX_DIR}/share/doc/newlib"

--- a/scripts/build/libc/uClibc.sh
+++ b/scripts/build/libc/uClibc.sh
@@ -107,7 +107,7 @@ do_libc_start_files() {
     # newer ones that are referenced are not available
     CT_DoLog EXTRA "Applying configuration"
     CT_DoYes "" |CT_DoExecLog ALL                                   \
-                 make CROSS_COMPILE="${cross}"                      \
+                 ${make} CROSS_COMPILE="${cross}"                   \
                  UCLIBC_EXTRA_CFLAGS="-pipe"                        \
                  PREFIX="${CT_SYSROOT_DIR}/"                        \
                  LOCALE_DATA_FILENAME="${uclibc_local_tarball}.tgz" \
@@ -115,7 +115,7 @@ do_libc_start_files() {
 
     CT_DoLog EXTRA "Building headers"
     CT_DoExecLog ALL                                        \
-    make ${CT_LIBC_UCLIBC_VERBOSITY}                        \
+    ${make} ${CT_LIBC_UCLIBC_VERBOSITY}                     \
          CROSS_COMPILE="${cross}"                           \
          UCLIBC_EXTRA_CFLAGS="-pipe"                        \
          PREFIX="${CT_SYSROOT_DIR}/"                        \
@@ -124,7 +124,7 @@ do_libc_start_files() {
 
     CT_DoLog EXTRA "Installing headers"
     CT_DoExecLog ALL                                        \
-    make ${CT_LIBC_UCLIBC_VERBOSITY}                        \
+    ${make} ${CT_LIBC_UCLIBC_VERBOSITY}                     \
          CROSS_COMPILE="${cross}"                           \
          UCLIBC_EXTRA_CFLAGS="-pipe"                        \
          PREFIX="${CT_SYSROOT_DIR}/"                        \
@@ -134,7 +134,7 @@ do_libc_start_files() {
     if [ "${CT_THREADS}" = "nptl" ]; then
         CT_DoLog EXTRA "Building start files"
         CT_DoExecLog ALL                                        \
-        make ${CT_LIBC_UCLIBC_PARALLEL:+${JOBSFLAGS}}           \
+        ${make} ${CT_LIBC_UCLIBC_PARALLEL:+${JOBSFLAGS}}        \
              CROSS_COMPILE="${cross}"                           \
              UCLIBC_EXTRA_CFLAGS="-pipe"                        \
              PREFIX="${CT_SYSROOT_DIR}/"                        \
@@ -154,12 +154,12 @@ do_libc_start_files() {
                                        -o libdummy.so
 
         CT_DoLog EXTRA "Installing start files"
-        CT_DoExecLog ALL install -m 0644 lib/crt1.o lib/crti.o lib/crtn.o   \
+        CT_DoExecLog ALL ${install} -m 0644 lib/crt1.o lib/crti.o lib/crtn.o   \
                                          "${CT_SYSROOT_DIR}/usr/lib"
 
         CT_DoLog EXTRA "Installing dummy shared libs"
-        CT_DoExecLog ALL install -m 0755 libdummy.so "${CT_SYSROOT_DIR}/usr/lib/libc.so"
-        CT_DoExecLog ALL install -m 0755 libdummy.so "${CT_SYSROOT_DIR}/usr/lib/libm.so"
+        CT_DoExecLog ALL ${install} -m 0755 libdummy.so "${CT_SYSROOT_DIR}/usr/lib/libc.so"
+        CT_DoExecLog ALL ${install} -m 0755 libdummy.so "${CT_SYSROOT_DIR}/usr/lib/libm.so"
     fi # CT_THREADS == nptl
 
     CT_EndStep
@@ -187,7 +187,7 @@ do_libc() {
     # use LIBC_EXTRA_CFLAGS here.
     CT_DoLog EXTRA "Applying configuration"
     CT_DoYes "" |CT_DoExecLog CFG                                   \
-                 make CROSS_COMPILE=${CT_TARGET}-                   \
+                 ${make} CROSS_COMPILE=${CT_TARGET}-                \
                  UCLIBC_EXTRA_CFLAGS="-pipe"                        \
                  PREFIX="${CT_SYSROOT_DIR}/"                        \
                  LOCALE_DATA_FILENAME="${uclibc_local_tarball}.tgz" \
@@ -198,7 +198,7 @@ do_libc() {
     # /Old/ versions can not build in //
     CT_DoLog EXTRA "Building C library"
     CT_DoExecLog ALL                                        \
-    make -j1                                                \
+    ${make} -j1                                             \
          CROSS_COMPILE=${CT_TARGET}-                        \
          UCLIBC_EXTRA_CFLAGS="-pipe"                        \
          PREFIX="${CT_SYSROOT_DIR}/"                        \
@@ -207,7 +207,7 @@ do_libc() {
          LOCALE_DATA_FILENAME="${uclibc_local_tarball}.tgz" \
          pregen
     CT_DoExecLog ALL                                        \
-    make ${CT_LIBC_UCLIBC_PARALLEL:+${JOBSFLAGS}}           \
+    ${make} ${CT_LIBC_UCLIBC_PARALLEL:+${JOBSFLAGS}}        \
          CROSS_COMPILE=${CT_TARGET}-                        \
          UCLIBC_EXTRA_CFLAGS="-pipe"                        \
          PREFIX="${CT_SYSROOT_DIR}/"                        \
@@ -232,7 +232,7 @@ do_libc() {
     #
     CT_DoLog EXTRA "Installing C library"
     CT_DoExecLog ALL                                        \
-    make CROSS_COMPILE=${CT_TARGET}-                        \
+    ${make} CROSS_COMPILE=${CT_TARGET}-                     \
          UCLIBC_EXTRA_CFLAGS="-pipe"                        \
          PREFIX="${CT_SYSROOT_DIR}/"                        \
          STRIPTOOL=true                                     \

--- a/scripts/build/test_suite/gcc.sh
+++ b/scripts/build/test_suite/gcc.sh
@@ -21,7 +21,7 @@ do_test_suite_gcc_build() {
                             "${CT_SRC_DIR}/gcc-${CT_CC_GCC_VERSION}/gcc/testsuite"  \
                             "${CT_TEST_SUITE_DIR}/gcc"
 
-    CT_DoExecLog ALL sed -i -r -e "s/@@DG_TARGET@@/${CT_TARGET}/g;"     \
+    CT_DoExecLog ALL ${sed} -i -r -e "s/@@DG_TARGET@@/${CT_TARGET}/g;"     \
                          "${CT_TEST_SUITE_DIR}/gcc/Makefile"
 
     CT_EndStep

--- a/scripts/crosstool-NG.sh.in
+++ b/scripts/crosstool-NG.sh.in
@@ -517,7 +517,7 @@ if [ -z "${CT_RESTART}" ]; then
     JOBSFLAGS=
     # Override the configured jobs with what's been given on the command line
     if [ -n "${CT_JOBS}" ]; then
-        if [ ! -z "`echo "${CT_JOBS}" | sed 's/[0-9]//g'`" ]; then
+        if [ ! -z "`echo "${CT_JOBS}" | ${sed} 's/[0-9]//g'`" ]; then
             CT_Abort "Number of parallel jobs must be integer."
         fi
         CT_PARALLEL_JOBS="${CT_JOBS}"
@@ -569,7 +569,7 @@ if [ -z "${CT_RESTART}" ]; then
     # not our mangled .config.2 with arrays.
     CT_DoLog EXTRA "Installing user-supplied crosstool-NG configuration"
     CT_DoExecLog ALL mkdir -p "${CT_PREFIX_DIR}/bin"
-    CT_DoExecLog DEBUG install -m 0755 "${CT_LIB_DIR}/scripts/toolchain-config.in" "${CT_PREFIX_DIR}/bin/${CT_TARGET}-ct-ng.config"
+    CT_DoExecLog DEBUG ${install} -m 0755 "${CT_LIB_DIR}/scripts/toolchain-config.in" "${CT_PREFIX_DIR}/bin/${CT_TARGET}-ct-ng.config"
     CT_DoExecLog DEBUG ${sed} -i -e 's,@@grep@@,"'"${grep}"'",;' "${CT_PREFIX_DIR}/bin/${CT_TARGET}-ct-ng.config"
     bzip2 -c -9 .config >>"${CT_PREFIX_DIR}/bin/${CT_TARGET}-ct-ng.config"
 

--- a/scripts/functions
+++ b/scripts/functions
@@ -478,7 +478,7 @@ CT_DoForceRmdir() {
 # Echoes the specified string on stdout until the pipe breaks.
 # Doesn't fail
 # $1: string to echo
-# Usage: CT_DoYes "" |make oldconfig
+# Usage: CT_DoYes "" |${make} oldconfig
 CT_DoYes() {
     yes "$1" || true
 }
@@ -1117,7 +1117,7 @@ CT_Patch() {
         if [ -n "${d}" -a -d "${d}" ]; then
             for p in "${d}"/*.patch; do
                 if [ -f "${p}" ]; then
-                    CT_DoExecLog ALL patch --no-backup-if-mismatch -g0 -F1 -p1 -f -i "${p}"
+                    CT_DoExecLog ALL ${patch} --no-backup-if-mismatch -g0 -F1 -p1 -f -i "${p}"
                 fi
             done
             if [ "${CT_PATCH_SINGLE}" = "y" ]; then
@@ -1363,7 +1363,7 @@ CT_DoSaveState() {
     # We must omit shell functions, and some specific bash variables
     # that break when restoring the environment, later. We could do
     # all the processing in the awk script, but a sed is easier...
-    set |awk '
+    set |${awk} '
               BEGIN { _p = 1; }
               $0~/^[^ ]+ \(\)/ { _p = 0; }
               _p == 1

--- a/scripts/populate.in
+++ b/scripts/populate.in
@@ -8,6 +8,7 @@ set -e
 install="@@CT_install@@"
 grep="@@CT_grep@@"
 sed="@@CT_sed@@"
+awk="@@CT_awk@@"
 
 # Detect where the toolchain is:
 CT_PREFIX_DIR="$(cd "$(dirname "$0")/.."; pwd)"
@@ -149,8 +150,8 @@ if [ -d "${CT_ROOT_DST_DIR}" ]; then
                 ;;
     esac
 fi
-src_inode=$(ls -1id "${CT_ROOT_SRC_DIR}/." |awk '{ print $1 }')
-dst_inode=$(ls -1id "${CT_ROOT_DST_DIR}/." 2>/dev/null |awk '{ print $1 }')
+src_inode=$(ls -1id "${CT_ROOT_SRC_DIR}/." |${awk} '{ print $1 }')
+dst_inode=$(ls -1id "${CT_ROOT_DST_DIR}/." 2>/dev/null |${awk} '{ print $1 }')
 if [ "${src_inode}" -eq "$((dst_inode+0))" ]; then
     printf "$myname: source and destination are the same!\n"
     exit 1
@@ -273,7 +274,7 @@ fi
 # Create a temporary place where to store... temp files.
 rand="$( dd if=/dev/urandom bs=1024 count=1 2>/dev/null \
          |md5sum                                        \
-         |awk '{ print $1; }'
+         |${awk} '{ print $1; }'
        )"
 CT_TMP_DIR="${TMPDIR:-/tmp}/populate-${rand}-${$}"
 ( umask 0077; mkdir "${CT_TMP_DIR}" ) || { printf "Could not create temporary directory\n"; exit 1; }

--- a/scripts/xldd.in
+++ b/scripts/xldd.in
@@ -158,8 +158,8 @@ fi
 
 sysroot="$( "${gcc}" -print-sysroot 2>/dev/null )"
 if [ -z "${sysroot}" ]; then
-    sysroot="$( "${gcc}" -print-file-name=libc.so 2>/dev/null   \
-                |sed -r -e 's:/usr/lib/libc.so$::;'             \
+    sysroot="$( "${gcc}" -print-file-name=libc.so 2>/dev/null \
+                |${sed} -r -e 's:/usr/lib/libc.so$::;'        \
               )"
 fi
 if [ -z "${sysroot}" ]; then


### PR DESCRIPTION
We check for apps:

* make
* sed
* grep
* awk
* libtool/libtoolize
* install
* patch
* and more

...during configure. Our scripts should be consistent about using the
variables that define where the found tool was found.

Of course, we do hard-link these tools in buildtools, but that should be
a backup for the components we are building. Our scripts should always
use the tools we find.

Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>