### PR TITLE
arch/sh: adding more SuperH variants

### DIFF
--- a/config/arch/sh.in
+++ b/config/arch/sh.in
@@ -7,4 +7,4 @@
 ## select ARCH_DEFAULT_LE
 ##
 ## help The Super-H architecture, as defined by:
-## help     http://www.renesas.com/fmwk.jsp?cnt=superh_family_landing.jsp&fp=/products/mpumcu/superh_family/
+## help     http://am.renesas.com/products/mpumcu/superh/index.jsp

--- a/config/arch/sh.in.2
+++ b/config/arch/sh.in.2
@@ -4,9 +4,29 @@ choice
     bool
     prompt "Variant"
 
+config ARCH_SH_SH1
+    bool
+    prompt "sh1"
+
+config ARCH_SH_SH2
+    bool
+    prompt "sh2"
+
+config ARCH_SH_SH2E
+    bool
+    prompt "sh2e"
+
+config ARCH_SH_SH2A
+    bool
+    prompt "sh2a"
+
 config ARCH_SH_SH3
     bool
     prompt "sh3"
+
+config ARCH_SH_SH3E
+    bool
+    prompt "sh3e"
 
 config ARCH_SH_SH4
     bool
@@ -20,6 +40,11 @@ endchoice
 
 config ARCH_SH_VARIANT
     string
+    default "sh1"   if ARCH_SH_SH1
+    default "sh2"   if ARCH_SH_SH2
+    default "sh2e"  if ARCH_SH_SH2E
+    default "sh2a"  if ARCH_SH_SH2A
     default "sh3"   if ARCH_SH_SH3
+    default "sh3e"  if ARCH_SH_SH3E
     default "sh4"   if ARCH_SH_SH4
     default "sh4a"  if ARCH_SH_SH4A

--- a/scripts/build/arch/sh.sh
+++ b/scripts/build/arch/sh.sh
@@ -20,7 +20,12 @@ CT_DoArchTupleValues () {
 
     # CFLAGS
     case "${CT_ARCH_SH_VARIANT}" in
+        sh1)    CT_ARCH_ARCH_CFLAG=-m1;;
+        sh2)    CT_ARCH_ARCH_CFLAG=-m2;;
+        sh2e)   CT_ARCH_ARCH_CFLAG=-m2e;;
+        sh2a)   CT_ARCH_ARCH_CFLAG=-m2a;;
         sh3)    CT_ARCH_ARCH_CFLAG=-m3;;
+        sh3e)   CT_ARCH_ARCH_CFLAG=-m3e;;
         sh4*)
             # softfp is not possible for SuperH, no need to test for it.
             case "${CT_ARCH_FLOAT}" in


### PR DESCRIPTION
adding SH1, SH2, SH2E, SH2A, SH3E as additional SuperH targets

furthermore updating hyperlink

tested SH2, worked  successfully _without_ newlib

Source: [GCC Reference](https://gcc.gnu.org/onlinedocs/gcc/SH-Options.html)
