### PR TITLE
musl-libc: Rewrite musl.sh build script

### DIFF
--- a/scripts/build/libc/musl.sh
+++ b/scripts/build/libc/musl.sh
@@ -3,15 +3,11 @@
 # Licensed under the GPL v2. See COPYING in the root of this package
 
 do_libc_get() {
-    local libc_src
-
-    libc_src="http://www.musl-libc.org/releases"
-
     if [ "${CT_LIBC_MUSL_CUSTOM}" = "y" ]; then
         CT_GetCustom "musl" "${CT_LIBC_MUSL_CUSTOM_VERSION}" \
             "${CT_LIBC_MUSL_CUSTOM_LOCATION}"
     else # ! custom location
-        CT_GetFile "musl-${CT_LIBC_VERSION}" "${libc_src}"
+        CT_GetFile "musl-${CT_LIBC_VERSION}" http://www.musl-libc.org/releases
     fi # ! custom location
 }
 
@@ -24,10 +20,52 @@ do_libc_check_config() {
     :
 }
 
-do_libc_configure() {
-    CT_DoLog EXTRA "Configuring C library"
+# Build and install headers and start files
+do_libc_start_files() {
+    # Start files and Headers should be configured the same way as the
+    # final libc, but built and installed differently.
+    do_libc_backend libc_mode=startfiles
+}
+
+# This function builds and install the full C library
+do_libc() {
+    do_libc_backend libc_mode=final
+}
+
+do_libc_post_cc() {
+    :
+}
+
+# This backend builds the C library
+# Usage: do_libc_backend param=value [...]
+#   Parameter           : Definition                      : Type      : Default
+#   libc_mode           : 'startfiles' or 'final'         : string    : (none)
+do_libc_backend() {
+    local libc_mode
     local -a extra_cflags
     local -a extra_config
+    local src_dir="${CT_SRC_DIR}/${CT_LIBC}-${CT_LIBC_VERSION}"
+    local libc_headers libc_startfiles libc_full
+
+    for arg in "$@"; do
+        eval "${arg// /\\ }"
+    done
+
+    case "${libc_mode}" in
+        startfiles)
+            CT_DoStep INFO "Installing C library headers & start files"
+            libc_headers=y
+            libc_startfiles=y
+            libc_full=
+            ;;
+        final)
+            CT_DoStep INFO "Installing C library"
+            libc_headers=
+            libc_startfiles=
+            libc_full=y
+            ;;
+        *)  CT_Abort "Unsupported (or unset) libc_mode='${libc_mode}'";;
+    esac
 
     # From buildroot:
     # gcc constant folding bug with weak aliases workaround
@@ -46,6 +84,8 @@ do_libc_configure() {
 
     extra_config+=( "--enable-optimize=${CT_LIBC_MUSL_OPTIMIZE}" )
 
+    CT_mkdir_pushd "${CT_BUILD_DIR}/build-libc-${libc_mode}"
+
     # NOTE: musl handles the build/host/target a little bit differently
     # then one would expect:
     #   build   : not used
@@ -54,56 +94,33 @@ do_libc_configure() {
     CT_DoExecLog CFG                \
     CFLAGS="${extra_cflags[@]}"     \
     CROSS_COMPILE="${CT_TARGET}-"   \
-    ./configure                     \
+    ${src_dir}/configure            \
         --host="${CT_TARGET}"       \
         --target="${CT_TARGET}"     \
         --prefix="/usr"             \
         --disable-gcc-wrapper       \
         "${extra_config[@]}"
-}
 
-do_libc_start_files() {
-    CT_DoStep INFO "Installing C library headers"
+    if [ "${libc_headers}" = "y" ]; then
+        CT_DoLog EXTRA "Installing C library headers"
+        CT_DoExecLog ALL ${make} DESTDIR="${CT_SYSROOT_DIR}" install-headers
+    fi
+    if [ "${libc_startfiles}" = "y" ]; then
+        CT_DoLog EXTRA "Building C library start files"
+        CT_DoExecLog ALL ${make} DESTDIR="${CT_SYSROOT_DIR}" \
+            obj/crt/crt1.o obj/crt/crti.o obj/crt/crtn.o
+        CT_DoLog EXTRA "Installing C library start files"
+        CT_DoExecLog ALL cp -av obj/crt/crt*.o "${CT_SYSROOT_DIR}/usr/lib"
+        CT_DoExecLog ALL ${CT_TARGET}-gcc -nostdlib \
+            -nostartfiles -shared -x c /dev/null -o "${CT_SYSROOT_DIR}/usr/lib/libc.so"
+    fi
+    if [ "${libc_full}" = "y" ]; then
+        CT_DoLog EXTRA "Building C library"
+        CT_DoExecLog ALL ${make} ${JOBSFLAGS}
 
-    # Simply copy files until musl has the ability to build out-of-tree
-    CT_DoLog EXTRA "Copying sources to build directory"
-    CT_DoExecLog ALL cp -av "${CT_SRC_DIR}/musl-${CT_LIBC_VERSION}" \
-                            "${CT_BUILD_DIR}/build-libc-headers"
-    cd "${CT_BUILD_DIR}/build-libc-headers"
-
-    do_libc_configure
-
-    CT_DoLog EXTRA "Installing headers"
-    CT_DoExecLog ALL ${make} DESTDIR="${CT_SYSROOT_DIR}" install-headers
-
-    CT_DoExecLog ALL ${make} DESTDIR="${CT_SYSROOT_DIR}" \
-        crt/crt1.o crt/crti.o crt/crtn.o
-    CT_DoExecLog ALL cp -av crt/crt*.o "${CT_SYSROOT_DIR}/usr/lib"
-    CT_DoExecLog ALL ${CT_TARGET}-gcc -nostdlib \
-        -nostartfiles -shared -x c /dev/null -o "${CT_SYSROOT_DIR}/usr/lib/libc.so"
-    CT_EndStep
-}
-
-do_libc() {
-    CT_DoStep INFO "Installing C library"
-
-    # Simply copy files until musl has the ability to build out-of-tree
-    CT_DoLog EXTRA "Copying sources to build directory"
-    CT_DoExecLog ALL cp -av "${CT_SRC_DIR}/musl-${CT_LIBC_VERSION}" \
-                            "${CT_BUILD_DIR}/build-libc"
-    cd "${CT_BUILD_DIR}/build-libc"
-
-    do_libc_configure
-
-    CT_DoLog EXTRA "Building C library"
-    CT_DoExecLog ALL ${make} ${JOBSFLAGS}
-
-    CT_DoLog EXTRA "Installing C library"
-    CT_DoExecLog ALL ${make} DESTDIR="${CT_SYSROOT_DIR}" install
+        CT_DoLog EXTRA "Installing C library"
+        CT_DoExecLog ALL ${make} DESTDIR="${CT_SYSROOT_DIR}" install
+    fi
 
     CT_EndStep
-}
-
-do_libc_post_cc() {
-    :
 }


### PR DESCRIPTION
This commit moves the do_libc_configure function to do_libc_backend and
switches do_libc_start_files and do_libc_final to call do_libc_backend.

The major reason for the rewrite is that musl => 1.1.13 has had it's own
build system rewritten and can now build out-of-tree.

Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>