### PR TITLE
linux: Update kernel versions

### DIFF
--- a/config/kernel/linux.in
+++ b/config/kernel/linux.in
@@ -46,31 +46,31 @@ choice
 
 config KERNEL_V_4_3
     bool
-    prompt "4.3 (mainline)"
+    prompt "4.3.3 (stable)"
 
 config KERNEL_V_4_2
     bool
-    prompt "4.2.6 (stable)"
+    prompt "4.2.8 (EOL)"
 
 config KERNEL_V_4_1
     bool
-    prompt "4.1.13"
+    prompt "4.1.15"
 
 config KERNEL_V_3_18
     bool
-    prompt "3.18.24"
+    prompt "3.18.25"
 
 config KERNEL_V_3_14
     bool
-    prompt "3.14.57"
+    prompt "3.14.58"
 
 config KERNEL_V_3_12
     bool
-    prompt "3.12.50"
+    prompt "3.12.51"
 
 config KERNEL_V_3_10
     bool
-    prompt "3.10.93"
+    prompt "3.10.94"
 
 config KERNEL_V_3_4
     bool
@@ -78,11 +78,11 @@ config KERNEL_V_3_4
 
 config KERNEL_V_3_2
     bool
-    prompt "3.2.72"
+    prompt "3.2.75"
 
 config KERNEL_V_2_6_32
     bool
-    prompt "2.6.32.68"
+    prompt "2.6.32.69"
     help
  
 endchoice
@@ -91,15 +91,15 @@ config KERNEL_VERSION
     string
 # Don't remove next line
 # CT_INSERT_VERSION_STRING_BELOW
-    default "4.3" if KERNEL_V_4_3
-    default "4.2.6" if KERNEL_V_4_2
-    default "4.1.13" if KERNEL_V_4_1
-    default "3.18.24" if KERNEL_V_3_18
-    default "3.14.57" if KERNEL_V_3_14
-    default "3.12.50" if KERNEL_V_3_12
-    default "3.10.93" if KERNEL_V_3_10
+    default "4.3.3" if KERNEL_V_4_3
+    default "4.2.8" if KERNEL_V_4_2
+    default "4.1.15" if KERNEL_V_4_1
+    default "3.18.25" if KERNEL_V_3_18
+    default "3.14.58" if KERNEL_V_3_14
+    default "3.12.51" if KERNEL_V_3_12
+    default "3.10.94" if KERNEL_V_3_10
     default "3.4.110" if KERNEL_V_3_4
-    default "3.2.72" if KERNEL_V_3_2
-    default "2.6.32.68" if KERNEL_V_2_6_32
+    default "3.2.75" if KERNEL_V_3_2
+    default "2.6.32.69" if KERNEL_V_2_6_32
 
 endif # ! KERNEL_LINUX_CUSTOM


### PR DESCRIPTION
The following versions were updated:
 * 4.3       -> 4.3.3 (stable)
 * 4.2.6     -> 4.2.8 (EOL)
 * 4.1.13    -> 4.1.15
 * 3.18.24   -> 3.18.25
 * 3.14.57   -> 3.14.58
 * 3.12.50   -> 3.12.51
 * 3.10.93   -> 3.10.94
 * 3.2.72    -> 3.2.75
 * 2.6.32.68 -> 2.6.32.69

4.3 mainline is now 4.3.3 stable
The 4.2 series is now EOL. You should move to 4.3.3!

Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>