### PR TITLE
comptools/make: Fix CT_COMP_TOOLS_make_gmake option

### DIFF
--- a/scripts/build/companion_tools/050-make.sh
+++ b/scripts/build/companion_tools/050-make.sh
@@ -23,7 +23,7 @@ do_companion_tools_make_build() {
     CT_DoExecLog ALL ${make}
     CT_DoExecLog ALL ${make} install
     if [ "${CT_COMP_TOOLS_make_gmake}" = "y" ]; then
-        CT_DoExecLog ALL ln -sv ${make} "${CT_BUILDTOOLS_PREFIX_DIR}/bin/gmake"
+        CT_DoExecLog ALL ln -sv make "${CT_BUILDTOOLS_PREFIX_DIR}/bin/gmake"
     fi
     CT_Popd
     CT_EndStep


### PR DESCRIPTION
Commit 6f8e89cb5ca061e899bf3feaaf3fecf30d366c3e broke that option.
Since ${make} points to /usr/bin/make, making the symlink from gmake
to /usr/bin/make is obviously the wrong decision. gmake should link to
our (old-versioned) self-built make.

Signed-off-by: Bernhard Walle bernhard@bwalle.de
