### PR TITLE
Custom locations rewrite

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -4,42 +4,42 @@ export PATH="$(pwd):$PATH"
 # Manage the travis build
 ct-ng_travis_build()
 {
-	# Override the log behaviour
-	sed -i	-e 's/^.*\(CT_LOG_ERROR\).*$/# \1 is not set/' \
-		-e 's/^.*\(CT_LOG_WARN\).*$/# \1 is not set/' \
-		-e 's/^.*\(CT_LOG_INFO\).*$/# \1 is not set/' \
-		-e 's/^.*\(CT_LOG_EXTRA\).*$/\1=y/' \
-		-e 's/^.*\(CT_LOG_ALL\).*$/# \1 is not set/' \
-		-e 's/^.*\(CT_LOG_DEBUG\).*$/# \1 is not set/' \
-		-e 's/^.*\(CT_LOG_LEVEL_MAX\).*$/\1="EXTRA"/' \
-		-e 's/^.*\(CT_LOG_PROGRESS_BAR\).*$/# \1 is not set/' \
-		-e 's/^.*\(CT_LOCAL_TARBALLS_DIR\).*$/\1="${HOME}\/src"/' \
-		-e 's/^.*\(CT_SAVE_TARBALLS\).*$/\1=y/' \
-		.config
+    # Override the log behaviour
+    sed -i -e 's/^.*\(CT_LOG_ERROR\).*$/# \1 is not set/' \
+        -e 's/^.*\(CT_LOG_WARN\).*$/# \1 is not set/' \
+        -e 's/^.*\(CT_LOG_INFO\).*$/# \1 is not set/' \
+        -e 's/^.*\(CT_LOG_EXTRA\).*$/\1=y/' \
+        -e 's/^.*\(CT_LOG_ALL\).*$/# \1 is not set/' \
+        -e 's/^.*\(CT_LOG_DEBUG\).*$/# \1 is not set/' \
+        -e 's/^.*\(CT_LOG_LEVEL_MAX\).*$/\1="EXTRA"/' \
+        -e 's/^.*\(CT_LOG_PROGRESS_BAR\).*$/# \1 is not set/' \
+        -e 's/^.*\(CT_LOCAL_TARBALLS_DIR\).*$/\1="${HOME}\/src"/' \
+        -e 's/^.*\(CT_SAVE_TARBALLS\).*$/\1=y/' \
+        .config
 
-	# Build the sample
-	ct-ng build.2 &
-	local build_pid=$!
+    # Build the sample
+    ct-ng build.2 &
+    local build_pid=$!
 
-	# Start a runner task to print a "still running" line every 5 minutes
-	# to avoid travis to think that the build is stuck
-	{
-		while true
-		do
-			sleep 300
-			printf "Crosstool-NG is still running ...\r"
-		done
-	} &
-	local runner_pid=$!
+    # Start a runner task to print a "still running" line every 5 minutes
+    # to avoid travis to think that the build is stuck
+    {
+        while true
+        do
+            sleep 300
+            printf "Crosstool-NG is still running ...\r"
+        done
+    } &
+    local runner_pid=$!
 
-	# Wait for the build to finish and get the result
-	wait $build_pid 2>/dev/null
-	local result=$?
+    # Wait for the build to finish and get the result
+    wait $build_pid 2>/dev/null
+    local result=$?
 
-	# Stop the runner task
-	kill $runner_pid
-	wait $runner_pid 2>/dev/null
+    # Stop the runner task
+    kill $runner_pid
+    wait $runner_pid 2>/dev/null
 
-	# Return the result
-	return $result
+    # Return the result
+    return $result
 }

--- a/config/arch/microblaze.in
+++ b/config/arch/microblaze.in
@@ -10,7 +10,7 @@
 ## select ARCH_DEFAULT_HAS_MMU
 ##
 ## help The MicroBlaze architecture, as defined by:
-## help 	http://www.xilinx.com/
+## help     http://www.xilinx.com/
 ## help 
 ## help Upstream projects do not currently provide
 ## help full support for the microblaze architecture

--- a/config/arch/xtensa.in.2
+++ b/config/arch/xtensa.in.2
@@ -1,31 +1,33 @@
 choice
-	prompt "Target Architecture Variant"
-	default ARCH_xtensa_fsf
+    prompt "Target Architecture Variant"
+    default ARCH_xtensa_fsf
+
 config XTENSA_CUSTOM
-	bool "Custom Xtensa processor configuration"
+    bool "Custom Xtensa processor configuration"
 
 config ARCH_xtensa_fsf
-	bool "fsf - Default configuration"
+    bool "fsf - Default configuration"
 
 endchoice
 
 config ARCH_XTENSA_CUSTOM_NAME
-	string "Custom Xtensa processor configuration name"
-	depends on XTENSA_CUSTOM
-	default ""
-	help
-	  Enter the name of the custom processor configuration.
-	  Overlay file for that configuration must be called
-	  'xtensa_<CUSTOM_NAME>.tar'.
-	  Leave blank to use the default 'xtensa-overlay.tar'.
-	  For more information about this option, please also consult
-	  section 'Using crosstool-NG to build Xtensa toolchains' in the
-	  docs/C - Misc. tutorials.txt
+    string "Custom Xtensa processor configuration name"
+    depends on XTENSA_CUSTOM
+    default ""
+    help
+      Enter the name of the custom processor configuration.
+      Overlay file for that configuration must be called
+      'xtensa_<CUSTOM_NAME>.tar'.
+
+      Leave blank to use the default 'xtensa-overlay.tar'.
+      For more information about this option, please also consult
+      section 'Using crosstool-NG to build Xtensa toolchains' in the
+      docs/C - Misc. tutorials.txt
 
 config ARCH_XTENSA_CUSTOM_OVERLAY_LOCATION
-	string "Full path to custom Xtensa processor configurations"
-	depends on XTENSA_CUSTOM
-	default ""
-	help
-	  Enter the path to the directory for the custom processor
-	  configuration file.
+    string "Full path to custom Xtensa processor configurations"
+    depends on XTENSA_CUSTOM
+    default ""
+    help
+      Enter the path to the directory for the custom processor
+      configuration file.

--- a/config/arch/xtensa.in.2
+++ b/config/arch/xtensa.in.2
@@ -28,5 +28,4 @@ config ARCH_XTENSA_CUSTOM_OVERLAY_LOCATION
 	default ""
 	help
 	  Enter the path to the directory for the custom processor
-	  configuration file or leave blank to use the default location:
-	  CT_CUSTOM_LOCATION_ROOT_DIR
+	  configuration file.

--- a/config/binutils/binutils.in
+++ b/config/binutils/binutils.in
@@ -2,6 +2,41 @@
 
 comment "GNU binutils"
 
+config BINUTILS_CUSTOM
+    bool
+    prompt "Custom binutils"
+    depends on EXPERIMENTAL
+    select BINUTILS_2_25_or_later
+    help
+      The choosen binutils version shall be not downloaded. Instead use
+      a custom location to get the source.
+
+if BINUTILS_CUSTOM
+
+config BINUTILS_CUSTOM_LOCATION
+    string
+    prompt "Full path to custom binutils source"
+    help
+      Enter the path to the directory or tarball of your source for binutils.
+
+      If the path is a tarball, it should extract to: <name>-<version>/
+      where the name is this component, binutils, and the version is set
+      below in the custom version string.
+
+config BINUTILS_CUSTOM_VERSION
+    string
+    prompt "Binutils Custom Version number"
+    help
+      Enter the version number for your custom binutils.
+
+config BINUTILS_VERSION
+    string
+    default BINUTILS_CUSTOM_VERSION
+
+endif # BINUTILS_CUSTOM
+
+if ! BINUTILS_CUSTOM
+
 config CC_BINUTILS_SHOW_LINARO
     bool
     prompt "Show Linaro versions"
@@ -94,23 +129,6 @@ config BINUTILS_V_2_18a
 
 endchoice
 
-config BINUTILS_CUSTOM
-    bool
-    prompt "Custom binutils"
-    depends on EXPERIMENTAL
-
-if BINUTILS_CUSTOM
-
-config BINUTILS_CUSTOM_LOCATION
-    string
-    prompt "Full path to custom binutils source"
-    default ""
-    help
-      Enter the path to the directory (or tarball) of your source for binutils,
-      or leave blank to use default CT_CUSTOM_LOCATION_ROOT_DIR/binutils
-
-endif # BINUTILS_CUSTOM
-
 config BINUTILS_VERSION
     string
 # Don't remove next line
@@ -128,6 +146,8 @@ config BINUTILS_VERSION
     default "2.20.1a" if BINUTILS_V_2_20_1a
     default "2.19.1a" if BINUTILS_V_2_19_1a
     default "2.18a" if BINUTILS_V_2_18a
+
+endif # ! BINUTILS_CUSTOM
 
 config BINUTILS_2_25_1_or_later
     bool

--- a/config/binutils/binutils.in.2
+++ b/config/binutils/binutils.in.2
@@ -18,11 +18,11 @@ config ELF2FLT_CUSTOM
     bool
     prompt "Custom elf2flt"
     depends on EXPERIMENTAL
+    help
+      The choosen elf2flt version shall be not downloaded. Instead use
+      a custom location to get the source.
 
 endchoice
-
-config ELF2FLT_VERSION
-    string
 
 if ELF2FLT_GIT
 
@@ -35,23 +35,30 @@ config ELF2FLT_GIT_CSET
 
       The default currently points to the HEAD of the git tree.
 
-config ELF2FLT_VERSION
-    default ELF2FLT_GIT_CSET
-
 endif # ELF2FLT_GIT
 
-if ELF2FLT_CUSTOM
-
 config ELF2FLT_VERSION
-    default "custom"
+    string
+    default ELF2FLT_GIT_CSET if ELF2FLT_GIT
+    default ELF2FLT_CUSTOM_VERSION if ELF2FLT_CUSTOM
+
+if ELF2FLT_CUSTOM
 
 config ELF2FLT_CUSTOM_LOCATION
     string
     prompt "Full path to custom elf2flt source"
