### PR TITLE
debian: update packaging

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+crosstool-ng (1.23.0-1) unstable; urgency=low
+
+  * Initial upload, Closes: #721430
+
+ -- Multiple Candidates <open@example.com>  Wed, 24 May 2017 13:47:31 +0200
+
 crosstool-ng (1.22.0git) unstable; urgency=low
 
   * Initial Debianized Release.

--- a/debian/control
+++ b/debian/control
@@ -1,13 +1,24 @@
 Source: crosstool-ng
-Section: unknown
+Section: devel
 Priority: optional
-Maintainer: Andrew 'Necromant' Andrianov <andrew@ncrmnt.org>
-Build-Depends: debhelper (>= 9), autotools-dev, libncursesw5-dev, libncurses5-dev, autoconf, git, gperf, bison, flex, texinfo, help2man, gawk, subversion, git, gzip, bzip2, tar, libtool-bin, automake
-Standards-Version: 3.9.5
+Maintainer: Multiple Candidates <open@example.com>
+Build-Depends: debhelper (>= 9), autoconf, automake, autotools-dev,
+ libncursesw5-dev, libncurses5-dev, gperf, bison, flex,
+ texinfo, help2man, gawk, git, subversion, bzip2, libtool-bin
+Standards-Version: 3.9.8
 Homepage: http://crosstool-ng.org/
 
 Package: crosstool-ng
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, build-essential, texi2html, texinfo
-Description: crosstool-ng
- The ultimate tool to create your own cross toolchains
+Depends: ${shlibs:Depends}, ${misc:Depends}, build-essential, texinfo
+Description: create your own cross toolchains
+ Crosstool-NG aims at building toolchains. Toolchains are an essential
+ component in a software development project. It will compile, assemble and
+ link the code that is being developed.
+ .
+ The usual toolchain is called "native" and is in packages
+ like 'clang' and 'gcc' (This package is not needed for doing
+ native development).
+ .
+ This package is for generating toolchains when doing development
+ on a foreign architecture (when you need a cross compiler).

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,61 +1,68 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: crosstool-ng
-Source: <http://crosstool-ng.org/>
+Source: http://crosstool-ng.org/
 
 Files: *
 Copyright: 2015 Crosstool-NG Developers
 License: GPL-2.0+
