### PR TITLE
patches/binutils: wcsncasecmp is provided by OSX >= 10.7

### DIFF
--- a/patches/binutils/2.25.1/350-Darwin-Two-fixes-from-Android-NDK-PTHREAD_ONCE_INIT-wcsncasecmp.patch
+++ b/patches/binutils/2.25.1/350-Darwin-Two-fixes-from-Android-NDK-PTHREAD_ONCE_INIT-wcsncasecmp.patch
@@ -21,7 +21,7 @@ index 13e39e4..7a98306 100644
  }
  #endif /* HAVE_WCHAR_H and not Cygwin/Mingw */
  
-+#ifdef __APPLE__
++#if defined __APPLE__ && __DARWIN_C_LEVEL < 200809L
 +/* wcsncasecmp isn't always defined in Mac SDK */
 +static int
 +wcsncasecmp(const wchar_t *s1, const wchar_t *s2, size_t n)


### PR DESCRIPTION
OSX SDK has a declaration for `wcsncasecmp` since 10.7, which conflicts with
the definition provided by the patch for binutils.

In `/usr/include/wchar.h` on ElCapitan we have:
```c
/* Additional functionality provided by:
 * POSIX.1-2008
 */

#if __DARWIN_C_LEVEL >= 200809L
__BEGIN_DECLS
// [snip]
int     wcsncasecmp(const wchar_t *, const wchar_t *, size_t n) __OSX_AVAILABLE_STARTING(__MAC_10_7, __IPHONE_4_3);
// [snip]
__END_DECLS
#endif /* __DARWIN_C_LEVEL >= 200809L */
```