### PR TITLE
binutils: Fix installing libiberty for target

### DIFF
--- a/scripts/build/binutils/binutils.sh
+++ b/scripts/build/binutils/binutils.sh
@@ -351,6 +351,10 @@ do_binutils_for_target() {
             extra_config+=("--disable-multilib")
         fi
 
+        if [ "${CT_BINUTILS_FOR_TARGET_IBERTY}" = "y" ]; then
+            extra_config+=("--enable-install-libiberty")
+        fi
+
         [ "${CT_TOOLCHAIN_ENABLE_NLS}" != "y" ] && extra_config+=("--disable-nls")
 
         CT_DoExecLog CFG                                            \


### PR DESCRIPTION
If CT_BINUTILS_FOR_TARGET_IBERTY is set, then it seems that we also must
set `--enable-install-libiberty` for configure to pickup that it needs
to be installed.

This closes #302

Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>