### PR TITLE
functions: use 'ln -sf' for softlinks

### DIFF
--- a/scripts/functions
+++ b/scripts/functions
@@ -671,7 +671,7 @@ CT_GetCustom() {
     elif [ "${component_location_type}" = "dir" ]; then
         CT_DoLog EXTRA "Got '${component_location}' from custom location"
         [ ! -d "${CT_SRC_DIR}/${component_name}-${component_version}" ] && \
-            CT_DoExecLog DEBUG cp -as "${component_location}" \
+            CT_DoExecLog DEBUG ln -sf "${component_location}" \
             "${CT_SRC_DIR}/${component_name}-${component_version}"
 
         # Don't try to extract from source directory, it's extracted!


### PR DESCRIPTION
I should have just used ln -sf when I rewrote the custom locations
change. BSD based systems don't have 'cp -s', so switch to using 'ln
-sf'.

Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>