-    default ""
     help
-      Enter the path to the directory (or tarball) of your source for elf2flt,
-      or leave blank to use default CT_CUSTOM_LOCATION_ROOT_DIR/elf2flt
+      Enter the path to the directory or tarball of your source for elf2flt.
+
+      If the path is a tarball, it should extract to: <name>-<version>/
+      where the name is this component, elf2flt, and the version is set
+      below in the custom version string.
+
+config ELF2FLT_CUSTOM_VERSION
+    string
+    prompt "elf2flt custom version number"
+    help
+      Enter the version number for your custom elf2flt.
 
 endif # ELF2FLT_CUSTOM
 
@@ -66,4 +73,4 @@ config ELF2FLT_EXTRA_CONFIG_ARRAY
       if they are properly quoted (or escaped, but prefer quotes). Eg.:
           --with-foo="1st arg with 4 spaces" --with-bar=2nd-arg-without-space
 
-endif
+endif # ARCH_BINFMT_FLAT

--- a/config/cc/gcc.in
+++ b/config/cc/gcc.in
@@ -13,6 +13,41 @@
 ## help gcc supports many languages, a powerful code parser, optimised binary
 ## help output, and lots of other features.
 
+config CC_GCC_CUSTOM
+    bool
+    prompt "Custom gcc"
+    depends on EXPERIMENTAL
+    select CC_GCC_latest
+    help
+      The choosen gcc version shall be not downloaded. Instead use
+      a custom location to get the source.
+
+if CC_GCC_CUSTOM
+
+config CC_GCC_CUSTOM_LOCATION
+    string
+    prompt "Full path to custom gcc source"
+    help
+      Enter the path to the directory or tarball of your source for gcc.
+
+      If the path is a tarball, it should extract to: <name>-<version>/
+      where the name is this component, gcc, and the version is set
+      below in the custom version string.
+
+config CC_GCC_CUSTOM_VERSION
+    string
+    prompt "Custom GCC Version"
+    help
+      Enter the version number for your custom gcc.
+
+config CC_GCC_VERSION
+    string
+    default CC_GCC_CUSTOM_VERSION
+
+endif #CC_GCC_CUSTOM
+
+if ! CC_GCC_CUSTOM
+
 config CC_GCC_SHOW_LINARO
     bool
     prompt "Show Linaro versions"
@@ -66,25 +101,7 @@ config CC_GCC_V_4_8_5
 
 endchoice
 
-config CC_GCC_CUSTOM
-    bool
-    prompt "Custom gcc"
-    depends on EXPERIMENTAL
-    help
-      The choosen compiler version shall be not downloaded. Instead use
-      a custom location to get the source.
-
-if CC_GCC_CUSTOM
-
-config CC_GCC_CUSTOM_LOCATION
-    string
-    prompt "Full path to custom gcc source"
-    default ""
-    help
-      Enter the path to the directory (or tarball) of your source for gcc,
-      or leave blank to use default CT_CUSTOM_LOCATION_ROOT_DIR/gcc
-
-endif #CC_GCC_CUSTOM
+endif # ! CC_GCC_CUSTOM
 
 config CC_GCC_4_8
     bool
@@ -237,6 +254,8 @@ config CC_GCC_HAS_LIBQUADMATH
 config CC_GCC_HAS_LIBSANITIZER
     bool
 
+if ! CC_GCC_CUSTOM
+
 config CC_GCC_VERSION
     string
 # Don't remove next line
@@ -246,6 +265,8 @@ config CC_GCC_VERSION
     default "4.9.3" if CC_GCC_V_4_9_3
     default "linaro-4.8-2015.06" if CC_GCC_V_linaro_4_8
     default "4.8.5" if CC_GCC_V_4_8_5
+
+endif # ! CC_GCC_CUSTOM
 
 config CC_LANG_JAVA_USE_ECJ
     bool

--- a/config/debug/gdb.in
+++ b/config/debug/gdb.in
@@ -10,6 +10,41 @@ if GDB_CROSS || GDB_NATIVE || GDB_GDBSERVER
 
 comment "gdb version"
 
+config GDB_CUSTOM
+    bool
+    prompt "Custom gdb"
+    depends on EXPERIMENTAL
+    select GDB_7_2_or_later
+    help
+      The choosen gdb version shall be not downloaded. Instead use
+      a custom location to get the source.
+
+if GDB_CUSTOM
+
+config GDB_CUSTOM_LOCATION
+    string
+    prompt "Full path to custom gdb source"
+    help
+      Enter the path to the directory or tarball of your source for gcc.
+
+      If the path is a tarball, it should extract to: <name>-<version>/
+      where the name is this component, gcc, and the version is set
+      below in the custom version string.
+
+config GDB_CUSTOM_VERSION
+    string
+    prompt "Custom GDB version"
+    help
+      Enter the version number for your custom gdb.
+
+config GDB_VERSION
+    string
+    default GDB_CUSTOM_VERSION
+
+endif # GDB_CUSTOM
+
+if ! GDB_CUSTOM
+
 config DEBUG_GDB_SHOW_LINARO
     bool
     prompt "Show Linaro versions"
@@ -166,13 +201,7 @@ config GDB_V_6_8a
 
 endchoice
 
-config GDB_CUSTOM
-    bool
-    prompt "Custom gdb"
-    depends on EXPERIMENTAL
-    help
-    The choosen gdb version shall be not downloaded. Instead use
-    a custom location to get the source.
+endif # ! GDB_CUSTOM
 
 config GDB_7_2_or_later
     bool
@@ -192,6 +221,8 @@ config GDB_HAS_PYTHON
 
 config GDB_INSTALL_GDBINIT
     bool
+
+if ! GDB_CUSTOM
 
 config GDB_VERSION
     string
@@ -223,17 +254,7 @@ config GDB_VERSION
     default "7.0a" if GDB_V_7_0a
     default "6.8a" if GDB_V_6_8a
 
-if GDB_CUSTOM
+endif # ! GDB_CUSTOM
 
-config GDB_CUSTOM_LOCATION
-    string
-    prompt "Full path to custom gdb source"
-    default ""
-    help
-      Enter the path to the directory (or tarball) of your source for gdb,
-      or leave blank to use default CT_CUSTOM_LOCATION_ROOT_DIR/gdb
-
-endif # GDB_CUSTOM
-
-endif
+endif # GDB_CROSS || GDB_NATIVE || GDB_GDBSERVER
 

--- a/config/global/paths.in
+++ b/config/global/paths.in
@@ -19,15 +19,6 @@ config SAVE_TARBALLS
       If you say 'y' here, new downloaded tarballs will be saved in the
       directory you entered above.
 
-config CUSTOM_LOCATION_ROOT_DIR
-    string
-    prompt "Directory containing custom source components"
-    depends on EXPERIMENTAL
-    help
-      This is the path CT-NG will attempt to use as a root for locating
-      local copies of source components (CUSTOM_LOCATION_ROOT_DIR/component)
-      unless a component declares its own specific custom location.
-
 config WORK_DIR
     string
     prompt "Working directory" if ! BACKEND

--- a/config/kernel/linux.in
+++ b/config/kernel/linux.in
@@ -5,6 +5,39 @@
 ##
 ## help Build a toolchain targeting systems running Linux as a kernel.
 
+config KERNEL_LINUX_CUSTOM
+    bool
+    prompt "custom tarball or directory"
+    help
+      The choosen linux version shall be not downloaded. Instead use
+      a custom location to get the source.
+
+if KERNEL_LINUX_CUSTOM
+
+config KERNEL_LINUX_CUSTOM_LOCATION
+    string
+    prompt "Path to custom source, tarball or directory"
+    help
+      Enter the path to the directory or tarball of your source for linux.
+
+      If the path is a tarball, it should extract to: <name>-<version>/
+      where the name is this component, linux, and the version is set
+      below in the custom version string.
+
+config KERNEL_LINUX_CUSTOM_VERSION
+    string
+    prompt "Custom Linux version"
+    help
+      Enter the version number for your custom linux.
+
+config KERNEL_VERSION
+    string
+    default KERNEL_LINUX_CUSTOM_VERSION
+
+endif # KERNEL_LINUX_CUSTOM
+
+if ! KERNEL_LINUX_CUSTOM
+
 choice
     bool
     prompt "Linux kernel version"
@@ -52,20 +85,6 @@ config KERNEL_V_2_6_32
     prompt "2.6.32.68"
     help
  
-config KERNEL_LINUX_CUSTOM
-    bool
-    prompt "custom tarball or directory"
-    help
-      Use a local tarball or local kernel directory of a complete kernel source tree.
-
-config KERNEL_LINUX_CUSTOM_LOCATION
-    string
-    prompt "Path to custom source, tarball or directory"
-    depends on KERNEL_LINUX_CUSTOM
-    help
-      Enter here the path to the tarball of your full kernel tree or
-      kernel directory
-
 endchoice
 
 config KERNEL_VERSION
@@ -82,4 +101,5 @@ config KERNEL_VERSION
     default "3.4.110" if KERNEL_V_3_4
     default "3.2.72" if KERNEL_V_3_2
     default "2.6.32.68" if KERNEL_V_2_6_32
-    default "custom" if KERNEL_LINUX_CUSTOM
+
+endif # ! KERNEL_LINUX_CUSTOM

--- a/config/kernel/linux.in
+++ b/config/kernel/linux.in
@@ -5,22 +5,6 @@
 ##
 ## help Build a toolchain targeting systems running Linux as a kernel.
 
-config KERNEL_LINUX_USE_CUSTOM_HEADERS
-    bool
-    prompt "Use pre-installed headers tree (OBSOLETE)"
-    depends on OBSOLETE
-    help
-      If you have some pre-installed kernel headers lying around, you can
-      enter the path to these headers, below, they will be copied from
-      there, and into the toolchain's sysroot.
-      
-      Note:
-      This will *not* let you use a complete kernel tree!
-      If you want to use your own full kernel tree, then you want to say 'N'
-      here, and select KERNEL_LINUX_CUSTOM, in the versions list, below.
-
-if ! KERNEL_LINUX_USE_CUSTOM_HEADERS
-
 choice
     bool
     prompt "Linux kernel version"
