### PR TITLE
Update elf2flt

### DIFF
--- a/config/binutils/binutils.in.2
+++ b/config/binutils/binutils.in.2
@@ -12,7 +12,7 @@ config ELF2FLT_GIT
     bool
     prompt "git"
     help
-      Grab the latest version of elf2flt from the CVS repository
+      Grab the latest version of elf2flt from the Git repository
 
 config ELF2FLT_CUSTOM
     bool
@@ -29,7 +29,7 @@ if ELF2FLT_GIT
 config ELF2FLT_GIT_CSET
     string
     prompt "git cset"
-    default "21c6a41885ad544763ccd19883c1353f3b0b7a47"
+    default "892e098c1268da3d063c9aee888ebbc638739b4b"
     help
       Enter the git changeset to use.
 

--- a/scripts/build/binutils/binutils.sh
+++ b/scripts/build/binutils/binutils.sh
@@ -25,7 +25,7 @@ do_binutils_get() {
             CT_GetCustom "elf2flt" "${CT_ELF2FLT_CUSTOM_VERSION}" \
                 "${CT_ELF2FLT_CUSTOM_LOCATION}"
         else
-            CT_GetGit elf2flt "${CT_ELF2FLT_GIT_CSET}" git://wh0rd.org/elf2flt.git
+            CT_GetGit elf2flt "${CT_ELF2FLT_GIT_CSET}" https://github.com/uclinux-dev/elf2flt.git
         fi
     fi
 }

--- a/scripts/build/kernel/linux.sh
+++ b/scripts/build/kernel/linux.sh
@@ -10,6 +10,7 @@ CT_DoKernelTupleValues() {
         # while others must have a -linux tuple.  Other targets
         # should be added here when someone starts to care about them.
         case "${CT_ARCH}" in
+            arm*)       CT_TARGET_KERNEL="linux" ;;
             m68k)       CT_TARGET_KERNEL="uclinux" ;;
             *)          CT_Abort "Unsupported no-mmu arch '${CT_ARCH}'"
         esac


### PR DESCRIPTION
This PR updates elf2flt and allows arm* to build linux headers when no-mmu.