### PR TITLE
binutils/gdb: Fix configure options when building from binutils-gdb repo

### DIFF
--- a/scripts/build/binutils/binutils.sh
+++ b/scripts/build/binutils/binutils.sh
@@ -211,6 +211,10 @@ do_binutils_backend() {
         extra_config+=("--disable-multilib")
     fi
 
+    # Disable gdb when building from the binutils-gdb repository.
+    extra_config+=("--disable-sim")
+    extra_config+=("--disable-gdb")
+
     [ "${CT_TOOLCHAIN_ENABLE_NLS}" != "y" ] && extra_config+=("--disable-nls")
 
     CT_DoLog DEBUG "Extra config passed: '${extra_config[*]}'"

--- a/scripts/build/debug/300-gdb.sh
+++ b/scripts/build/debug/300-gdb.sh
@@ -100,6 +100,11 @@ do_debug_gdb_build() {
             LD_for_gdb="${CT_HOST}-ld -static"
         fi
 
+	# Disable binutils options when building from the binutils-gdb repo.
+	cross_extra_config+=("--disable-binutils")
+	cross_extra_config+=("--disable-ld")
+	cross_extra_config+=("--disable-gas")
+
         CT_DoLog DEBUG "Extra config passed: '${cross_extra_config[*]}'"
 
         CT_DoExecLog CFG                                \
@@ -186,6 +191,11 @@ do_debug_gdb_build() {
 
         export ac_cv_func_strncmp_works=yes
 
+	# Disable binutils options when building from the binutils-gdb repo.
+	native_extra_config+=("--disable-binutils")
+	native_extra_config+=("--disable-ld")
+	native_extra_config+=("--disable-gas")
+
         CT_DoLog DEBUG "Extra config passed: '${native_extra_config[*]}'"
 
         CT_DoExecLog CFG                                \
@@ -250,6 +260,11 @@ do_debug_gdb_build() {
                 gdbserver_extra_config+=( --disable-inprocess-agent )
             fi
         fi
+
+	# Disable binutils options when building from the binutils-gdb repo.
+	gdbserver_extra_config+=("--disable-binutils")
+	gdbserver_extra_config+=("--disable-ld")
+	gdbserver_extra_config+=("--disable-gas")
 
         CT_DoExecLog CFG                                \
         CC="${CT_TARGET}-gcc"                           \


### PR DESCRIPTION
When building from:
{git,http}://sourceware.org/git/binutils-gdb.git

and setting BINUTILS_CUSTOM or GDB_CUSTOM, they could be the same
source.

These config options should not affect normal released versions.

Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>