@@ -99,32 +83,3 @@ config KERNEL_VERSION
     default "3.2.72" if KERNEL_V_3_2
     default "2.6.32.68" if KERNEL_V_2_6_32
     default "custom" if KERNEL_LINUX_CUSTOM
-
-endif # ! KERNEL_LINUX_USE_CUSTOM_HEADERS
-
-if KERNEL_LINUX_USE_CUSTOM_HEADERS
-
-config KERNEL_LINUX_CUSTOM_PATH
-    string
-    prompt "Path to custom headers directory/tarball"
-    help
-      See KERNEL_LINUX_CUSTOM_IS_TARBALL, below.
-
-config KERNEL_LINUX_CUSTOM_IS_TARBALL
-    bool
-    prompt "This is a tarball"
-    help
-      If you say 'n' here, the path above is expected to point to a directory
-      containing readily prepared headers
-      
-      If you say 'y' here, then the path above is expected to point to a
-      tarball of such a directory.
-      
-      Eg., if your headers are available in: /foo/bar/buz/my_hdrs/include,
-      say 'n' here, and enter: /foo/bar/buz/my_hdrs below.
-      
-      Now, passing a tarball around is easier than passing a directory, so
-      if you want to, you can make a tarball of /foo/bar/buz/my_hdrs/include,
-      say 'y' here, and enter the path to this tarball below.
-
-endif # KERNEL_LINUX_USE_CUSTOM_HEADERS

--- a/config/kernel/linux.in.2
+++ b/config/kernel/linux.in.2
@@ -1,7 +1,5 @@
 # Linux kernel options
 
-if ! KERNEL_LINUX_USE_CUSTOM_HEADERS
-
 choice
     bool
     prompt "Kernel verbosity:"
@@ -40,5 +38,3 @@ config KERNEL_LINUX_INSTALL_CHECK
     help
       If you are in doubt that installed headers are buggy, say 'Y'
       here to have an extra check passed onto the headers.
-
-endif # ! KERNEL_LINUX_USE_CUSTOM_HEADERS

--- a/config/libc/avr-libc.in
+++ b/config/libc/avr-libc.in
@@ -9,6 +9,40 @@
 ## help Atmel AVR 8-bit RISC microcontrollers. In addition, the library
 ## help provides the basic startup code needed by most applications.
 
+config LIBC_AVR_LIBC_CUSTOM
+    bool
+    prompt "Custom avr-libc"
+    depends on EXPERIMENTAL
+    help
+      The choosen avr-libc version shall be not downloaded. Instead use
+      a custom location to get the source.
+
+if LIBC_AVR_LIBC_CUSTOM
+
+config LIBC_AVR_LIBC_CUSTOM_LOCATION
+    string
+    prompt "Full path to custom avr-libc source"
+    help
+      Enter the path to the directory or tarball of your source for avr-libc.
+
+      If the path is a tarball, it should extract to: <name>-<version>/
+      where the name is this component, avr-libc, and the version is set
+      below in the custom version string.
+
+config LIBC_AVR_LIBC_CUSTOM_VERSION
+    string
+    prompt "Custom AVR-Libc version"
+    help
+      Enter the version number for your custom avr-libc.
+
+config LIBC_VERSION
+    string
+    default LIBC_AVR_LIBC_CUSTOM_VERSION
+
+endif # LIBC_AVR_LIBC_CUSTOM
+
+if ! LIBC_AVR_LIBC_CUSTOM
+
 choice
     bool
     prompt "avr-libc version"
@@ -23,24 +57,7 @@ config LIBC_AVR_LIBC_V_1_8_0
     bool
     prompt "1.8.0"
 
-config LIBC_AVR_LIBC_CUSTOM
-    bool
-    prompt "Custom avr-libc"
-    depends on EXPERIMENTAL
-
 endchoice
-
-if LIBC_AVR_LIBC_CUSTOM
-
-config LIBC_AVR_LIBC_CUSTOM_LOCATION
-    string
-    prompt "Full path to custom avr-libc source"
-    default ""
-    help
-      Enter the path to the directory (or tarball) of your source for avr-libc,
-      or leave blank to use default CT_CUSTOM_LOCATION_ROOT_DIR/avr-libc
-
-endif # LIBC_AVR_LIBC_CUSTOM
 
 config LIBC_VERSION
     string
@@ -48,4 +65,5 @@ config LIBC_VERSION
 # CT_INSERT_VERSION_STRING_BELOW
     default "1.8.1" if LIBC_AVR_LIBC_V_1_8_1
     default "1.8.0" if LIBC_AVR_LIBC_V_1_8_0
-    default "custom" if LIBC_AVR_LIBC_CUSTOM
+
+endif # ! LIBC_AVR_LIBC_CUSTOM

--- a/config/libc/glibc.in
+++ b/config/libc/glibc.in
@@ -12,6 +12,42 @@
 config THREADS
     default "nptl"
 
+config LIBC_GLIBC_CUSTOM
+    bool
+    prompt "Custom glibc"
+    depends on EXPERIMENTAL
+    select LIBC_CUSTOM
+    select LIBC_GLIBC_2_20_or_later
+    help
+      The choosen glibc version shall be not downloaded. Instead use
+      a custom location to get the source.
+
+if LIBC_GLIBC_CUSTOM
+
+config LIBC_GLIBC_CUSTOM_LOCATION
+    string
+    prompt "Full path to custom glibc source"
+    help
+      Enter the path to the directory or tarball of your source for glibc.
+
+      If the path is a tarball, it should extract to: <name>-<version>/
+      where the name is this component, glibc, and the version is set
+      below in the custom version string.
+
+config LIBC_GLIBC_CUSTOM_VERSION
+    string
+    prompt "Custom GLIBC version"
+    help
+      Enter the version number for your custom glibc.
+
+config LIBC_VERSION
+    string
+    default LIBC_GLIBC_CUSTOM_VERSION
+
+endif # LIBC_GLIBC_CUSTOM
+
+if ! LIBC_GLIBC_CUSTOM
+
 config CC_GLIBC_SHOW_LINARO
     bool
     prompt "Show Linaro versions"
@@ -132,14 +168,9 @@ config LIBC_GLIBC_V_2_8
     prompt "2.8"
     select LIBC_GLIBC_PORTS_EXTERNAL
 
-config LIBC_GLIBC_CUSTOM
-    bool
-    prompt "Custom glibc"
-    depends on EXPERIMENTAL
-    select LIBC_CUSTOM
-    select LIBC_GLIBC_2_20_or_later
-
 endchoice
+
+endif # ! LIBC_GLIBC_CUSTOM
 
 config LIBC_GLIBC_2_20_or_later
     bool
@@ -149,20 +180,7 @@ config LIBC_GLIBC_2_20_or_later
 config LIBC_GLIBC_2_17_or_later
     bool
 
-config LIBC_CUSTOM
-    bool
-
-if LIBC_GLIBC_CUSTOM
-
-config LIBC_GLIBC_CUSTOM_LOCATION
-    string
-    prompt "Full path to custom glibc source"
-    default ""
-    help
-      Enter the path to the directory (or tarball) of your source for glibc,
-      or leave blank to use default CT_CUSTOM_LOCATION_ROOT_DIR/glibc
-
-endif # LIBC_GLIBC_CUSTOM
+if ! LIBC_GLIBC_CUSTOM
 
 config LIBC_VERSION
     string
@@ -187,4 +205,5 @@ config LIBC_VERSION
     default "2.10.1" if LIBC_GLIBC_V_2_10_1
     default "2.9" if LIBC_GLIBC_V_2_9
     default "2.8" if LIBC_GLIBC_V_2_8
-    default "custom" if LIBC_GLIBC_CUSTOM
+
+endif # ! LIBC_GLIBC_CUSTOM

--- a/config/libc/musl.in
+++ b/config/libc/musl.in
@@ -12,6 +12,40 @@
 config THREADS
     default "musl"
 
+config LIBC_MUSL_CUSTOM
+    bool
+    prompt "Custom musl"
+    depends on EXPERIMENTAL
+    help
+      The choosen musl-libc version shall be not downloaded. Instead use
+      a custom location to get the source.
+
+if LIBC_MUSL_CUSTOM
+
+config LIBC_MUSL_CUSTOM_LOCATION
+    string
+    prompt "Full path to custom musl-libc source"
+    help
+      Enter the path to the directory or tarball of your source for musl.
+
+      If the path is a tarball, it should extract to: <name>-<version>/
+      where the name is this component, musl, and the version is set
+      below in the custom version string.
+
+config LIBC_MUSL_CUSTOM_VERSION
+    string
+    prompt "Custom MUSL version"
+    help
+      Enter the version number for your custom musl-libc.
+
+config LIBC_VERSION
+    string
+    default LIBC_MUSL_CUSTOM_VERSION
+
+endif # LIBC_MUSL_CUSTOM
+
+if ! LIBC_MUSL_CUSTOM
+
 choice
     bool
     prompt "musl version"
@@ -27,11 +61,6 @@ config LIBC_MUSL_V_1_0
     bool
     prompt "1.0.5 (Stable)"
 
-config LIBC_MUSL_V_CUSTOM
-    bool
-    prompt "Custom musl"
-    depends on EXPERIMENTAL
-
 endchoice
 
 config LIBC_VERSION
@@ -40,4 +69,5 @@ config LIBC_VERSION
 # CT_INSERT_VERSION_STRING_BELOW
     default "1.1.12" if LIBC_MUSL_V_1_1
     default "1.0.5" if LIBC_MUSL_V_1_0
-    default "custom" if LIBC_MUSL_V_CUSTOM
+
+endif # ! LIBC_MUSL_CUSTOM

--- a/config/libc/newlib.in
+++ b/config/libc/newlib.in
@@ -12,6 +12,41 @@
 ## help is only available in source form. It can be compiled for a wide
 ## help array of processors, and will usually work on any architecture with
 ## help the addition of a few low-level routines.
