### PR TITLE
Update gcc linaro

### DIFF
--- a/config/cc/gcc.in
+++ b/config/cc/gcc.in
@@ -77,6 +77,12 @@ config CC_GCC_V_5_3_0
     prompt "5.3.0"
     select CC_GCC_5
 
+config CC_GCC_V_linaro_5_2
+    bool
+    prompt "linaro-5.2-2015.11"
+    depends on CC_GCC_SHOW_LINARO
+    select CC_GCC_5
+
 config CC_GCC_V_linaro_4_9
     bool
     prompt "linaro-4.9-2015.06"
@@ -261,6 +267,7 @@ config CC_GCC_VERSION
 # Don't remove next line
 # CT_INSERT_VERSION_STRING_BELOW
     default "5.3.0" if CC_GCC_V_5_3_0
+    default "linaro-5.2-2015.11" if CC_GCC_V_linaro_5_2
     default "linaro-4.9-2015.06" if CC_GCC_V_linaro_4_9
     default "4.9.3" if CC_GCC_V_4_9_3
     default "linaro-4.8-2015.06" if CC_GCC_V_linaro_4_8

--- a/scripts/build/cc/100-gcc.sh
+++ b/scripts/build/cc/100-gcc.sh
@@ -28,9 +28,10 @@ do_gcc_get() {
                        ftp://{gcc.gnu.org,sourceware.org}/pub/gcc/releases/gcc-${CT_CC_GCC_VERSION}
         else
             YYMM=`echo ${CT_CC_GCC_VERSION} |cut -d- -f3 |${sed} -e 's,^..,,'`
-            CT_GetFile "gcc-${CT_CC_GCC_VERSION}"                                                               \
-                       "http://launchpad.net/gcc-linaro/${linaro_series}/${linaro_version}/+download"       \
-                       https://releases.linaro.org/${YYMM}/components/toolchain/gcc-linaro/${linaro_series} \
+            CT_GetFile "gcc-${CT_CC_GCC_VERSION}"                                                             \
+                       "https://releases.linaro.org/components/toolchain/gcc-linaro/${linaro_version}"        \
+                       "https://releases.linaro.org/${YYMM}/components/toolchain/gcc-linaro/${linaro_series}" \
+                       "http://launchpad.net/gcc-linaro/${linaro_series}/${linaro_version}/+download"         \
                        http://cbuild.validation.linaro.org/snapshots
         fi
 


### PR DESCRIPTION
These commits update the download path for new linaro releases, and adds a new 5.2-2015.11 release.