### PR TITLE
binutils: Fix binutils manuals_install variable

### DIFF
--- a/scripts/build/binutils/binutils.sh
+++ b/scripts/build/binutils/binutils.sh
@@ -252,8 +252,8 @@ do_binutils_backend() {
         if [ "${CT_BINUTILS_LINKER_GOLD}" = "y" ]; then
             manuals_for+=( gold )
         fi
-        manuals_install=( "${manuals_for[@]/#/install-pdf-}" )
-        manuals_install+=( "${manuals_for[@]/#/install-html-}" )
+        manuals_install=( "${manuals_for[@]/\#/install-pdf-}" )
+        manuals_install+=( "${manuals_for[@]/\#/install-html-}" )
         CT_DoExecLog ALL ${make} ${JOBSFLAGS} pdf html
         CT_DoExecLog ALL ${make} "${manuals_install[@]}"
     fi


### PR DESCRIPTION
In commit: 74d555b2
A regex in a parameter subsitution replaces a '#' hash symbol, but it is
not made literal '\#', so from the hash to the end of the line is a
comment.

Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>