+#
+config LIBC_NEWLIB_CUSTOM
+    bool
+    prompt "Custom newlib"
+    depends on EXPERIMENTAL
+    select LIBC_NEWLIB_2_2_or_later
+    help
+      The choosen newlib version shall be not downloaded. Instead use
+      a custom location to get the source.
+
+if LIBC_NEWLIB_CUSTOM
+
+config LIBC_NEWLIB_CUSTOM_LOCATION
+    string
+    prompt "Full path to custom newlib source"
+    help
+      Enter the path to the directory or tarball of your source for newlib.
+
+      If the path is a tarball, it should extract to: <name>-<version>/
+      where the name is this component, newlib, and the version is set
+      below in the custom version string.
+
+config LIBC_NEWLIB_CUSTOM_VERSION
+    string
+    prompt "Custom NEWLIB version"
+    help
+      Enter the version number for your custom newlib.
+
+config LIBC_VERSION
+    string
+    default LIBC_NEWLIB_CUSTOM_VERSION
+
+endif # LIBC_NEWLIB_CUSTOM
+
+if ! LIBC_NEWLIB_CUSTOM
 
 config CC_NEWLIB_SHOW_LINARO
     bool
@@ -81,13 +116,7 @@ config LIBC_NEWLIB_V_1_17_0
 
 endchoice
 
-config LIBC_NEWLIB_CUSTOM
-    bool
-    prompt "Custom newlib"
-    depends on EXPERIMENTAL
-    help
-    The choosen library version shall be not downloaded. Instead use
-    a custom location to get the source.
+endif # ! LIBC_NEWLIB_CUSTOM
 
 config LIBC_NEWLIB_2_2
     bool
@@ -115,18 +144,7 @@ config LIBC_NEWLIB_2_0_or_later
     bool
     select LIBC_PROVIDES_CXA_ATEXIT
 
-if LIBC_NEWLIB_CUSTOM
-
-config LIBC_NEWLIB_CUSTOM_LOCATION
-    string
-    prompt "Full path to custom newlib source"
-    default ""
-    help
-      Enter the path to the directory (or tarball) of your source for newlib,
-      or leave blank to use default CT_CUSTOM_LOCATION_ROOT_DIR/newlib
-
-endif # LIBC_NEWLIB_CUSTOM
-
+if ! LIBC_NEWLIB_CUSTOM
 config LIBC_VERSION
     string
 # Don't remove next line
@@ -143,6 +161,8 @@ config LIBC_VERSION
     help
       Enter the tag you want to use.
       Leave empty to use the 'head' of the repository.
+
+endif # ! LIBC_NEWLIB_CUSTOM
 
 config LIBC_NEWLIB_TARGET_CFLAGS
     string

--- a/config/libc/newlib.in.2
+++ b/config/libc/newlib.in.2
@@ -31,9 +31,9 @@ config LIBC_NEWLIB_DISABLE_SUPPLIED_SYSCALLS
     prompt "Disable the syscalls supplied with newlib"
     help
       Disable the syscalls that come with newlib. You
-	  will have to implement your own _sbrk, _read,
-	  _write... If you plan to port newlib to a new
-	  platform/board, say Yes.
+      will have to implement your own _sbrk, _read,
+      _write... If you plan to port newlib to a new
+      platform/board, say Yes.
 
 config LIBC_NEWLIB_ENABLE_TARGET_OPTSPACE
     bool

--- a/config/libc/uClibc.in
+++ b/config/libc/uClibc.in
@@ -20,6 +20,55 @@ comment "'softfp' ABI and uClibc is not entirely tested in crosstool-NG"
 comment "You may experience issues, although it should work just fine"
 endif # ARCH_FLOAT_SOFTFP
 
+config LIBC_UCLIBC_CUSTOM
+    bool
+    prompt "Custom uClibc"
+    depends on EXPERIMENTAL
+    help
+      The choosen uclibc version shall be not downloaded. Instead use
+      a custom location to get the source.
+
+if LIBC_UCLIBC_CUSTOM
+
+choice
+    bool
+    prompt "uClibc Version Name"
+
+config LIBC_UCLIBC_CUSTOM_UCLIBC
+    bool "uClibc"
+    select LIBC_UCLIBC_0_9_33_2_or_later
+
+config LIBC_UCLIBC_CUSTOM_UCLIBC_NG
+    bool "uClibc-ng"
+    select LIBC_UCLIBC_NG_1_0_0_or_later
+
+endchoice
+
+config LIBC_UCLIBC_CUSTOM_LOCATION
+    string
+    prompt "Full path to custom uClibc source"
+    help
+      Enter the path to the directory or tarball of your source for uClibc.
+
+      If the path is a tarball, it should extract to: <name>-<version>/
+      where the name is this component will be set by the uClibc Version Name
+      option from above, and the version is set below in the custom version
+      string.
+
+config LIBC_UCLIBC_CUSTOM_VERSION
+    string
+    prompt "Custom uClibc Version"
+    help
+      Enter the version number for your custom uClibc.
+
+config LIBC_VERSION
+    string
+    default LIBC_UCLIBC_CUSTOM_VERSION
+
+endif # LIBC_UCLIBC_CUSTOM
+
+if ! LIBC_UCLIBC_CUSTOM
+
 choice
     bool
     prompt "uClibc version"
@@ -36,25 +85,7 @@ config LIBC_UCLIBC_V_0_9_33_2
     prompt "0.9.33.2"
     select LIBC_UCLIBC_0_9_33_2_or_later
 
-config LIBC_UCLIBC_CUSTOM
-    bool
-    prompt "Custom uClibc"
-    depends on EXPERIMENTAL
-    select LIBC_UCLIBC_0_9_33_2_or_later
-
 endchoice
-
-if LIBC_UCLIBC_CUSTOM
-
-config LIBC_UCLIBC_CUSTOM_LOCATION
-    string
-    prompt "Full path to custom uClibc source"
-    default ""
-    help
-      Enter the path to the directory (or tarball) of your source for uClibc,
-      or leave blank to use default CT_CUSTOM_LOCATION_ROOT_DIR/uClibc
-
-endif # LIBC_UCLIBC_CUSTOM
 
 config LIBC_VERSION
     string
@@ -62,6 +93,8 @@ config LIBC_VERSION
 # CT_INSERT_VERSION_STRING_BELOW
     default "1.0.9" if LIBC_UCLIBC_NG_V_1_0_9
     default "0.9.33.2" if LIBC_UCLIBC_V_0_9_33_2
+
+endif # ! LIBC_UCLIBC_CUSTOM
 
 config LIBC_UCLIBC_NG_1_0_9_or_later
     bool

--- a/scripts/addToolVersion.sh
+++ b/scripts/addToolVersion.sh
@@ -14,37 +14,37 @@ myname="$0"
 
 doHelp() {
     cat <<-EOF
-		Usage: ${myname} <--tool> <[options] version [...]> ...
-		  'tool' in one of:
-		    gcc, binutils, glibc, uClibc, newlib, linux, gdb, dmalloc,
-		    duma, strace, ltrace, libelf, gmp, mpfr, isl, cloog, mpc,
-		    mingw-w64, expat, ncurses
-		
-		  Valid options for all tools:
-		    --stable, -s, +x   (default)
-		      mark the version as being stable (as opposed to experimental, below)
-		
-		    --experimental, -x, +s
-		      mark the version as being experimental (as opposed to stable, above)
-		
-		    --current, -c, +o   (default)
-		      mark the version as being cuurent (as opposed to obsolete, below)
-		
-		    --obsolete, -o, +c
-		      mark the version as being obsolete (as opposed to current, above)
-		
-		  Note: setting a new tool resets to the defaults: 'stable' and 'current'.
-		
-		  'version' is a valid version for the specified tool.
-		
-		  Examples:
-		    add stable current version 2.6.19.2 to linux kernel:
-		      ${myname} --linux 2.6.19.2
-		
-		    add experimental obsolete version 2.3.5 and stable current versions 2.6.1
-		    and 2.6.2 to glibc, add stable obsolete version 3.3.3 to gcc:
-		      ${myname} --glibc -x -o 2.3.5 -s -c 2.6.1 2.6.2 --gcc -o 3.3.3
-		EOF
+        Usage: ${myname} <--tool> <[options] version [...]> ...
+          'tool' in one of:
+            gcc, binutils, glibc, uClibc, newlib, linux, gdb, dmalloc,
+            duma, strace, ltrace, libelf, gmp, mpfr, isl, cloog, mpc,
+            mingw-w64, expat, ncurses
+
+          Valid options for all tools:
+            --stable, -s, +x   (default)
+              mark the version as being stable (as opposed to experimental, below)
+
+            --experimental, -x, +s
+              mark the version as being experimental (as opposed to stable, above)
+
+            --current, -c, +o   (default)
+              mark the version as being cuurent (as opposed to obsolete, below)
+
+            --obsolete, -o, +c
+              mark the version as being obsolete (as opposed to current, above)
+
+          Note: setting a new tool resets to the defaults: 'stable' and 'current'.
+
+          'version' is a valid version for the specified tool.
+
+          Examples:
+            add stable current version 2.6.19.2 to linux kernel:
+              ${myname} --linux 2.6.19.2
+
+            add experimental obsolete version 2.3.5 and stable current versions 2.6.1
+            and 2.6.2 to glibc, add stable obsolete version 3.3.3 to gcc:
+              ${myname} --glibc -x -o 2.3.5 -s -c 2.6.1 2.6.2 --gcc -o 3.3.3
+        EOF
 }
 
 # Extract field $3 from version $1 with separator $2
@@ -187,7 +187,7 @@ while [ $# -gt 0 ]; do
         --ltrace)   EXP=; OBS=; cat=LTRACE;         tool=ltrace;    tool_prefix=debug;          dot2suffix=;;
         --gmp)      EXP=; OBS=; cat=GMP;            tool=gmp;       tool_prefix=companion_libs; dot2suffix=;;
         --mpfr)     EXP=; OBS=; cat=MPFR;           tool=mpfr;      tool_prefix=companion_libs; dot2suffix=;;
