### PR TITLE
functions: Softlink custom directory

### DIFF
--- a/scripts/functions
+++ b/scripts/functions
@@ -671,7 +671,7 @@ CT_GetCustom() {
     elif [ "${component_location_type}" = "dir" ]; then
         CT_DoLog EXTRA "Got '${component_location}' from custom location"
         [ ! -d "${CT_SRC_DIR}/${component_name}-${component_version}" ] && \
-            CT_DoExecLog DEBUG cp -al "${component_location}" \
+            CT_DoExecLog DEBUG cp -as "${component_location}" \
             "${CT_SRC_DIR}/${component_name}-${component_version}"
 
         # Don't try to extract from source directory, it's extracted!


### PR DESCRIPTION
Hardlinking the custom source directory does not work across separate
mount points. Chnage this to a softlink instead.

This closes #336

Reported-by: Jasmin Jessich <jasmin@anw.at>
Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>