### PR TITLE
Create symlinks for mingw

### DIFF
--- a/scripts/build/libc/mingw.sh
+++ b/scripts/build/libc/mingw.sh
@@ -65,7 +65,16 @@ do_libc_start_files() {
     # It seems mingw is strangely set up to look into /mingw instead of
     # /usr (notably when looking for the headers). This symlink is
     # here to workaround this, and seems to be here to last... :-/
-    CT_DoExecLog ALL ln -sv "usr/${CT_TARGET}" "${CT_SYSROOT_DIR}/mingw"
+    CT_DoExecLog ALL ln -sv "${MINGW_INSTALL_PREFIX#/}" "${CT_SYSROOT_DIR}/mingw"
+
+    # Also create symlinks for companion libraries that want to install
+    # into /usr/lib and /usr/include
+    if [ "${MINGW_INSTALL_PREFIX}" = "/usr/${CT_TARGET}" ]; then
+        CT_DoExecLog ALL rmdir "${CT_SYSROOT_DIR}/usr/include"
+        CT_DoExecLog ALL ln -sv "${CT_TARGET}/include" "${CT_SYSROOT_DIR}/usr/include"
+        CT_DoExecLog ALL rmdir "${CT_SYSROOT_DIR}/usr/lib"
+        CT_DoExecLog ALL ln -sv "${CT_TARGET}/lib" "${CT_SYSROOT_DIR}/usr/lib"
+    fi
 
     CT_EndStep
 }


### PR DESCRIPTION
Mingw GCC is configured to look into mingw/include and mingw/lib. Mingw
is itself a symlink to usr/$(CT_TARGET), so the headers/libs end up in
$sysroot/usr/$(CT_TARGET)/include and $sysroot/usr/$(CT_TARGET)/lib. By
default, configure uses /usr prefix (not /usr/$(CT_TARGET)), for install
prefix of the companion libs/tools - so create symlinks from usr/include
and usr/lib to the respective mingw locations.

The right approach, perhaps, would be to make that /usr prefix
overridable (and override it in mingw.sh). However, this will require
changing all the *_for_target() methods, and it is not very testable
right now as some companion tools/libs fail to build in mingw.

With this change, mingw config with native-gdb enabled builds ok - but
fails later (at the `finish' stage), while stripping the gdbserver
(apparently, it doesn't expect .exe suffix on it).

As a side note, mingw builds seem kind of fragile still. Perhaps, mark
them EXPERIMENTAL in 1.22.0?

Signed-off-by: Alexey Neyman stilor@att.net
