### PR TITLE
uClibc: Add kconfig option to enable IPv6 support

### DIFF
--- a/config/libc/uClibc.in.2
+++ b/config/libc/uClibc.in.2
@@ -59,6 +59,12 @@ config LIBC_UCLIBC_LOCALES_PREGEN_DATA
       If so, please report the issue, so we can default this
       to off if too many people complain.
 
+config LIBC_UCLIBC_IPV6
+    bool
+    prompt "Add support for IPv6"
+    help
+      Say y if you want uClibc to support IPv6.
+
 config LIBC_UCLIBC_WCHAR
     bool
     prompt "Add support for WCHAR"

--- a/scripts/build/libc/uClibc.sh
+++ b/scripts/build/libc/uClibc.sh
@@ -427,6 +427,13 @@ manage_uClibc_config() {
         CT_KconfigDisableOption "UCLIBC_HAS_WCHAR" "${dst}"
     fi
 
+    # IPv6 support
+    if [ "${CT_LIBC_UCLIBC_IPV6}" = "y" ]; then
+        CT_KconfigEnableOption "UCLIBC_HAS_IPV6" "${dst}"
+    else
+        CT_KconfigDisableOption "UCLIBC_HAS_IPV6" "${dst}"
+    fi
+
     # Force on options needed for C++ if we'll be making a C++ compiler.
     # I'm not sure locales are a requirement for doing C++... Are they?
     if [ "${CT_CC_LANG_CXX}" = "y" ]; then


### PR DESCRIPTION
This commit adds a kconfig option to enable IPv6 support.

Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>