### PR TITLE
Pass CFLAGS_FOR_TARGET/CXXFLAGS_FOR_TARGET for libstdc++ in baremetal build

### DIFF
--- a/patches/gcc/4.8.5/130-pr43538.patch
+++ b/patches/gcc/4.8.5/130-pr43538.patch
@@ -1,0 +1,25 @@
+From c037df1be41f8daf4d581d7ffa4ec8cfa640bccf Mon Sep 17 00:00:00 2001
+From: glisse <glisse@138bc75d-0d04-0410-961f-82ee72b054a4>
+Date: Fri, 25 Apr 2014 08:03:08 +0000
+Subject: [PATCH] 2014-04-25  Marc Glisse  <marc.glisse@inria.fr>
+
+	PR target/43538
+	* mt-gnu: Don't reset CXXFLAGS_FOR_TARGET.
+
+
+git-svn-id: svn+ssh://gcc.gnu.org/svn/gcc/trunk@209784 138bc75d-0d04-0410-961f-82ee72b054a4
+Signed-off-by: Max Filippov <jcmvbkbc@gmail.com>
+---
+ config/mt-gnu    | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/config/mt-gnu b/config/mt-gnu
+index 15bf417..5c696f5 100644
+--- a/config/mt-gnu
++++ b/config/mt-gnu
+@@ -1 +1 @@
+-CXXFLAGS_FOR_TARGET = $(CXXFLAGS) -D_GNU_SOURCE
++CXXFLAGS_FOR_TARGET += -D_GNU_SOURCE
+-- 
+2.1.4
+

--- a/patches/gcc/4.8.5/131-mt-ospace-preserve-FLAGS_FOR_TARGET.patch
+++ b/patches/gcc/4.8.5/131-mt-ospace-preserve-FLAGS_FOR_TARGET.patch
@@ -1,0 +1,28 @@
+From 9bcf38cd9f382486b3823eb923b50e2e9a89cef7 Mon Sep 17 00:00:00 2001
+From: law <law@138bc75d-0d04-0410-961f-82ee72b054a4>
+Date: Tue, 18 Nov 2014 22:12:52 +0000
+Subject: [PATCH] 2014-11-17  Bob Dunlop  <bob.dunlop@xyzzy.org.uk>
+
+        * mt-ospace (CFLAGS_FOR_TARGET): Append -g -Os rather than
+        overwriting.
+        (CXXFLAGS_FOR_TARGET): Similarly.
+
+git-svn-id: svn+ssh://gcc.gnu.org/svn/gcc/trunk@217739 138bc75d-0d04-0410-961f-82ee72b054a4
+Signed-off-by: Max Filippov <jcmvbkbc@gmail.com>
+---
+ config/mt-ospace | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/config/mt-ospace b/config/mt-ospace
+index 7f09104..ce29ff4 100644
+--- a/config/mt-ospace
++++ b/config/mt-ospace
+@@ -1,3 +1,3 @@
+ # Build libraries optimizing for space, not speed.
+- CFLAGS_FOR_TARGET = -g -Os
+- CXXFLAGS_FOR_TARGET = -g -Os
++ CFLAGS_FOR_TARGET += -g -Os
++ CXXFLAGS_FOR_TARGET += -g -Os
+-- 
+2.1.4
+

--- a/patches/gcc/4.9.3/130-pr43538.patch
+++ b/patches/gcc/4.9.3/130-pr43538.patch
@@ -1,0 +1,25 @@
+From c037df1be41f8daf4d581d7ffa4ec8cfa640bccf Mon Sep 17 00:00:00 2001
+From: glisse <glisse@138bc75d-0d04-0410-961f-82ee72b054a4>
+Date: Fri, 25 Apr 2014 08:03:08 +0000
+Subject: [PATCH] 2014-04-25  Marc Glisse  <marc.glisse@inria.fr>
+
+	PR target/43538
+	* mt-gnu: Don't reset CXXFLAGS_FOR_TARGET.
+
+
+git-svn-id: svn+ssh://gcc.gnu.org/svn/gcc/trunk@209784 138bc75d-0d04-0410-961f-82ee72b054a4
+Signed-off-by: Max Filippov <jcmvbkbc@gmail.com>
+---
+ config/mt-gnu    | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/config/mt-gnu b/config/mt-gnu
+index 15bf417..5c696f5 100644
+--- a/config/mt-gnu
++++ b/config/mt-gnu
+@@ -1 +1 @@
+-CXXFLAGS_FOR_TARGET = $(CXXFLAGS) -D_GNU_SOURCE
++CXXFLAGS_FOR_TARGET += -D_GNU_SOURCE
+-- 
+2.1.4
+

--- a/patches/gcc/4.9.3/131-mt-ospace-preserve-FLAGS_FOR_TARGET.patch
+++ b/patches/gcc/4.9.3/131-mt-ospace-preserve-FLAGS_FOR_TARGET.patch
@@ -1,0 +1,28 @@
+From 9bcf38cd9f382486b3823eb923b50e2e9a89cef7 Mon Sep 17 00:00:00 2001
+From: law <law@138bc75d-0d04-0410-961f-82ee72b054a4>
+Date: Tue, 18 Nov 2014 22:12:52 +0000
+Subject: [PATCH] 2014-11-17  Bob Dunlop  <bob.dunlop@xyzzy.org.uk>
+
+        * mt-ospace (CFLAGS_FOR_TARGET): Append -g -Os rather than
+        overwriting.
+        (CXXFLAGS_FOR_TARGET): Similarly.
+
+git-svn-id: svn+ssh://gcc.gnu.org/svn/gcc/trunk@217739 138bc75d-0d04-0410-961f-82ee72b054a4
+Signed-off-by: Max Filippov <jcmvbkbc@gmail.com>
+---
+ config/mt-ospace | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/config/mt-ospace b/config/mt-ospace
+index 7f09104..ce29ff4 100644
+--- a/config/mt-ospace
++++ b/config/mt-ospace
+@@ -1,3 +1,3 @@
+ # Build libraries optimizing for space, not speed.
+- CFLAGS_FOR_TARGET = -g -Os
+- CXXFLAGS_FOR_TARGET = -g -Os
++ CFLAGS_FOR_TARGET += -g -Os
++ CXXFLAGS_FOR_TARGET += -g -Os
+-- 
+2.1.4
+

--- a/scripts/build/cc/100-gcc.sh
+++ b/scripts/build/cc/100-gcc.sh
@@ -423,6 +423,9 @@ do_gcc_core_backend() {
     CFLAGS="${cflags}"                                 \
     CXXFLAGS="${cflags}"                               \
     LDFLAGS="${core_LDFLAGS[*]}"                       \
+    CFLAGS_FOR_TARGET="${CT_TARGET_CFLAGS}"            \
+    CXXFLAGS_FOR_TARGET="${CT_TARGET_CFLAGS}"          \
+    LDFLAGS_FOR_TARGET="${CT_TARGET_LDFLAGS}"          \
     "${CT_SRC_DIR}/gcc-${CT_CC_GCC_VERSION}/configure" \
         --build=${CT_BUILD}                            \
         --host=${host}                                 \


### PR DESCRIPTION
Hi Bryan,

this series makes it possible to build libstdc++ for baremetal cross-compiler with flags specified in the CT_TARGET_CFLAGS. It backports two gcc fixes that preserve CFLAGS_FOR_TARGET and CXXFLAGS_FOR_TARGET from gcc-5.x to gcc-4.8.x and gcc-4.9.x and passes these environment variables to gcc configure script in do_gcc_core_backend() as it is done in do_gcc_backend().
It fixes issue #374.