### PR TITLE
scripts: Be less sensitive to case sensitivity

### DIFF
--- a/scripts/crosstool-NG.sh.in
+++ b/scripts/crosstool-NG.sh.in
@@ -88,10 +88,12 @@ CT_WORK_DIR="${CT_WORK_DIR:-${CT_TOP_DIR}/.build}"
 CT_DoExecLog ALL mkdir -p "${CT_WORK_DIR}"
 CT_DoExecLog DEBUG rm -f "${CT_WORK_DIR}/backtrace"
 
-# Check build file system case-sensitiveness
-CT_DoExecLog DEBUG touch "${CT_WORK_DIR}/foo"
-CT_TestAndAbort "Your file system in '${CT_WORK_DIR}' is *not* case-sensitive!" -f "${CT_WORK_DIR}/FOO"
-CT_DoExecLog DEBUG rm -f "${CT_WORK_DIR}/foo"
+if [ "${CT_LIBC}" = "glibc" -o "${CT_KERNEL}" = "linux" ]; then
+    # Check build file system case-sensitiveness
+    CT_DoExecLog DEBUG touch "${CT_WORK_DIR}/foo"
+    CT_TestAndAbort "Your file system in '${CT_WORK_DIR}' is *not* case-sensitive!" -f "${CT_WORK_DIR}/FOO"
+    CT_DoExecLog DEBUG rm -f "${CT_WORK_DIR}/foo"
+fi
 
 # Check the user is using an existing SHELL to be used by ./configure and Makefiles
 CT_TestOrAbort "The CONFIG_SHELL '${CT_CONFIG_SHELL}' is not valid" -f "${CT_CONFIG_SHELL}" -a -x "${CT_CONFIG_SHELL}"
@@ -270,10 +272,12 @@ CT_DoExecLog ALL mkdir -p "${CT_HOST_COMPLIBS_DIR}"
 # Only create the state dir if asked for a restartable build
 [ -n "${CT_DEBUG_CT_SAVE_STEPS}" ] && CT_DoExecLog ALL mkdir -p "${CT_STATE_DIR}"
 
-# Check install file system case-sensitiveness
-CT_DoExecLog DEBUG touch "${CT_PREFIX_DIR}/foo"
-CT_TestAndAbort "Your file system in '${CT_PREFIX_DIR}' is *not* case-sensitive!" -f "${CT_PREFIX_DIR}/FOO"
-CT_DoExecLog DEBUG rm -f "${CT_PREFIX_DIR}/foo"
+if [ "${CT_LIBC}" = "glibc" -o "${CT_KERNEL}" = "linux" ]; then
+    # Check install file system case-sensitiveness
+    CT_DoExecLog DEBUG touch "${CT_PREFIX_DIR}/foo"
+    CT_TestAndAbort "Your file system in '${CT_PREFIX_DIR}' is *not* case-sensitive!" -f "${CT_PREFIX_DIR}/FOO"
+    CT_DoExecLog DEBUG rm -f "${CT_PREFIX_DIR}/foo"
+fi
 
 # Kludge: CT_INSTALL_DIR and CT_PREFIX_DIR might have grown read-only if
 # the previous build was successful.


### PR DESCRIPTION
It only matters for The Linux Kernel and glibc so let's not
fail on other setups. Although OS X HFS+ can be formatted as
case sensitive, and the Windows Registry has a flag to enable
it too, they are not the default and many things go wrong when
they are enabled due to years of neglect and ignorance.

Signed-off-by: Ray Donnelly <mingw.android@gmail.com>