### PR TITLE
uClibc: remove references to sh64*

### DIFF
--- a/scripts/build/libc/uClibc.sh
+++ b/scripts/build/libc/uClibc.sh
@@ -260,7 +260,6 @@ manage_uClibc_config() {
         x86:32)      arch=i386;;
         x86:64)      arch=x86_64;;
         sh:32)       arch="sh";;
-        sh:64)       arch="sh64";;
         *)           arch="${CT_ARCH}";;
     esac
     # Also remove stripping: its the responsibility of the


### PR DESCRIPTION
As per the change notes of GCC-6:

https://gcc.gnu.org/gcc-6/changes.html

and conversations I've had with the buildroot folks, there is no need
to support sh5/sh64.

Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>