### PR TITLE
binutils: Fix LDFLAGS for static toolchain

### DIFF
--- a/scripts/build/binutils/binutils.sh
+++ b/scripts/build/binutils/binutils.sh
@@ -235,7 +235,7 @@ do_binutils_backend() {
         "${CT_BINUTILS_EXTRA_CONFIG_ARRAY[@]}"
 
     if [ "${static_build}" = "y" ]; then
-        extra_make_flags+=("LDFLAGS=-all-static")
+        extra_make_flags+=("LDFLAGS=${ldflags} -all-static")
         CT_DoLog EXTRA "Prepare binutils for static build"
         CT_DoExecLog ALL ${make} ${JOBSFLAGS} configure-host
     fi


### PR DESCRIPTION
If building a static toolchain, the ldflags option passed to
do_binutils_backend is overridden when we set `LDFLAGS=-all-static`.

We should pass `LDFLAGS=${ldflags} -all-static` in this case.

This fixes #297

Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>