### PR TITLE
configure: Don't write a.out on static compiler check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -136,7 +136,7 @@ AC_PROG_CPP
 #---------------------------------------------------------------------
 # Check to see if gcc can static link
 AC_MSG_CHECKING([if gcc can static link])
-echo "int main() {}" | gcc -static -xc - > /dev/null 2>&1
+echo "int main() {}" | gcc -static -o /dev/null -xc - > /dev/null 2>&1
 static_test=$?
 AS_IF([test $static_test -eq 0],
           [static_link=y


### PR DESCRIPTION
Because I don't pass `-o` to gcc, it makes an a.out file with gcc.
For clang it doesn't make the a.out, as that is not the default.

It doesn't hurt to output to /dev/null for both.

Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>