-	--isl)      EXP=; OBS=; cat=ISL;            tool=isl;       tool_prefix=companion_libs; dot2suffix=;;
+        --isl)      EXP=; OBS=; cat=ISL;            tool=isl;       tool_prefix=companion_libs; dot2suffix=;;
         --cloog)    EXP=; OBS=; cat=CLOOG;          tool=cloog;     tool_prefix=companion_libs; dot2suffix=;;
         --mpc)      EXP=; OBS=; cat=MPC;            tool=mpc;       tool_prefix=companion_libs; dot2suffix=;;
         --libelf)   EXP=; OBS=; cat=LIBELF;         tool=libelf;    tool_prefix=companion_libs; dot2suffix=;;

--- a/scripts/build/arch/xtensa.sh
+++ b/scripts/build/arch/xtensa.sh
@@ -22,13 +22,7 @@ CT_ConfigureXtensa() {
         custom_overlay="xtensa-overlay.tar"
     fi
 
-    if [ -n "${CT_CUSTOM_LOCATION_ROOT_DIR}" \
-         -a -z "${custom_location}" ]; then
-             custom_location="${CT_CUSTOM_LOCATION_ROOT_DIR}"
-    fi
-
-    CT_TestAndAbort "${custom_overlay}: CT_CUSTOM_LOCATION_ROOT_DIR or CT_ARCH_XTENSA_CUSTOM_OVERLAY_LOCATION must be set." \
-        -z "${CT_CUSTOM_LOCATION_ROOT_DIR}" -a -z "${custom_location}"
+    CT_TestAndAbort "${custom_overlay}: CT_ARCH_XTENSA_CUSTOM_OVERLAY_LOCATION must be set." -z "${custom_location}"
 
     local full_file="${custom_location}/${custom_overlay}"
     local basename="${component}-${version}"

--- a/scripts/build/binutils/binutils.sh
+++ b/scripts/build/binutils/binutils.sh
@@ -5,8 +5,8 @@
 # Download binutils
 do_binutils_get() {
     if [ "${CT_BINUTILS_CUSTOM}" = "y" ]; then
-        CT_GetCustom "binutils" "${CT_BINUTILS_VERSION}" \
-                     "${CT_BINUTILS_CUSTOM_LOCATION}"
+        CT_GetCustom "binutils" "${CT_BINUTILS_CUSTOM_VERSION}" \
+            "${CT_BINUTILS_CUSTOM_LOCATION}"
     else
         if echo ${CT_BINUTILS_VERSION} |${grep} -q linaro; then
             YYMM=`echo ${CT_BINUTILS_VERSION} |cut -d- -f3 |${sed} -e 's,^..,,'`
@@ -22,8 +22,8 @@ do_binutils_get() {
 
     if [ -n "${CT_ARCH_BINFMT_FLAT}" ]; then
         if [ "${CT_ELF2FLT_CUSTOM}" = "y" ]; then
-            CT_GetCustom "elf2flt" "${CT_ELF2FLT_VERSION}"  \
-                         "${CT_ELF2FLT_CUSTOM_LOCATION}"
+            CT_GetCustom "elf2flt" "${CT_ELF2FLT_CUSTOM_VERSION}" \
+                "${CT_ELF2FLT_CUSTOM_LOCATION}"
         else
             CT_GetGit elf2flt "${CT_ELF2FLT_GIT_CSET}" git://wh0rd.org/elf2flt.git
         fi
@@ -32,19 +32,12 @@ do_binutils_get() {
 
 # Extract binutils
 do_binutils_extract() {
-    # If using custom directory location, nothing to do
-    if ! [ "${CT_BINUTILS_CUSTOM}" = "y" \
-         -a -d "${CT_SRC_DIR}/binutils-${CT_BINUTILS_VERSION}" ]; then
-        CT_Extract "binutils-${CT_BINUTILS_VERSION}"
-        CT_Patch "binutils" "${CT_BINUTILS_VERSION}"
-    fi
+    CT_Extract "binutils-${CT_BINUTILS_VERSION}"
+    CT_Patch "binutils" "${CT_BINUTILS_VERSION}"
 
     if [ -n "${CT_ARCH_BINFMT_FLAT}" ]; then
-        if ! [ "${CT_ELF2FLT_CUSTOM}" = "y" \
-             -a -d "${CT_SRC_DIR}/elf2flt-${CT_ELF2FLT_VERSION}" ]; then
-            CT_Extract "elf2flt-${CT_ELF2FLT_GIT_CSET}"
-            CT_Patch "elf2flt" "${CT_ELF2FLT_GIT_CSET}"
-        fi
+        CT_Extract "elf2flt-${CT_ELF2FLT_GIT_CSET}"
+        CT_Patch "elf2flt" "${CT_ELF2FLT_GIT_CSET}"
     fi
 
     if [ -n "${CT_ARCH_XTENSA_CUSTOM_NAME}" ]; then

--- a/scripts/build/cc.sh
+++ b/scripts/build/cc.sh
@@ -38,21 +38,21 @@ do_cc_core_pass_1() {
 
 # Core pass 2 the cc facilities
 do_cc_core_pass_2() {
-	for f in ${CT_CC_FACILITY_LIST}; do
+    for f in ${CT_CC_FACILITY_LIST}; do
         do_${f}_core_pass_2
     done
 }
 
 # Build for build the cc facilities
 do_cc_for_build() {
-	for f in ${CT_CC_FACILITY_LIST}; do
+    for f in ${CT_CC_FACILITY_LIST}; do
         do_${f}_for_build
     done
 }
 
 # Build for host the cc facilities
 do_cc_for_host() {
-	for f in ${CT_CC_FACILITY_LIST}; do
+    for f in ${CT_CC_FACILITY_LIST}; do
         do_${f}_for_host
     done
 }

--- a/scripts/build/cc/100-gcc.sh
+++ b/scripts/build/cc/100-gcc.sh
@@ -8,7 +8,8 @@ do_gcc_get() {
     local linaro_series=""
 
     if [ "${CT_CC_GCC_CUSTOM}" = "y" ]; then
-        CT_GetCustom "gcc" "${CT_CC_GCC_VERSION}" "${CT_CC_GCC_CUSTOM_LOCATION}"
+        CT_GetCustom "gcc" "${CT_CC_GCC_CUSTOM_VERSION}" \
+            "${CT_CC_GCC_CUSTOM_LOCATION}"
     else
         # Account for the Linaro versioning
         linaro_version="$( echo "${CT_CC_GCC_VERSION}"  \
@@ -48,12 +49,6 @@ do_gcc_get() {
 
 # Extract gcc
 do_gcc_extract() {
-    # If using custom directory location, nothing to do
-    if [ "${CT_CC_GCC_CUSTOM}" = "y"                    \
-         -a -d "${CT_SRC_DIR}/gcc-${CT_CC_GCC_VERSION}" ]; then
-        return 0
-    fi
-
     CT_Extract "gcc-${CT_CC_GCC_VERSION}"
     CT_Patch "gcc" "${CT_CC_GCC_VERSION}"
 

--- a/scripts/build/cc/100-gcc.sh
+++ b/scripts/build/cc/100-gcc.sh
@@ -143,7 +143,7 @@ do_gcc_core_pass_2() {
             ;;
         *)
             core_opts+=( "mode=static" )
-	    core_opts+=( "build_libgcc=yes" )
+            core_opts+=( "build_libgcc=yes" )
             ;;
     esac
 
@@ -313,9 +313,9 @@ do_gcc_core_backend() {
         if [ "${CT_ISL}" = "y" ]; then
             extra_config+=("--with-isl=${complibs}")
         fi
-	if [ "${CT_CLOOG}" = "y" ]; then
-	    extra_config+=("--with-cloog=${complibs}")
-	fi
+        if [ "${CT_CLOOG}" = "y" ]; then
+            extra_config+=("--with-cloog=${complibs}")
+        fi
     elif [ "${CT_CC_GCC_HAS_GRAPHITE}" = "y" ]; then
         extra_config+=("--with-isl=no")
         extra_config+=("--with-cloog=no")
@@ -472,8 +472,8 @@ do_gcc_core_backend() {
             CT_DoExecLog ALL ${make} ${JOBSFLAGS} -C libbacktrace
         fi
 
-	libgcc_rule="libgcc.mvars"
-	core_targets=( gcc target-libgcc )
+        libgcc_rule="libgcc.mvars"
+        core_targets=( gcc target-libgcc )
 
         # On bare metal and canadian build the host-compiler is used when
         # actually the build-system compiler is required. Choose the correct
@@ -710,7 +710,7 @@ do_gcc_backend() {
         extra_config+=("--enable-cxx-flags=${CT_CC_GCC_ENABLE_CXX_FLAGS}")
     fi
     if [ "${CT_THREADS}" = "none" ]; then
-	extra_config+=(--disable-libatomic)
+        extra_config+=(--disable-libatomic)
     fi
     if [ "${CT_CC_GCC_LIBMUDFLAP}" = "y" ]; then
         extra_config+=(--enable-libmudflap)
@@ -790,9 +790,9 @@ do_gcc_backend() {
         if [ "${CT_ISL}" = "y" ]; then
             extra_config+=("--with-isl=${complibs}")
         fi
-	if [ "${CT_CLOOG}" = "y" ]; then
-	    extra_config+=("--with-cloog=${complibs}")
-	fi
+        if [ "${CT_CLOOG}" = "y" ]; then
+            extra_config+=("--with-cloog=${complibs}")
+        fi
     elif [ "${CT_CC_GCC_HAS_GRAPHITE}" = "y" ]; then
         extra_config+=("--with-isl=no")
         extra_config+=("--with-cloog=no")

--- a/scripts/build/companion_libs/130-cloog.sh
+++ b/scripts/build/companion_libs/130-cloog.sh
@@ -87,9 +87,9 @@ do_cloog_backend() {
     done
 
     if [ "${CT_CLOOG_0_18_or_later}" = y ]; then
-	cloog_opts+=( --with-gmp=system --with-gmp-prefix="${prefix}" )
-	cloog_opts+=( --with-isl=system --with-isl-prefix="${prefix}" )
-	cloog_opts+=( --without-osl )
+        cloog_opts+=( --with-gmp=system --with-gmp-prefix="${prefix}" )
+        cloog_opts+=( --with-isl=system --with-isl-prefix="${prefix}" )
+        cloog_opts+=( --without-osl )
     fi
 
     CT_DoLog EXTRA "Configuring CLooG"
@@ -99,13 +99,13 @@ do_cloog_backend() {
     LDFLAGS="${ldflags}"                                \
     LIBS="-lm"                                          \
     "${CT_SRC_DIR}/cloog-${CT_CLOOG_VERSION}/configure" \
-	--build=${CT_BUILD}                             \
-	--host=${host}                                  \
-	--prefix="${prefix}"                            \
-	--with-bits=gmp                                 \
-	--with-host-libstdcxx='-lstdc++'                \
-	--disable-shared                                \
-	--enable-static                                 \
+        --build=${CT_BUILD}                             \
+        --host=${host}                                  \
+        --prefix="${prefix}"                            \
+        --with-bits=gmp                                 \
+        --with-host-libstdcxx='-lstdc++'                \
+        --disable-shared                                \
+        --enable-static                                 \
         "${cloog_opts[@]}"
 
     CT_DoLog EXTRA "Building CLooG"

--- a/scripts/build/debug/300-gdb.sh
+++ b/scripts/build/debug/300-gdb.sh
@@ -95,10 +95,10 @@ do_debug_gdb_build() {
             LD_for_gdb="${CT_HOST}-ld -static"
         fi
 
-	# Disable binutils options when building from the binutils-gdb repo.
-	cross_extra_config+=("--disable-binutils")
-	cross_extra_config+=("--disable-ld")
-	cross_extra_config+=("--disable-gas")
+    # Disable binutils options when building from the binutils-gdb repo.
+    cross_extra_config+=("--disable-binutils")
+    cross_extra_config+=("--disable-ld")
+    cross_extra_config+=("--disable-gas")
 
         CT_DoLog DEBUG "Extra config passed: '${cross_extra_config[*]}'"
 
@@ -186,10 +186,10 @@ do_debug_gdb_build() {
 
         export ac_cv_func_strncmp_works=yes
 
-	# Disable binutils options when building from the binutils-gdb repo.
-	native_extra_config+=("--disable-binutils")
-	native_extra_config+=("--disable-ld")
-	native_extra_config+=("--disable-gas")
+        # Disable binutils options when building from the binutils-gdb repo.
+        native_extra_config+=("--disable-binutils")
+        native_extra_config+=("--disable-ld")
+        native_extra_config+=("--disable-gas")
 
         CT_DoLog DEBUG "Extra config passed: '${native_extra_config[*]}'"
 
@@ -256,10 +256,10 @@ do_debug_gdb_build() {
             fi
         fi
 
-	# Disable binutils options when building from the binutils-gdb repo.
-	gdbserver_extra_config+=("--disable-binutils")
-	gdbserver_extra_config+=("--disable-ld")
-	gdbserver_extra_config+=("--disable-gas")
+        # Disable binutils options when building from the binutils-gdb repo.
+        gdbserver_extra_config+=("--disable-binutils")
+        gdbserver_extra_config+=("--disable-ld")
+        gdbserver_extra_config+=("--disable-gas")
 
         CT_DoExecLog CFG                                \
         CC="${CT_TARGET}-gcc"                           \

--- a/scripts/build/debug/300-gdb.sh
+++ b/scripts/build/debug/300-gdb.sh
@@ -7,7 +7,8 @@ do_debug_gdb_get() {
     local linaro_series=""
 
     if [ "${CT_GDB_CUSTOM}" = "y" ]; then
-        CT_GetCustom "gdb" "${CT_GDB_VERSION}" "${CT_GDB_CUSTOM_LOCATION}"
+        CT_GetCustom "gdb" "${CT_GDB_CUSTOM_VERSION}" \
+            "${CT_GDB_CUSTOM_LOCATION}"
     else
         # Account for the Linaro versioning
         linaro_version="$( echo "${CT_GDB_VERSION}"      \
@@ -33,12 +34,6 @@ do_debug_gdb_get() {
 }
 
 do_debug_gdb_extract() {
-    # If using custom directory location, nothing to do
-    if [    "${CT_GDB_CUSTOM}" = "y" \
-         -a -d "${CT_SRC_DIR}/gdb-${CT_GDB_VERSION}" ]; then
-        return 0
-    fi
-
     CT_Extract "gdb-${CT_GDB_VERSION}"
     CT_Patch "gdb" "${CT_GDB_VERSION}"
 

--- a/scripts/build/kernel/linux.sh
+++ b/scripts/build/kernel/linux.sh
@@ -24,8 +24,8 @@ do_kernel_get() {
     local korg_base mirror_base
 
     if [ "${CT_KERNEL_LINUX_CUSTOM}" = "y" ]; then
-        CT_GetCustom "linux" "${CT_KERNEL_VERSION}"     \
-                     "${CT_KERNEL_LINUX_CUSTOM_LOCATION}"
+        CT_GetCustom "linux" "${CT_KERNEL_LINUX_CUSTOM_VERSION}" \
+            "${CT_KERNEL_LINUX_CUSTOM_LOCATION}"
     else # Not a custom tarball
         case "${CT_KERNEL_VERSION}" in
             2.6.*.*|3.*.*|4.*.*)
@@ -82,9 +82,6 @@ do_kernel_headers() {
     mkdir -p "${CT_BUILD_DIR}/build-kernel-headers"
 
     kernel_path="${CT_SRC_DIR}/linux-${CT_KERNEL_VERSION}"
-    if [ "${CT_KERNEL_LINUX_CUSTOM}" = "y" ]; then
-        kernel_path="${CT_SRC_DIR}/linux-custom"
-    fi
     V_OPT="V=${CT_KERNEL_LINUX_VERBOSE_LEVEL}"
 
     kernel_arch="${CT_ARCH}"

--- a/scripts/build/kernel/linux.sh
+++ b/scripts/build/kernel/linux.sh
@@ -23,10 +23,6 @@ do_kernel_get() {
     local rel_dir
     local korg_base mirror_base
 
-    if [ "${CT_KERNEL_LINUX_USE_CUSTOM_HEADERS}" = "y"  ]; then
-        return 0
-    fi
-
     if [ "${CT_KERNEL_LINUX_CUSTOM}" = "y" ]; then
         CT_GetCustom "linux" "${CT_KERNEL_VERSION}"     \
                      "${CT_KERNEL_LINUX_CUSTOM_LOCATION}"
@@ -59,11 +55,6 @@ do_kernel_get() {
 
 # Extract kernel
 do_kernel_extract() {
-    # If using a custom headers tree, nothing to do
-    if [ "${CT_KERNEL_LINUX_USE_CUSTOM_HEADERS}" = "y" ]; then
-        return 0
-    fi
-
     # If using a custom directory location, nothing to do
     if [ "${CT_KERNEL_LINUX_CUSTOM}" = "y"    \
          -a -d "${CT_SRC_DIR}/linux-${CT_KERNEL_VERSION}" ]; then
@@ -81,25 +72,12 @@ do_kernel_extract() {
     CT_Patch "linux" "${CT_KERNEL_VERSION}"
 }
 
-# Wrapper to the actual headers install method
-do_kernel_headers() {
-    CT_DoStep INFO "Installing kernel headers"
-
-    if [ "${CT_KERNEL_LINUX_USE_CUSTOM_HEADERS}" = "y" ]; then
-        do_kernel_custom
-    else
-        do_kernel_install
-    fi
-
-    CT_EndStep
-}
-
 # Install kernel headers using headers_install from kernel sources.
-do_kernel_install() {
+do_kernel_headers() {
     local kernel_path
     local kernel_arch
 
-    CT_DoLog DEBUG "Using kernel's headers_install"
+    CT_DoStep INFO "Installing kernel headers"
 
     mkdir -p "${CT_BUILD_DIR}/build-kernel-headers"
 
@@ -145,28 +123,6 @@ do_kernel_install() {
                                 -o -name '..check.cmd'      \
                              \)                             \
                              -exec rm {} \;
-}
 
-# Use custom headers (most probably by using make headers_install in a
-# modified (read: customised) kernel tree, or using pre-2.6.18 headers, such
-# as 2.4). In this case, simply copy the headers in place
-do_kernel_custom() {
-    local tar_opt
-
-    CT_DoLog EXTRA "Installing custom kernel headers"
-
-    mkdir -p "${CT_SYSROOT_DIR}/usr"
-    cd "${CT_SYSROOT_DIR}/usr"
-    if [ "${CT_KERNEL_LINUX_CUSTOM_IS_TARBALL}" = "y" ]; then
-        case "${CT_KERNEL_LINUX_CUSTOM_PATH}" in
-            *.tar)      ;;
-            *.tgz)      tar_opt=--gzip;;
-            *.tar.gz)   tar_opt=--gzip;;
-            *.tar.bz2)  tar_opt=--bzip2;;
-            *.tar.xz)   tar_opt=--xz;;
-        esac
-        CT_DoExecLog ALL tar x ${tar_opt} -vf ${CT_KERNEL_LINUX_CUSTOM_PATH}
-    else
-        CT_DoExecLog ALL cp -rv "${CT_KERNEL_LINUX_CUSTOM_PATH}/include" .
-    fi
+    CT_EndStep
 }

--- a/scripts/build/libc/avr-libc.sh
+++ b/scripts/build/libc/avr-libc.sh
@@ -6,24 +6,14 @@ do_libc_get() {
     libc_src="http://download.savannah.gnu.org/releases/avr-libc"
 
     if [ "${CT_LIBC_AVR_LIBC_CUSTOM}" = "y" ]; then
-        CT_GetCustom "avr-libc" "${CT_LIBC_VERSION}"      \
-                     "${CT_LIBC_AVR_LIBC_CUSTOM_LOCATION}"
+        CT_GetCustom "avr-libc" "${CT_LIBC_AVR_LIBC_CUSTOM_VERSION}" \
+            "${CT_LIBC_AVR_LIBC_CUSTOM_LOCATION}"
     else # ! custom location
         CT_GetFile "avr-libc-${CT_LIBC_VERSION}" "${libc_src}"
     fi # ! custom location
 }
 
 do_libc_extract() {
-    # If using custom directory location, nothing to do.
-    if [ "${CT_LIBC_AVR_LIBC_CUSTOM}" = "y" ]; then
-        # Abort if the custom directory is not found.
-        if ! [ -d "${CT_SRC_DIR}/avr-libc-${CT_LIBC_VERSION}" ]; then
-            CT_Abort "Directory not found: ${CT_SRC_DIR}/avr-libc-${CT_LIBC_VERSION}"
-        fi
-
-        return 0
-    fi
-
     CT_Extract "avr-libc-${CT_LIBC_VERSION}"
     CT_Patch "avr-libc" "${CT_LIBC_VERSION}"
 }

--- a/scripts/build/libc/glibc.sh
+++ b/scripts/build/libc/glibc.sh
@@ -6,16 +6,10 @@
 do_libc_extract() {
     local addon
 
-    # Attempt CT_EXTRACT only if NOT custom, or CUSTOM_LOCATION is not a directory
-    if [ "${CT_LIBC_CUSTOM}" != "y" \
-         -o ! -d "${CT_LIBC_CUSTOM_LOCATION}" ]; then
-        CT_Extract "${CT_LIBC}-${CT_LIBC_VERSION}"
-    fi
+    CT_Extract "${CT_LIBC}-${CT_LIBC_VERSION}"
     CT_Pushd "${CT_SRC_DIR}/${CT_LIBC}-${CT_LIBC_VERSION}"
     # Attempt CT_PATCH only if NOT custom
-    if [ "${CT_LIBC_CUSTOM}" != "y" ]; then
-        CT_Patch nochdir "${CT_LIBC}" "${CT_LIBC_VERSION}"
-    fi
+    CT_Patch nochdir "${CT_LIBC}" "${CT_LIBC_VERSION}"
 
     # Extract the add-opns if => 2.17
     if [ "${CT_LIBC_GLIBC_2_17_or_later}" != "y" ]; then
@@ -554,9 +548,9 @@ do_libc_get() {
     addons_list=($(do_libc_add_ons_list " "))
 
     # Main source
-    if [ "${CT_LIBC_CUSTOM}" = "y" ]; then
-        CT_GetCustom "glibc" "${CT_LIBC_VERSION}" "${CT_LIBC_GLIBC_CUSTOM_LOCATION}"
-        CT_LIBC_CUSTOM_LOCATION="${CT_SRC_DIR}/glibc-${CT_LIBC_VERSION}"
+    if [ "${CT_LIBC_GLIBC_CUSTOM}" = "y" ]; then
+        CT_GetCustom "glibc" "${CT_LIBC_GLIBC_CUSTOM_VERSION}" \
+            "${CT_LIBC_GLIBC_CUSTOM_LOCATION}"
     else
         if echo ${CT_LIBC_VERSION} |${grep} -q linaro; then
             # Linaro glibc releases come from regular downloads...

--- a/scripts/build/libc/musl.sh
+++ b/scripts/build/libc/musl.sh
@@ -8,24 +8,14 @@ do_libc_get() {
     libc_src="http://www.musl-libc.org/releases"
 
     if [ "${CT_LIBC_MUSL_CUSTOM}" = "y" ]; then
-        CT_GetCustom "musl" "${CT_LIBC_VERSION}"      \
-                     "${CT_LIBC_MUSL_CUSTOM_LOCATION}"
+        CT_GetCustom "musl" "${CT_LIBC_MUSL_CUSTOM_VERSION}" \
+            "${CT_LIBC_MUSL_CUSTOM_LOCATION}"
     else # ! custom location
         CT_GetFile "musl-${CT_LIBC_VERSION}" "${libc_src}"
     fi # ! custom location
 }
 
 do_libc_extract() {
-    # If using custom directory location, nothing to do.
-    if [ "${CT_LIBC_MUSL_CUSTOM}" = "y" ]; then
-        # Abort if the custom directory is not found.
-        if ! [ -d "${CT_SRC_DIR}/musl-${CT_LIBC_VERSION}" ]; then
-            CT_Abort "Directory not found: ${CT_SRC_DIR}/musl-${CT_LIBC_VERSION}"
-        fi
-
-        return 0
-    fi
-
     CT_Extract "musl-${CT_LIBC_VERSION}"
     CT_Patch "musl" "${CT_LIBC_VERSION}"
 }

--- a/scripts/build/libc/newlib.sh
+++ b/scripts/build/libc/newlib.sh
@@ -14,8 +14,8 @@ do_libc_get() {
                      ftp://sourceware.org/pub/newlib}"
 
     if [ "${CT_LIBC_NEWLIB_CUSTOM}" = "y" ]; then
-        CT_GetCustom "newlib" "${CT_LIBC_VERSION}"      \
-                     "${CT_LIBC_NEWLIB_CUSTOM_LOCATION}"
+        CT_GetCustom "newlib" "${CT_LIBC_NEWLIB_CUSTOM_VERSION}" \
+            "${CT_LIBC_NEWLIB_CUSTOM_LOCATION}"
     else # ! custom location
         if echo ${CT_LIBC_VERSION} |${grep} -q linaro; then
             YYMM=`echo ${CT_LIBC_VERSION} |cut -d- -f3 |${sed} -e 's,^..,,'`
@@ -30,12 +30,6 @@ do_libc_get() {
 }
 
 do_libc_extract() {
-    # If using custom directory location, nothing to do
-    if [    "${CT_LIBC_NEWLIB_CUSTOM}" = "y"             \
-         -a -d "${CT_SRC_DIR}/newlib-${CT_LIBC_VERSION}" ]; then
-        return 0
-    fi
-
     CT_Extract "newlib-${CT_LIBC_VERSION}"
     CT_Patch "newlib" "${CT_LIBC_VERSION}"
 

--- a/scripts/build/libc/uClibc.sh
+++ b/scripts/build/libc/uClibc.sh
@@ -19,8 +19,8 @@ fi
 # Download uClibc
 do_libc_get() {
     if [ "${CT_LIBC_UCLIBC_CUSTOM}" = "y" ]; then
-        CT_GetCustom "${uclibc_name}" "${CT_LIBC_VERSION}" \
-                     "${CT_LIBC_UCLIBC_CUSTOM_LOCATION}"
+        CT_GetCustom "${uclibc_name}" "${CT_LIBC_UCLIBC_CUSTOM_VERSION}" \
+            "${CT_LIBC_UCLIBC_CUSTOM_LOCATION}"
     else
         CT_GetFile "${uclibc_name}-${CT_LIBC_VERSION}" ${libc_src}
     fi
@@ -34,16 +34,8 @@ do_libc_get() {
 
 # Extract uClibc
 do_libc_extract() {
-    # If not using custom directory location, extract and patch
-    # Note: we do the inverse test we do in other components,
-    # because here we still need to extract the locales, even for
-    # custom location directory. Just use negate the whole test,
-    # to keep it the same as for other components.
-    if ! [ "${CT_LIBC_UCLIBC_CUSTOM}" = "y" \
-         -a -d "${CT_SRC_DIR}/${uclibc_name}-${CT_LIBC_VERSION}" ]; then
-        CT_Extract "${uclibc_name}-${CT_LIBC_VERSION}"
-        CT_Patch "${uclibc_name}" "${CT_LIBC_VERSION}"
-    fi
+    CT_Extract "${uclibc_name}-${CT_LIBC_VERSION}"
+    CT_Patch "${uclibc_name}" "${CT_LIBC_VERSION}"
 
     # uClibc locales
     # Extracting pregen locales ourselves is kinda

--- a/scripts/functions
+++ b/scripts/functions
@@ -1,4 +1,6 @@
-# This file contains some usefull common functions -*- sh -*-
+# -*- mode: sh; tab-width: 4 -*-
+# vi: ts=4:sw=4:sts=4:et
+# This file contains some usefull common functions
 # Copyright 2007 Yann E. MORIN
 # Licensed under the GPL v2. See COPYING in the root of this package
 
@@ -625,39 +627,58 @@ CT_GetLocal() {
 }
 
 # This function gets the custom source from either a tarball or directory
-# Usage: CT_GetCustom <component> <custom_version> <custom_location>
+# Usage: CT_GetCustom <name> <version> <location>
 CT_GetCustom() {
-    local custom_component="$1"
-    local custom_version="$2"
-    local custom_location="$3"
-    local custom_name="${custom_component}-${custom_version}"
+    local component_name="$1"
+    local component_version="$2"
+    local component_location="$3"
 
-    CT_TestAndAbort "${custom_name}: CT_CUSTOM_LOCATION_ROOT_DIR or ${custom_component}'s CUSTOM_LOCATION must be set." \
-                    -z "${CT_CUSTOM_LOCATION_ROOT_DIR}" -a -z "${custom_location}"
+    # Some local variables we use to help us figure out what to do
+    local component_location_type="dir" # str: 'file' or 'dir'
+    local component_location_filename="" # filename... if it's a file
 
-    if [ -n "${CT_CUSTOM_LOCATION_ROOT_DIR}" \
-         -a -z "${custom_location}"          ]; then
-        custom_location="${CT_CUSTOM_LOCATION_ROOT_DIR}/${custom_component}"
+    CT_TestAndAbort \
+        "${component_name}: Custom location setting is empty" \
+        -z "${component_location}"
+
+    CT_TestAndAbort \
+        "${component_name}: Custom version setting is empty" \
+        -z "${component_version}"
+
+    if [ -f "${component_location}" ]; then
+        component_location_type="file"
+        component_location_filename="$(basename ${component_location})"
+    elif [ -d "${component_location}" ]; then
+        # Yes, it's the default, but it rules out the else case in the `if'.
+        component_location_type="dir"
+        # as -d and -f say: it's a <directory|file> and is readable!
+    else
+        CT_Abort "${component_name}: Unable to read ${component_location}, make sure the setting is correct and double check the permissions!"
     fi
 
-    CT_DoLog EXTRA "Using '${custom_name}' from custom location"
-    if [ ! -d "${custom_location}" ]; then
+    if [ "${component_location_type}" = "file" ]; then
+        CT_DoLog EXTRA "Got '${component_location}' from custom location"
         # We need to know the custom tarball extension,
         # so we can create a properly-named symlink, which
         # we use later on in 'extract'
-        case "${custom_location}" in
-            *.tar.xz)       custom_name="${custom_name}.tar.xz";;
-            *.tar.bz2)      custom_name="${custom_name}.tar.bz2";;
-            *.tar.gz|*.tgz) custom_name="${custom_name}.tar.gz";;
-            *.tar)          custom_name="${custom_name}.tar";;
-            *)  CT_Abort "Unknown extension for custom tarball '${custom_location}'";;
+        case "${component_location}" in
+            *.tar.xz|*.tar.bz2|*.tar.lzma|*.tar.gz|*.tgz|*.tar|*.zip) ;;
+            *) CT_Abort "Unknown extension for custom tarball '${component_location}'" ;;
         esac
-        CT_DoExecLog DEBUG ln -sf "${custom_location}"  \
-                                  "${CT_TARBALLS_DIR}/${custom_name}"
-    else
-        CT_DoExecLog DEBUG ln -snf "${custom_location}" \
-                                   "${CT_SRC_DIR}/${custom_name}"
+        [ ! -L "${CT_TARBALLS_DIR}/${component_location_filename}" ] && \
+            CT_DoExecLog DEBUG ln -sf "${component_location}" \
+            "${CT_TARBALLS_DIR}/${component_location_filename}"
+    elif [ "${component_location_type}" = "dir" ]; then
+        CT_DoLog EXTRA "Got '${component_location}' from custom location"
+        [ ! -d "${CT_SRC_DIR}/${component_name}-${component_version}" ] && \
+            CT_DoExecLog DEBUG cp -al "${component_location}" \
+            "${CT_SRC_DIR}/${component_name}-${component_version}"
+
+        # Don't try to extract from source directory, it's extracted!
+        touch "${CT_SRC_DIR}/.${component_name}-${component_version}.extracted"
     fi
+    # Don't patch a custom source, it's custom!
+    touch "${CT_SRC_DIR}/.${component_name}-${component_version}.patched"
 }
 
 # This function saves the specified to local storage if possible,

--- a/scripts/functions
+++ b/scripts/functions
@@ -938,17 +938,17 @@ CT_Extract() {
     basename="$1"
     shift
 
-    if ! ext="$(CT_GetFileExtension "${basename}")"; then
-        CT_DoLog WARN "'${basename}' not found in '${CT_TARBALLS_DIR}'"
-        return 1
-    fi
-    local full_file="${CT_TARBALLS_DIR}/${basename}${ext}"
-
     # Check if already extracted
     if [ -e "${CT_SRC_DIR}/.${basename}.extracted" ]; then
         CT_DoLog DEBUG "Already extracted '${basename}'"
         return 0
     fi
+
+    if ! ext="$(CT_GetFileExtension "${basename}")"; then
+	CT_DoLog WARN "'${basename}' not found in '${CT_TARBALLS_DIR}'"
+	return 1
+    fi
+    local full_file="${CT_TARBALLS_DIR}/${basename}${ext}"
 
     # Check if previously partially extracted
     if [ -e "${CT_SRC_DIR}/.${basename}.extracting" ]; then

--- a/scripts/patch-rework.sh
+++ b/scripts/patch-rework.sh
@@ -11,35 +11,35 @@ diff="$@"
 
 do_help() {
     cat <<-_EOF_
-		${0##*/}: transform a patchset of non-p1 patches into -p1 patches
-		
-		Usage:
-		    ${0##*/} <basedir> <src> <dst> [diffopts ...]
-		
-		Where:
-		    basedir
-		        points to the directory of the component to patch
-		
-		    src
-		        points to the directory containing the existing patchset
-		        to transform
-		
-		    dst
-		        points to the directory where to put transformed patches
-		
-		    diffopts
-		        optional options to pass to diff, for debug purposes. You
-		        should not need it
-		
-		Example:
-		    Transform Gentoo patches against gcc-4.4.2 (some of which are
-		    -p0, -p1 or even -p2 patches) into all -p1 patches:
-		
-		        tar xjf gcc-4.4.2.tar.bz2
-		        patch-rework.sh gcc-4.4.2                   \\
-		                        /path/to/gentoo/gcc/patches \\
-		                        gcc-4.4.2.patches
-		_EOF_
+        ${0##*/}: transform a patchset of non-p1 patches into -p1 patches
+        
+        Usage:
+            ${0##*/} <basedir> <src> <dst> [diffopts ...]
+        
+        Where:
+            basedir
+                points to the directory of the component to patch
+        
+            src
+                points to the directory containing the existing patchset
+                to transform
+        
+            dst
+                points to the directory where to put transformed patches
+        
+            diffopts
+                optional options to pass to diff, for debug purposes. You
+                should not need it
+        
+        Example:
+            Transform Gentoo patches against gcc-4.4.2 (some of which are
+            -p0, -p1 or even -p2 patches) into all -p1 patches:
+        
+                tar xjf gcc-4.4.2.tar.bz2
+                patch-rework.sh gcc-4.4.2                   \\
+                                /path/to/gentoo/gcc/patches \\
+                                gcc-4.4.2.patches
+        _EOF_
 }
 
 # Sanity checks
@@ -48,8 +48,8 @@ if [    -z "${base}"                    \
      -o ! -d "${src}"                   \
      -o -e "${dst}" -a ! -d "${dst}"    \
    ]; then
-	do_help
-	exit 1
+    do_help
+    exit 1
 fi
 
 mkdir -p "${dst}"

--- a/scripts/saveSample.sh.in
+++ b/scripts/saveSample.sh.in
@@ -37,12 +37,6 @@ if [ "${CT_CUSTOM_PATCH}" = "y" ]; then
     echo "You will not be able to (easily) share this sample in this case."
     read -p "Press Ctrl-C to stop now, or Enter to continue..."
 fi
-if [ "${CT_KERNEL_LINUX_USE_CUSTOM_HEADERS}" = "y" ]; then
-    exec >&7
-    echo "You are using custom Linux headers."
-    echo "You will not be able to (easily) share this sample in this case."
-    read -p "Press Ctrl-C to stop now, or Enter to continue..."
-fi
 
 # Do not use a progress bar
 unset CT_LOG_PROGRESS_BAR

--- a/scripts/showSamples.sh
+++ b/scripts/showSamples.sh
@@ -69,7 +69,7 @@ dump_single_sample() {
             printf "    %-*s : %s\n" ${width} "OS" "${CT_KERNEL}${CT_KERNEL_VERSION:+-}${CT_KERNEL_VERSION}"
             if [    -n "${CT_GMP}"              \
                  -o -n "${CT_MPFR}"             \
-		 -o -n "${CT_ISL}"              \
+                 -o -n "${CT_ISL}"              \
                  -o -n "${CT_CLOOG}"            \
                  -o -n "${CT_MPC}"              \
                  -o -n "${CT_LIBELF}"           \
@@ -77,7 +77,7 @@ dump_single_sample() {
                  -o -n "${CT_NCURSES}"          \
                  -o -n "${CT_GMP_TARGET}"       \
                  -o -n "${CT_MPFR_TARGET}"      \
-		 -o -n "${CT_ISL_TARGET}"       \
+                 -o -n "${CT_ISL_TARGET}"       \
                  -o -n "${CT_CLOOG_TARGET}"     \
                  -o -n "${CT_MPC_TARGET}"       \
                  -o -n "${CT_LIBELF_TARGET}"    \
@@ -89,8 +89,8 @@ dump_single_sample() {
             fi
             [ -z "${CT_GMP}"     -a -z "${CT_GMP_TARGET}"     ] || printf " gmp-%s"       "${CT_GMP_VERSION}"
             [ -z "${CT_MPFR}"    -a -z "${CT_MPFR_TARGET}"    ] || printf " mpfr-%s"      "${CT_MPFR_VERSION}"
-	    [ -z "${CT_ISL}"     -a -z "${CT_ISL_TARGET}"     ] || printf " isl-%s"       "${CT_ISL_VERSION}"
-	    [ -z "${CT_CLOOG}"   -a -z "${CT_CLOOG_TARGET}"   ] || printf " cloog-%s"     "${CT_CLOOG_VERSION}"
+            [ -z "${CT_ISL}"     -a -z "${CT_ISL_TARGET}"     ] || printf " isl-%s"       "${CT_ISL_VERSION}"
+            [ -z "${CT_CLOOG}"   -a -z "${CT_CLOOG_TARGET}"   ] || printf " cloog-%s"     "${CT_CLOOG_VERSION}"
             [ -z "${CT_MPC}"     -a -z "${CT_MPC_TARGET}"     ] || printf " mpc-%s"       "${CT_MPC_VERSION}"
             [ -z "${CT_LIBELF}"  -a -z "${CT_LIBELF_TARGET}"  ] || printf " libelf-%s"    "${CT_LIBELF_VERSION}"
             [ -z "${CT_EXPAT}"   -a -z "${CT_EXPAT_TARGET}"   ] || printf " expat-%s"     "${CT_EXPAT_VERSION}"


### PR DESCRIPTION
This patch series cleans up and rewrites CT_GetCustom and friends.

We also drop the usage of:

* CT_CUSTOM_LOCATION_ROOT_DIR
* CT_KERNEL_LINUX_USE_CUSTOM_HEADERS