### PR TITLE
Cygwin more fixes

### DIFF
--- a/patches/gcc/5.3.0/370-gcc-plugin-Win-Dont-need-undefined-extern-var-refs-nor-fpic.patch
+++ b/patches/gcc/5.3.0/370-gcc-plugin-Win-Dont-need-undefined-extern-var-refs-nor-fpic.patch
@@ -1,0 +1,160 @@
+diff -urN gcc-5.3.0.orig/config/gcc-plugin.m4 gcc-5.3.0/config/gcc-plugin.m4
+--- gcc-5.3.0.orig/config/gcc-plugin.m4	2015-12-19 14:39:04.120734900 +0000
++++ gcc-5.3.0/config/gcc-plugin.m4	2015-12-20 01:28:45.381965300 +0000
+@@ -20,6 +20,9 @@
+ 
+    pluginlibs=
+ 
++   PICFLAG="-fPIC"
++   UNDEFINEDPREAMBLE="extern int X;"
++   UNDEFINEDCODE="return X == 0;"
+    case "${host}" in
+      *-*-darwin*)
+        if test x$build = x$host; then
+@@ -30,6 +33,11 @@
+ 	 export_sym_check=
+        fi
+      ;;
++     *-*-mingw*|*-*-cygwin*|*-*-msys*)
++       PICFLAG=""
++       UNDEFINEDPREAMBLE=""
++       UNDEFINEDCODE=""
++     ;;
+      *)
+        if test x$build = x$host; then
+ 	 export_sym_check="objdump${exeext} -T"
+@@ -81,17 +89,17 @@
+      case "${host}" in
+        *-*-darwin*)
+ 	 CFLAGS=`echo $CFLAGS | sed s/-mdynamic-no-pic//g`
+-	 CFLAGS="$CFLAGS -fPIC"
++	 CFLAGS="$CFLAGS ${PICFLAG}"
+ 	 LDFLAGS="$LDFLAGS -shared -undefined dynamic_lookup"
+        ;;
+        *)
+-	 CFLAGS="$CFLAGS -fPIC"
+-	 LDFLAGS="$LDFLAGS -fPIC -shared"
++	 CFLAGS="$CFLAGS ${PICFLAG}"
++	 LDFLAGS="$LDFLAGS ${PICFLAG} -shared"
+        ;;
+      esac
+-     AC_MSG_CHECKING([for -fPIC -shared])
++     AC_MSG_CHECKING([for ${PICFLAG} -shared])
+      AC_TRY_LINK(
+-       [extern int X;],[return X == 0;],
++       [${UNDEFINEDPREAMBLE}],[${UNDEFINEDCODE}],
+        [AC_MSG_RESULT([yes]); have_pic_shared=yes],
+        [AC_MSG_RESULT([no]); have_pic_shared=no])
+      if test x"$have_pic_shared" != x"yes" -o x"$ac_cv_search_dlopen" = x"no"; then
+diff -urN gcc-5.3.0.orig/gcc/configure gcc-5.3.0/gcc/configure
+--- gcc-5.3.0.orig/gcc/configure	2015-12-19 14:40:16.893975900 +0000
++++ gcc-5.3.0/gcc/configure	2015-12-20 01:28:45.472476700 +0000
+@@ -28386,6 +28386,9 @@
+ 
+    pluginlibs=
+ 
++   PICFLAG="-fPIC"
++   UNDEFINEDPREAMBLE="extern int X;"
++   UNDEFINEDCODE="return X == 0;"
+    case "${host}" in
+      *-*-darwin*)
+        if test x$build = x$host; then
+@@ -28396,6 +28399,11 @@
+ 	 export_sym_check=
+        fi
+      ;;
++     *-*-mingw*|*-*-cygwin*|*-*-msys*)
++       PICFLAG=""
++       UNDEFINEDPREAMBLE=""
++       UNDEFINEDCODE=""
++     ;;
+      *)
+        if test x$build = x$host; then
+ 	 export_sym_check="objdump${exeext} -T"
+@@ -28508,23 +28516,23 @@
+      case "${host}" in
+        *-*-darwin*)
+ 	 CFLAGS=`echo $CFLAGS | sed s/-mdynamic-no-pic//g`
+-	 CFLAGS="$CFLAGS -fPIC"
++	 CFLAGS="$CFLAGS ${PICFLAG}"
+ 	 LDFLAGS="$LDFLAGS -shared -undefined dynamic_lookup"
+        ;;
+        *)
+-	 CFLAGS="$CFLAGS -fPIC"
+-	 LDFLAGS="$LDFLAGS -fPIC -shared"
++	 CFLAGS="$CFLAGS ${PICFLAG}"
++	 LDFLAGS="$LDFLAGS ${PICFLAG} -shared"
+        ;;
+      esac
+-     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for -fPIC -shared" >&5
+-$as_echo_n "checking for -fPIC -shared... " >&6; }
++     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ${PICFLAG} -shared" >&5
++$as_echo_n "checking for ${PICFLAG} -shared... " >&6; }
+      cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+-extern int X;
++${UNDEFINEDPREAMBLE}
+ int
+ main ()
+ {
+-return X == 0;
++${UNDEFINEDCODE}
+   ;
+   return 0;
+ }
+diff -urN gcc-5.3.0.orig/libcc1/configure gcc-5.3.0/libcc1/configure
+--- gcc-5.3.0.orig/libcc1/configure	2015-12-19 14:40:20.855979000 +0000
++++ gcc-5.3.0/libcc1/configure	2015-12-20 01:28:45.504980900 +0000
+@@ -14500,6 +14500,9 @@
+ 
+    pluginlibs=
+ 
++   PICFLAG="-fPIC"
++   UNDEFINEDPREAMBLE="extern int X;"
++   UNDEFINEDCODE="return X == 0;"
+    case "${host}" in
+      *-*-darwin*)
+        if test x$build = x$host; then
+@@ -14510,6 +14513,11 @@
+ 	 export_sym_check=
+        fi
+      ;;
++     *-*-mingw*|*-*-cygwin*|*-*-msys*)
++       PICFLAG=""
++       UNDEFINEDPREAMBLE=""
++       UNDEFINEDCODE=""
++     ;;
+      *)
+        if test x$build = x$host; then
+ 	 export_sym_check="objdump${exeext} -T"
+@@ -14622,23 +14630,23 @@
+      case "${host}" in
+        *-*-darwin*)
+ 	 CFLAGS=`echo $CFLAGS | sed s/-mdynamic-no-pic//g`
+-	 CFLAGS="$CFLAGS -fPIC"
++	 CFLAGS="$CFLAGS ${PICFLAG}"
+ 	 LDFLAGS="$LDFLAGS -shared -undefined dynamic_lookup"
+        ;;
+        *)
+-	 CFLAGS="$CFLAGS -fPIC"
+-	 LDFLAGS="$LDFLAGS -fPIC -shared"
++	 CFLAGS="$CFLAGS ${PICFLAG}"
++	 LDFLAGS="$LDFLAGS ${PICFLAG} -shared"
+        ;;
+      esac
+-     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for -fPIC -shared" >&5
+-$as_echo_n "checking for -fPIC -shared... " >&6; }
++     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ${PICFLAG} -shared" >&5
++$as_echo_n "checking for ${PICFLAG} -shared... " >&6; }
+      cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+-extern int X;
++${UNDEFINEDPREAMBLE}
+ int
+ main ()
+ {
+-return X == 0;
++${UNDEFINEDCODE}
+   ;
+   return 0;
+ }

