### PR TITLE
cross-gdb: Enable TUI interface

### DIFF
--- a/scripts/build/companion_libs/220-ncurses.sh
+++ b/scripts/build/companion_libs/220-ncurses.sh
@@ -33,7 +33,7 @@ do_ncurses_for_build() {
           "--without-cxx-binding" \
           "--without-ada")
     do_ncurses_backend host="${CT_BUILD}" \
-                       destdir="${CT_BUILDTOOLS_PREFIX_DIR}" \
+                       prefix="${CT_BUILDTOOLS_PREFIX_DIR}" \
                        cflags="${CT_CFLAGS_FOR_BUILD}" \
                        ldflags="${CT_LDFLAGS_FOR_BUILD}" \
                        "${opts[@]}"

--- a/scripts/build/debug/300-gdb.sh
+++ b/scripts/build/debug/300-gdb.sh
@@ -124,6 +124,7 @@ do_debug_gdb_build() {
             --with-build-sysroot="${CT_SYSROOT_DIR}"    \
             --with-sysroot="${CT_SYSROOT_DIR}"          \
             --disable-werror                            \
+            --enable-tui                                \
             "${cross_extra_config[@]}"                  \
             "${CT_GDB_CROSS_EXTRA_CONFIG_ARRAY[@]}"
 


### PR DESCRIPTION
This change enables TUI (text user interface) for cross-gdb. Since this
feature relies on ncurses we also make sure ncurses for host gets built.
