### PR TITLE
Remove GCC dependency to libelf

### DIFF
--- a/config/cc/gcc.in
+++ b/config/cc/gcc.in
@@ -213,7 +213,6 @@ config CC_GCC_USE_LTO
     bool
     default y
     depends on CC_GCC_HAS_LTO
-    select CC_GCC_USE_LIBELF
     help
       Enable the Link Time Optimisations.
 
@@ -249,10 +248,6 @@ config CC_GCC_USE_GMP_MPFR
 config CC_GCC_USE_MPC
     bool
     select MPC_NEEDED
-
-config CC_GCC_USE_LIBELF
-    bool
-    select LIBELF_NEEDED
 
 config CC_GCC_HAS_LIBQUADMATH
     bool

--- a/scripts/build/cc/100-gcc.sh
+++ b/scripts/build/cc/100-gcc.sh
@@ -343,10 +343,8 @@ do_gcc_core_backend() {
         extra_config+=("--with-cloog=no")
     fi
     if [ "${CT_CC_GCC_USE_LTO}" = "y" ]; then
-        extra_config+=("--with-libelf=${complibs}")
         extra_config+=("--enable-lto")
     elif [ "${CT_CC_GCC_HAS_LTO}" = "y" ]; then
-        extra_config+=("--with-libelf=no")
         extra_config+=("--disable-lto")
     fi
 
@@ -801,10 +799,8 @@ do_gcc_backend() {
         extra_config+=("--with-cloog=no")
     fi
     if [ "${CT_CC_GCC_USE_LTO}" = "y" ]; then
-        extra_config+=("--with-libelf=${complibs}")
         extra_config+=("--enable-lto")
     elif [ "${CT_CC_GCC_HAS_LTO}" = "y" ]; then
-        extra_config+=("--with-libelf=no")
         extra_config+=("--disable-lto")
     fi
 


### PR DESCRIPTION
As crosstools-ng only support GCC >= 4.8 we do not need libelf for gcc. GCC dropped this dependency with 4.6.

Signed-off-by: Matthias Weisser <m.weisser.m@gmail.com>