### PR TITLE
binutils: add patch that fixes mac os x gold build

### DIFF
--- a/patches/binutils/2.25.1/400-arm-rotate_left-fix.patch
+++ b/patches/binutils/2.25.1/400-arm-rotate_left-fix.patch
@@ -1,0 +1,26 @@
+From d840c081f8082e8b9e63fead5306643975a97bb3 Mon Sep 17 00:00:00 2001
+From: Richard Earnshaw <Richard.Earnshaw@arm.com>
+Date: Thu, 20 Nov 2014 17:02:47 +0000
+Subject: [PATCH] * config/tc-arm.c (rotate_left): Avoid undefined behaviour
+ when N = 0.
+
+---
+ gas/config/tc-arm.c | 2 +-
+ 1 files changed, 1 insertions(+), 1 deletion(-)
+
+diff --git a/gas/config/tc-arm.c b/gas/config/tc-arm.c
+index 5077f87..9100fb2 100644
+--- a/gas/config/tc-arm.c
++++ b/gas/config/tc-arm.c
+@@ -7251,7 +7251,7 @@ parse_operands (char *str, const unsigned int *pattern, bfd_boolean thumb)
+ 
+ /* Functions for operand encoding.  ARM, then Thumb.  */
+ 
+-#define rotate_left(v, n) (v << n | v >> (32 - n))
++#define rotate_left(v, n) (v << (n & 31) | v >> ((32 - n) & 31))
+ 
+ /* If VAL can be encoded in the immediate field of an ARM instruction,
+    return the encoded form.  Otherwise, return FAIL.  */
+-- 
+1.9.4
+


### PR DESCRIPTION
https://sourceware.org/bugzilla/show_bug.cgi?id=19281

Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>