### PR TITLE
gcc: remove CC_GCC_EXTRA_ENV_ARRAY

### DIFF
--- a/config/cc/gcc.in.2
+++ b/config/cc/gcc.in.2
@@ -37,16 +37,6 @@ config CC_GCC_EXTRA_CONFIG_ARRAY
       if they are properly quoted (or escaped, but prefer quotes). Eg.:
           --with-foo="1st arg with 4 spaces" --with-bar=2nd-arg-without-space
 
-config CC_GCC_EXTRA_ENV_ARRAY
-    string
-    prompt "Extra env variables to set for make"
-    default ""
-    help
-      Used to add specific env variables on the make command line for the
-      gcc build (eg. INHIBIT_LIBC_CFLAGS='-DUSE_TM_CLONE_REGISTRY=0')
-
-      Leave blank if you don't know better.
-
 config CC_GCC_TARGET_FINAL
     bool
     prompt "Use the default targets all and install for the final compiler"

--- a/scripts/build/cc/100-gcc.sh
+++ b/scripts/build/cc/100-gcc.sh
@@ -200,7 +200,6 @@ do_gcc_core_backend() {
     local -a core_targets_all
     local -a core_targets_install
     local -a extra_user_config
-    local -a extra_user_env
     local arg
 
     for arg in "$@"; do
@@ -407,10 +406,6 @@ do_gcc_core_backend() {
         extra_config+=("--disable-multilib")
     fi
 
-    if [ "x${CT_CC_GCC_EXTRA_ENV_ARRAY}" != "x" ]; then
-        extra_user_env=( "${CT_CC_GCC_EXTRA_ENV_ARRAY[@]}" )
-    fi
-
     CT_DoLog DEBUG "Extra config passed: '${extra_config[*]}'"
 
     # Clang's default bracket-depth is 256, and building GCC
@@ -488,7 +483,7 @@ do_gcc_core_backend() {
             repair_cc=""
         fi
 
-        CT_DoExecLog ALL ${make} ${JOBSFLAGS} ${extra_user_env} -C gcc ${libgcc_rule} \
+        CT_DoExecLog ALL ${make} ${JOBSFLAGS} -C gcc ${libgcc_rule} \
                               ${repair_cc}
         ${sed} -r -i -e 's@-lc@@g' gcc/${libgcc_rule}
     else # build_libgcc
@@ -519,10 +514,10 @@ do_gcc_core_backend() {
     esac
 
     CT_DoLog EXTRA "Building ${log_txt}"
-    CT_DoExecLog ALL ${make} ${JOBSFLAGS} ${extra_user_env} ${core_targets_all}
+    CT_DoExecLog ALL ${make} ${JOBSFLAGS} ${core_targets_all}
 
     CT_DoLog EXTRA "Installing ${log_txt}"
-    CT_DoExecLog ALL ${make} ${JOBSFLAGS} ${extra_user_env} ${core_targets_install}
+    CT_DoExecLog ALL ${make} ${JOBSFLAGS} ${core_targets_install}
 
     # Remove the libtool "pseudo-libraries": having them in the installed
     # tree makes the libtoolized utilities that are built next assume


### PR DESCRIPTION
I was noticing that $extra_user_env was inconsistently used in
100-gcc.sh. I don't feel comfortable having just any make flag or
environment variable passed to make from a config file. If a specific
option needs to be passed to make for gcc, then a specific kconfig
option should be added for that make flag/option/env.

Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>