--- a/patches/gcc/5.3.0/380-gcc-plugin-POSIX-include-sys-select-h.patch
+++ b/patches/gcc/5.3.0/380-gcc-plugin-POSIX-include-sys-select-h.patch
@@ -1,0 +1,11 @@
+diff -urN gcc-5.3.0.orig/libcc1/connection.cc gcc-5.3.0/libcc1/connection.cc
+--- gcc-5.3.0.orig/libcc1/connection.cc	2015-12-19 14:40:20.860479600 +0000
++++ gcc-5.3.0/libcc1/connection.cc	2015-12-20 01:31:04.346611500 +0000
+@@ -21,6 +21,7 @@
+ #include <string>
+ #include <unistd.h>
+ #include <sys/types.h>
++#include <sys/select.h>
+ #include <string.h>
+ #include <errno.h>
+ #include "marshall.hh"

--- a/scripts/build/companion_libs/200-libelf.sh
+++ b/scripts/build/companion_libs/200-libelf.sh
@@ -135,6 +135,13 @@ do_libelf_backend() {
     CT_DoExecLog ALL ${make}
 
     CT_DoLog EXTRA "Installing libelf"
+
+    # Guard against $destdir$prefix == //
+    # which is a UNC path on Cygwin/MSYS2
+    if [[ ${destdir} == / ]] && [[ ${prefix} == /* ]]; then
+        destdir=
+    fi
+
     CT_DoExecLog ALL ${make} instroot="${destdir}" install
 }
 

--- a/scripts/build/companion_libs/320-libiconv.sh
+++ b/scripts/build/companion_libs/320-libiconv.sh
@@ -102,6 +102,7 @@ do_libiconv_backend() {
         --build=${CT_BUILD}                                   \
         --host="${host}"                                      \
         --prefix="${prefix}"                                  \
+        --disable-nls                                         \
         "${extra_config[@]}"                                  \
 
     CT_DoLog EXTRA "Building libiconv"


### PR DESCRIPTION
Fixes https://sourceware.org/ml/crossgcc/2015-11/msg00084.html (expat-for-host library nature (static/shared) to match with the other host libraries; it's linked to gettext and they aren't allowed to differ), then some follow on bugs I encountered trying to build that sample (patches were needed so that GCC plugins can be built on Cygwin). I've yet to verify that it builds completely yet, so this is more for discussion and so I can get testing feedback from Thies Peter, so don't merge yet, even if everything  looks good (which I doubt).

Cheers!