+ /usr/share/common-licenses/GPL-2
 
 Files: debian/*
-Copyright: 2015 Andrew 'Necromant' Andrianov <andrew@ncrmnt.org>
+Copyright:
+  2015 Andrew 'Necromant' Andrianov <andrew@ncrmnt.org>
+  2017 Several Candidates <open@example.com>
 License: GPL-2.0+
+ /usr/share/common-licenses/GPL-2
 
-License: GPL-2.0+
-Unless otherwise stated in individual files, this work is licensed to you under
-the following terms.
 
-- Files in docs/ are available under the Creative Commons Attribution, Share
-  Alike (by-sa), v2.5, to be found there:
-    licenses.d/by-sa/deed.en     (human-readable summary)
-    licenses.d/by-sa/legalcode   (legal code, the full license)
-    
-- Files found in patches/*/ are available under the same license as the
-  upstream software they apply to.
+Files: docs/*
+Copyright: Various
+License: CC-BY-SA-2.5
+ Files in docs/ are available under the Creative Commons Attribution, Share
+ Alike (by-sa), v2.5, to be found there:
+   licenses.d/by-sa/deed.en     (human-readable summary)
+   licenses.d/by-sa/legalcode   (legal code, the full license)
 
-  That means that you can't use those patches if you were licensed the
-  software under a specific license which is not the one the software is
-  commonly available under.
-
-  As an example, if you ever managed to get the Linux kernel under a license
-  other than the GPLv2, you are not allowed to use the Linux kernel patches
-  coming with crosstool-NG, as those are available under the GPLv2, which is
-  the license the Linux kernel is most commonly available under.
-
-  As a convenience, the GNU Lesser General Public License (LGPL) v2.1 (for the
-  patches against glibc, uClibc, and some other libraries) is available there:
-    licenses.d/lgpl.txt
-
-- Other files not covered by the above licenses, and not covered by an
-  individual license specified in the file itself, or an accompanying file,
-  are available under the GNU General Public License (GPL), v2, to be found
-  here:
-    licenses.d/gpl.txt
-
-- Also, I want to clarify one point. If you build a toolchain with crosstool-NG
-  and you happen to sell, deliver, or otherwise publish this toolchain to a
-  third party, I consider crosstool-NG as being part of the sources needed to
-  rebuild the afore-mentioned toolchain, alongside with all other source code
-  that third party is otherwise entitled to receive, due to other licenses of
-  the different components. See licenses.d/gpl.txt, section 3, which reads:
-   > For an executable work, complete source code means [...], plus the
-   > scripts used to control compilation and installation of the executable.
-
-  In short: crosstool-NG is the part refered to as "the scripts to control
-  compilation and installation of the executable", it being the toolchain in
-  our case; and as such you must make it available, in conformance to the
-  GPLv2, see above.
-
-  Also, if you have local patches that you apply to the different components
-  (either manualy, or by instructing crosstool-NG to do so), you will have to
-  make those patches available alongside with your toolchain, to comply with
-  the licenses of the components impacted by your patches.
+Files: patches/*
+Copyright: Various
+License: Various
+ Files found in patches/*/ are available under the same license as the
+ upstream software they apply to.
+ .
+ That means that you can't use those patches if you were licensed the
+ software under a specific license which is not the one the software is
+ commonly available under.
+ .
+ As an example, if you ever managed to get the Linux kernel under a license
+ other than the GPLv2, you are not allowed to use the Linux kernel patches
+ coming with crosstool-NG, as those are available under the GPLv2, which is
+ the license the Linux kernel is most commonly available under.
+ .
+ As a convenience, the GNU Lesser General Public License (LGPL) v2.1 (for the
+ patches against glibc, uClibc, and some other libraries) is available there:
+   licenses.d/lgpl.txt
+ .
+ Other files not covered by the above licenses, and not covered by an
+ individual license specified in the file itself, or an accompanying file,
+ are available under the GNU General Public License (GPL), v2, to be found
+ here:
+   licenses.d/gpl.txt
+ .
+ Also, I want to clarify one point. If you build a toolchain with crosstool-NG
+ and you happen to sell, deliver, or otherwise publish this toolchain to a
+ third party, I consider crosstool-NG as being part of the sources needed to
+ rebuild the afore-mentioned toolchain, alongside with all other source code
+ that third party is otherwise entitled to receive, due to other licenses of
+ the different components. See licenses.d/gpl.txt, section 3, which reads:
+  > For an executable work, complete source code means [...], plus the
+  > scripts used to control compilation and installation of the executable.
+ .
+ In short: crosstool-NG is the part refered to as "the scripts to control
+ compilation and installation of the executable", it being the toolchain in
+ our case; and as such you must make it available, in conformance to the
+ GPLv2, see above.
+ .
+ Also, if you have local patches that you apply to the different components
+ (either manualy, or by instructing crosstool-NG to do so), you will have to
+ make those patches available alongside with your toolchain, to comply with
+ the licenses of the components impacted by your patches.

--- a/debian/rules
+++ b/debian/rules
@@ -23,7 +23,8 @@ include /usr/share/dpkg/default.mk
 
 # Make sure we call ./bootstrap before running dh_auto_configure
 override_dh_auto_configure:
-	./bootstrap && dh_auto_configure
+	test -e configure || ./bootstrap
+	dh_auto_configure
 
 #Make sure to include bash completion file in the package
 override_dh_auto_install:

--- a/debian/source/format
+++ b/debian/source/format
@@ -1,1 +1,1 @@
-3.0 (native)
+3.0 (quilt)


### PR DESCRIPTION
Support building in tree and from a released tarball by optionally
running ./bootstrap.

Fix some issues reported by lintian.
-E: crosstool-ng changes: bad-distribution-in-changes-file unstable
-E: crosstool-ng source: build-depends-on-essential-package-without-using-version build-depends: gzip
-E: crosstool-ng source: build-depends-on-essential-package-without-using-version build-depends: tar
-W: crosstool-ng source: syntax-error-in-dep5-copyright line 14: Cannot parse line "Unless otherwise stated in individual files, this work is licensed to you under"
-E: crosstool-ng: copyright-should-refer-to-common-license-file-for-lgpl
-E: crosstool-ng: description-starts-with-package-name
-E: crosstool-ng: section-is-dh_make-template
-E: crosstool-ng: depends-on-obsolete-package depends: texi2html

Signed-off-by: Chris Packham chris.packham@alliedtelesis.co.nz
