### PR TITLE
Makefile.in: Fix uninstall target

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -382,7 +382,7 @@ install-post:
 #--------------------------------------
 # Uninstall rules
 
-real-uninstall: $(patsubst %,uninstall-%,$(TARGETS))
+real-uninstall: $(patsubst %,uninstall-%,$(filter-out lib-kconfig,$(TARGETS)))
 
 uninstall-bin:
 	@echo "  RM      '$(DESTDIR)$(bindir)/$(PROG_NAME)'"


### PR DESCRIPTION
`make uninstall` is ran against `$(TARGETS)`, which includes `lib-kconfig`.
`lib-kconfig` is installed as a part of the `lib` target, so during
uninstall, removing `lib` is enough to also remove `lib-kconfig`.

Filter out `lib-kconfig` during `real-uninstall`.

Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>