### PR TITLE
configure: Check to see if gcc can static link

### DIFF
--- a/config/cc/gcc.in.2
+++ b/config/cc/gcc.in.2
@@ -56,6 +56,7 @@ config CC_GCC_STATIC_LIBSTDCXX
     bool
     prompt "Link libstdc++ statically into the gcc binary"
     default y
+    depends on CONFIGURE_has_static_link
     select WANTS_STATIC_LINK
     help
       Newer gcc versions require some c++ libraries. So statically

--- a/config/debug/gdb.in.cross
+++ b/config/debug/gdb.in.cross
@@ -18,6 +18,7 @@ if GDB_CROSS
 config GDB_CROSS_STATIC
     bool
     prompt "Build a static cross gdb"
+    depends on CONFIGURE_has_static_link
     select WANTS_STATIC_LINK
     help
       A static cross gdb can be usefull if you debug on a machine that is

--- a/config/debug/gdb.in.gdbserver
+++ b/config/debug/gdb.in.gdbserver
@@ -17,6 +17,7 @@ config GDB_GDBSERVER_HAS_IPA_LIB
 config GDB_GDBSERVER_STATIC
     bool
     prompt "Build a static gdbserver"
+    depends on CONFIGURE_has_static_link
     default y
     help
       In case you have trouble with dynamic loading of shared libraries,

--- a/config/debug/gdb.in.native
+++ b/config/debug/gdb.in.native
@@ -15,6 +15,7 @@ if GDB_NATIVE
 config GDB_NATIVE_STATIC
     bool
     prompt "Build a static native gdb"
+    depends on CONFIGURE_has_static_link
     help
       In case you have trouble with dynamic loading of shared libraries,
       you will find that a static gdb comes in handy.

--- a/config/toolchain.in
+++ b/config/toolchain.in
@@ -52,6 +52,7 @@ config WANTS_STATIC_LINK
 config STATIC_TOOLCHAIN
     bool
     prompt "Build Static Toolchain"
+    depends on CONFIGURE_has_static_link
     select WANTS_STATIC_LINK
     help
       Build static host binaries.

--- a/configure.ac
+++ b/configure.ac
@@ -133,6 +133,19 @@ AS_IF([test -z "$CC"],
       [AC_MSG_ERROR([no suitable compiler found])])
 AC_PROG_CPP
 
+#---------------------------------------------------------------------
+# Check to see if gcc can static link
+AC_MSG_CHECKING([if gcc can static link])
+echo "int main() {}" | gcc -static -xc - > /dev/null 2>&1
+static_test=$?
+AS_IF([test $static_test -eq 0],
+          [static_link=y
+           AC_MSG_RESULT([yes])],
+      [test $static_test -ne 0],
+          [static_link=
+           AC_MSG_RESULT([no])])
+ACX_SET_KCONFIG_OPTION([static_link])
+
 # But we still need a way to specify the PATH to GNU versions (Damn MacOS)
 AC_ARG_WITH([objcopy],
     AS_HELP_STRING([--with-objcopy=PATH],


### PR DESCRIPTION
This is a semi-nasty-hack to see if gcc can static link.
Obviously on Mac OS X this is not possible, so we set
CT_CONFIGURE_has_static_link=y if it can.

Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>