### PR TITLE
Glibc 2.16.0 backports for 1.22

### DIFF
--- a/patches/glibc/2.16.0/510-accept-make-versions-4.0-or-higher.patch
+++ b/patches/glibc/2.16.0/510-accept-make-versions-4.0-or-higher.patch
@@ -1,0 +1,34 @@
+From 28d708c44bc47b56f6551ff285f78edcf61c208a Mon Sep 17 00:00:00 2001
+From: Marc-Antoine Perennou <Marc-Antoine@Perennou.com>
+Date: Thu, 31 Oct 2013 12:37:50 +1000
+Subject: [PATCH] Accept make versions 4.0 and greater
+---
+diff --git a/configure b/configure
+index f382138..5e61abd 100755
+--- a/configure
++++ b/configure
+@@ -4761,7 +4761,7 @@ $as_echo_n "checking version of $MAKE... " >&6; }
+   ac_prog_version=`$MAKE --version 2>&1 | sed -n 's/^.*GNU Make[^0-9]*\([0-9][0-9.]*\).*$/\1/p'`
+   case $ac_prog_version in
+     '') ac_prog_version="v. ?.??, bad"; ac_verc_fail=yes;;
+-    3.79* | 3.[89]*)
++    3.79* | 3.[89]* | [4-9].* | [1-9][0-9]*)
+        ac_prog_version="$ac_prog_version, ok"; ac_verc_fail=no;;
+     *) ac_prog_version="$ac_prog_version, bad"; ac_verc_fail=yes;;
+ 
+diff --git a/configure.in b/configure.in
+index 49b70fd..6da8efd 100644
+--- a/configure.in
++++ b/configure.in
+@@ -984,7 +984,7 @@ AC_CHECK_PROG_VER(CC, ${ac_tool_prefix}gcc ${ac_tool_prefix}cc, -v,
+   critic_missing="$critic_missing gcc")
+ AC_CHECK_PROG_VER(MAKE, gnumake gmake make, --version,
+   [GNU Make[^0-9]*\([0-9][0-9.]*\)],
+-  [3.79* | 3.[89]*], critic_missing="$critic_missing make")
++  [3.79* | 3.[89]* | [4-9].* | [1-9][0-9]*], critic_missing="$critic_missing make")
+ 
+ AC_CHECK_PROG_VER(MSGFMT, gnumsgfmt gmsgfmt msgfmt, --version,
+   [GNU gettext.* \([0-9]*\.[0-9.]*\)],
+-- 
+1.9.4
+

--- a/patches/glibc/2.16.0/520-fix-sed-configure-check.patch
+++ b/patches/glibc/2.16.0/520-fix-sed-configure-check.patch
@@ -1,0 +1,35 @@
+From 07e515506660b1d0c1934dc0ac0e2ac5e7a4a760 Mon Sep 17 00:00:00 2001
+From: "Dmitry V. Levin" <ldv@altlinux.org>
+Date: Wed, 22 Aug 2012 12:58:18 -0700
+Subject: [PATCH] Fix sed configure check for newer sed --version output.
+
+---
+diff --git a/configure b/configure
+index 9dddf3c..a573bfe 100755
+--- a/configure
++++ b/configure
+@@ -4963,7 +4963,7 @@ else
+   # Found it, now check the version.
+   { $as_echo "$as_me:${as_lineno-$LINENO}: checking version of $SED" >&5
+ $as_echo_n "checking version of $SED... " >&6; }
+-  ac_prog_version=`$SED --version 2>&1 | sed -n 's/^.*GNU sed version \([0-9]*\.[0-9.]*\).*$/\1/p'`
++  ac_prog_version=`$SED --version 2>&1 | sed -n 's/^.*GNU sed[^0-9]* \([0-9]*\.[0-9.]*\).*$/\1/p'`
+   case $ac_prog_version in
+     '') ac_prog_version="v. ?.??, bad"; ac_verc_fail=yes;;
+     3.0[2-9]*|3.[1-9]*|[4-9]*)
+diff --git a/configure.in b/configure.in
+index f5dbff6..1b05c87 100644
+--- a/configure.in
++++ b/configure.in
+@@ -909,7 +909,7 @@ AC_CHECK_PROG_VER(MAKEINFO, makeinfo, --version,
+   [4.[5-9]*|4.[1-9][0-9]*|[5-9].*],
+   MAKEINFO=: aux_missing="$aux_missing makeinfo")
+ AC_CHECK_PROG_VER(SED, sed, --version,
+-  [GNU sed version \([0-9]*\.[0-9.]*\)],
++  [GNU sed[^0-9]* \([0-9]*\.[0-9.]*\)],
+   [3.0[2-9]*|3.[1-9]*|[4-9]*],
+   SED=: aux_missing="$aux_missing sed")
+ 
+-- 
+1.9.4
+


### PR DESCRIPTION
As suggested in  #339 this is targeting the 1.22 branch.

These are some back ports that allow glibc-2.16.0 to build on a newer system.