### PR TITLE
Fixes binutils and gold (raspi2 sample builds ok if you disable the static toolchain options)

### DIFF
--- a/patches/binutils/2.25.1/340-Darwin-gold-binary-cc-include-string-not-cstring.patch
+++ b/patches/binutils/2.25.1/340-Darwin-gold-binary-cc-include-string-not-cstring.patch
@@ -1,0 +1,11 @@
+--- binutils-2.25.orig/gold/binary.cc	2015-06-09 10:48:32.000000000 +0100
++++ binutils-2.25/gold/binary.cc	2015-06-09 10:49:23.000000000 +0100
+@@ -23,7 +23,7 @@
+ #include "gold.h"
+ 
+ #include <cerrno>
+-#include <cstring>
++#include <string>
+ #include "safe-ctype.h"
+ 
+ #include "elfcpp.h"

--- a/patches/binutils/2.25.1/350-Darwin-Two-fixes-from-Android-NDK-PTHREAD_ONCE_INIT-wcsncasecmp.patch
+++ b/patches/binutils/2.25.1/350-Darwin-Two-fixes-from-Android-NDK-PTHREAD_ONCE_INIT-wcsncasecmp.patch
@@ -1,0 +1,77 @@
+From c39479f4ab4d372b518957871e1f205a03e7c3d6 Mon Sep 17 00:00:00 2001
+From: Andrew Hsieh <andrewhsieh@google.com>
+Date: Wed, 18 Mar 2015 10:57:24 +0800
+Subject: [PATCH] Fix darwin build
+
+1. In Drawin PTHREAD_ONCE_INIT is {0x30B1BCBA, {0}} and the GCC < 4.4
+   doesn't support ended initializer list
+2. wcsncasecmp doesn't exist in MacSDK10.6.x
+
+Change-Id: I69204a72f853f5263dffedc448379d75ed4eca2e
+---
+ binutils-2.25/bfd/peXXigen.c       | 22 ++++++++++++++++++++++
+ binutils-2.25/gold/gold-threads.cc | 15 ++++++++++++---
+ 2 files changed, 34 insertions(+), 3 deletions(-)
+
+diff --git binutils-2.25.orig/bfd/peXXigen.c binutils-2.25/bfd/peXXigen.c
+index 13e39e4..7a98306 100644
+--- binutils-2.25.orig/bfd/peXXigen.c
++++ binutils-2.25/bfd/peXXigen.c
+@@ -3522,6 +3522,28 @@ u16_mbtouc (wchar_t * puc, const unsigned short * s, unsigned int n)
+ }
+ #endif /* HAVE_WCHAR_H and not Cygwin/Mingw */
+ 
++#ifdef __APPLE__
++/* wcsncasecmp isn't always defined in Mac SDK */
++static int
++wcsncasecmp(const wchar_t *s1, const wchar_t *s2, size_t n)
++{
++  wchar_t c1, c2;
++
++  if (n == 0)
++    return (0);
++  for (; *s1; s1++, s2++)
++  {
++    c1 = towlower(*s1);
++    c2 = towlower(*s2);
++    if (c1 != c2)
++      return ((int)c1 - c2);
++    if (--n == 0)
++      return (0);
++  }
++  return (-*s2);
++}
++#endif
++
+ /* Perform a comparison of two entries.  */
+ static signed int
+ rsrc_cmp (bfd_boolean is_name, rsrc_entry * a, rsrc_entry * b)
+diff --git binutils-2.25.orig/gold/gold-threads.cc binutils-2.25/gold/gold-threads.cc
+index ff5a8ac..45140e0 100644
+--- binutils-2.25.orig/gold/gold-threads.cc
++++ binutils-2.25/gold/gold-threads.cc
+@@ -284,9 +284,18 @@ Condvar::~Condvar()
+ class Once_initialize
+ {
+  public:
+-  Once_initialize()
+-    : once_(PTHREAD_ONCE_INIT)
+-  { }
++   Once_initialize()
++#if !defined(__APPLE__)
++     : once_(PTHREAD_ONCE_INIT)
++   { }
++#else
++// In Drawin PTHREAD_ONCE_INIT is {0x30B1BCBA, {0}} and the GCC < 4.4 doesn't support
++// extended initializer list as above */
++   {
++     pthread_once_t once_2 = PTHREAD_ONCE_INIT;
++     once_ = once_2; 
++   }
++#endif
+ 
+   // Return a pointer to the pthread_once_t variable.
+   pthread_once_t*
+-- 
+2.1.3
+

--- a/patches/binutils/2.25/340-Darwin-gold-binary-cc-include-string-not-cstring.patch
+++ b/patches/binutils/2.25/340-Darwin-gold-binary-cc-include-string-not-cstring.patch
@@ -1,0 +1,11 @@
+--- binutils-2.25.orig/gold/binary.cc	2015-06-09 10:48:32.000000000 +0100
++++ binutils-2.25/gold/binary.cc	2015-06-09 10:49:23.000000000 +0100
+@@ -23,7 +23,7 @@
+ #include "gold.h"
+ 
+ #include <cerrno>
+-#include <cstring>
++#include <string>
+ #include "safe-ctype.h"
+ 
+ #include "elfcpp.h"

--- a/patches/binutils/2.25/350-Darwin-Two-fixes-from-Android-NDK-PTHREAD_ONCE_INIT-wcsncasecmp.patch
+++ b/patches/binutils/2.25/350-Darwin-Two-fixes-from-Android-NDK-PTHREAD_ONCE_INIT-wcsncasecmp.patch
@@ -1,0 +1,77 @@
+From c39479f4ab4d372b518957871e1f205a03e7c3d6 Mon Sep 17 00:00:00 2001
+From: Andrew Hsieh <andrewhsieh@google.com>
+Date: Wed, 18 Mar 2015 10:57:24 +0800
+Subject: [PATCH] Fix darwin build
+
+1. In Drawin PTHREAD_ONCE_INIT is {0x30B1BCBA, {0}} and the GCC < 4.4
+   doesn't support ended initializer list
+2. wcsncasecmp doesn't exist in MacSDK10.6.x
+
+Change-Id: I69204a72f853f5263dffedc448379d75ed4eca2e
+---
+ binutils-2.25/bfd/peXXigen.c       | 22 ++++++++++++++++++++++
+ binutils-2.25/gold/gold-threads.cc | 15 ++++++++++++---
+ 2 files changed, 34 insertions(+), 3 deletions(-)
+
+diff --git binutils-2.25.orig/bfd/peXXigen.c binutils-2.25/bfd/peXXigen.c
+index 13e39e4..7a98306 100644
+--- binutils-2.25.orig/bfd/peXXigen.c
++++ binutils-2.25/bfd/peXXigen.c
+@@ -3522,6 +3522,28 @@ u16_mbtouc (wchar_t * puc, const unsigned short * s, unsigned int n)
+ }
+ #endif /* HAVE_WCHAR_H and not Cygwin/Mingw */
+ 
++#ifdef __APPLE__
++/* wcsncasecmp isn't always defined in Mac SDK */
++static int
++wcsncasecmp(const wchar_t *s1, const wchar_t *s2, size_t n)
++{
++  wchar_t c1, c2;
++
++  if (n == 0)
++    return (0);
++  for (; *s1; s1++, s2++)
++  {
++    c1 = towlower(*s1);
++    c2 = towlower(*s2);
++    if (c1 != c2)
++      return ((int)c1 - c2);
++    if (--n == 0)
++      return (0);
++  }
++  return (-*s2);
++}
++#endif
++
+ /* Perform a comparison of two entries.  */
+ static signed int
+ rsrc_cmp (bfd_boolean is_name, rsrc_entry * a, rsrc_entry * b)
+diff --git binutils-2.25.orig/gold/gold-threads.cc binutils-2.25/gold/gold-threads.cc
+index ff5a8ac..45140e0 100644
+--- binutils-2.25.orig/gold/gold-threads.cc
++++ binutils-2.25/gold/gold-threads.cc
+@@ -284,9 +284,18 @@ Condvar::~Condvar()
+ class Once_initialize
+ {
+  public:
+-  Once_initialize()
+-    : once_(PTHREAD_ONCE_INIT)
+-  { }
++   Once_initialize()
++#if !defined(__APPLE__)
++     : once_(PTHREAD_ONCE_INIT)
++   { }
++#else
++// In Drawin PTHREAD_ONCE_INIT is {0x30B1BCBA, {0}} and the GCC < 4.4 doesn't support
++// extended initializer list as above */
++   {
++     pthread_once_t once_2 = PTHREAD_ONCE_INIT;
++     once_ = once_2; 
++   }
++#endif
+ 
+   // Return a pointer to the pthread_once_t variable.
+   pthread_once_t*
+-- 
+2.1.3
+

--- a/scripts/build/cc/100-gcc.sh
+++ b/scripts/build/cc/100-gcc.sh
@@ -426,6 +426,12 @@ do_gcc_core_backend() {
 
     CT_DoLog DEBUG "Extra config passed: '${extra_config[*]}'"
 
+    # Clang's default bracket-depth is 256, and building GCC
+    # requires somewhere between 257 and 512.
+    if ${CT_BUILD}-gcc --version 2>&1 | grep clang; then
+        cflags="$cflags "-fbracket-depth=512
+    fi
+
     # Use --with-local-prefix so older gccs don't look in /usr/local (http://gcc.gnu.org/PR10532)
     CT_DoExecLog CFG                                   \
     CC_FOR_BUILD="${CT_BUILD}-gcc"                     \
@@ -915,6 +921,13 @@ do_gcc_backend() {
     fi
 
     CT_DoLog DEBUG "Extra config passed: '${extra_config[*]}'"
+
+    # https://gcc.gnu.org/ml/gcc/2014-05/msg00014.html
+    # "gcc 4.9.0 do not build on OSX" .. because Clang's default
+    # bracket-depth is 256
+    if ${CT_BUILD}-gcc --version 2>&1 | grep clang; then
+        cflags="$cflags "-fbracket-depth=512
+    fi
 
     CT_DoExecLog CFG                                \
     CC_FOR_BUILD="${CT_BUILD}-gcc"                  \


### PR DESCRIPTION
One of the patches came from Google's Android NDK and I kept it as it was for credit and origin tracing purposes.