### PR TITLE
Update elf2flt git repository location

### DIFF
--- a/config/binutils/binutils.in.2
+++ b/config/binutils/binutils.in.2
@@ -29,7 +29,7 @@ if ELF2FLT_GIT
 config ELF2FLT_GIT_CSET
     string
     prompt "git cset"
-    default "454b6b415a31959661406bdfbd9dad22229367bf"
+    default "9dbc458c6122c495bbdec8dc975a15c9d39e5ff2"
     help
       Enter the git changeset to use.
 

--- a/scripts/build/binutils/binutils.sh
+++ b/scripts/build/binutils/binutils.sh
@@ -25,7 +25,7 @@ do_binutils_get() {
             CT_GetCustom "elf2flt" "${CT_ELF2FLT_CUSTOM_VERSION}" \
                 "${CT_ELF2FLT_CUSTOM_LOCATION}"
         else
-            CT_GetGit elf2flt "${CT_ELF2FLT_GIT_CSET}" http://cgit.openadk.org/cgi/cgit/elf2flt.git
+            CT_GetGit elf2flt "${CT_ELF2FLT_GIT_CSET}" https://github.com/uclinux-dev/elf2flt.git
         fi
     fi
 }


### PR DESCRIPTION
The elf2flt git repository has been moved to GitHub. Updated the script
accordingly.

Signed-off-by: Martin Lund <martin.lund@keep-it-simple.com>