### PR TITLE
Added new gcc config option CC_GCC_CONFIG_TLS

### DIFF
--- a/config/cc/gcc.in.2
+++ b/config/cc/gcc.in.2
@@ -90,6 +90,25 @@ config CC_GCC_SYSTEM_ZLIB
       
       If unsure, say 'n'.
 
+config CC_GCC_CONFIG_TLS
+    tristate
+    prompt "Configure TLS (Thread Local Storage)"
+    default m
+    help
+      Specify that the target supports TLS (Thread Local Storage). Usually
+      configure can correctly determine if TLS is supported. In cases where
+      it guesses incorrectly, TLS can be explicitly enabled or disabled.
+      This can happen if the assembler supports TLS but the C library does
+      not, or if the assumptions made by the configure test are incorrect.
+
+       Option  | TLS use            | Associated ./configure switch
+      ---------+--------------------+--------------------------------
+         Y     | forcibly used      | --enable-tls
+         M     | auto               | (none, ./configure decides)
+         N     | forcibly not used  | --disable-tls
+      
+      If unsure, say 'M'.
+
 #-----------------------------------------------------------------------------
 # Optimisation features
 

--- a/scripts/build/cc/100-gcc.sh
+++ b/scripts/build/cc/100-gcc.sh
@@ -555,6 +555,12 @@ do_gcc_core_backend() {
         extra_config+=("--with-system-zlib")
     fi
 
+    case "${CT_CC_GCC_CONFIG_TLS}" in
+        y)  extra_config+=("--enable-tls");;
+        m)  ;;
+        "") extra_config+=("--disable-tls");;
+    esac
+
     # Some versions of gcc have a defective --enable-multilib.
     # Since that's the default, only pass --disable-multilib. For multilib,
     # also enable multiarch. Without explicit --enable-multiarch, pass-1
@@ -1076,6 +1082,12 @@ do_gcc_backend() {
     if [ "${CT_CC_GCC_SYSTEM_ZLIB}" = "y" ]; then
         extra_config+=("--with-system-zlib")
     fi
+
+    case "${CT_CC_GCC_CONFIG_TLS}" in
+        y)  extra_config+=("--enable-tls");;
+        m)  ;;
+        "") extra_config+=("--disable-tls");;
+    esac
 
     # Some versions of gcc have a defective --enable-multilib.
     # Since that's the default, only pass --disable-multilib.


### PR DESCRIPTION
Adding new tristate configuration for TLS (Thread Local Storage) to
add "--enable-tls" (y), "--disable-tls" (n) or nothing (m).

Signed-off-by: Jasmin Jessich jasmin@anw.at

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/crosstool-ng/crosstool-ng/375)

<!-- Reviewable:end -->
