### PR TITLE
glibc: Add support for v2.23, only Cygwin patch from v2.22

### DIFF
--- a/config/libc/glibc.in
+++ b/config/libc/glibc.in
@@ -71,6 +71,11 @@ choice
 # Don't remove next line
 # CT_INSERT_VERSION_BELOW
 
+config LIBC_GLIBC_V_2_23
+    bool
+    prompt "2.23"
+    select LIBC_GLIBC_2_20_or_later
+
 config LIBC_GLIBC_V_2_22
     bool
     prompt "2.22"
@@ -186,6 +191,7 @@ config LIBC_VERSION
     string
 # Don't remove next line
 # CT_INSERT_VERSION_STRING_BELOW
+    default "2.23" if LIBC_GLIBC_V_2_23
     default "2.22" if LIBC_GLIBC_V_2_22
     default "2.21" if LIBC_GLIBC_V_2_21
     default "linaro-2.20-2014.11" if LIBC_GLIBC_LINARO_V_2_20

--- a/patches/glibc/2.23/110-Cygwin-doesnt-have-stat64.patch
+++ b/patches/glibc/2.23/110-Cygwin-doesnt-have-stat64.patch
@@ -1,0 +1,13 @@
+--- glibc-2.22/sunrpc/rpc_main.c.orig	2015-08-05 07:42:21.000000000 +0100
++++ glibc-2.22/sunrpc/rpc_main.c	2015-10-21 23:37:31.071268800 +0100
+@@ -51,6 +51,10 @@
+ #include "rpc_scan.h"
+ #include "proto.h"
+ 
++#if defined(__CYGWIN__)
++#define stat64 stat
++#endif
++
+ #include "../version.h"
+ #define PACKAGE _libc_intl_domainname
+ 


### PR DESCRIPTION
This patch adds support for the recently released GNU C Library v2.23,
for release details, see:

https://www.sourceware.org/ml/libc-alpha/2016-02/msg00502.html

I've added only the Cygwin patch from v2.22, the Sparc one does not apply anymore.

Signed-off-by: Joachim Nilsson <troglobit@gmail.com>