### PR TITLE
Apply patch for config.gcc to support e6500 to gcc4.9.3

### DIFF
--- a/patches/gcc/4.9.3/120-gcc-config.gcc-fix-typo-for-powerpc-e6500-cpu_is_64b.patch
+++ b/patches/gcc/4.9.3/120-gcc-config.gcc-fix-typo-for-powerpc-e6500-cpu_is_64b.patch
@@ -1,0 +1,29 @@
+From 9bf6066d588632dab9f78932df15b5b4140f31f3 Mon Sep 17 00:00:00 2001
+From: "Arnout Vandecappelle (Essensium/Mind)" <arnout@mind.be>
+Date: Fri, 6 Nov 2015 14:27:23 +0100
+Subject: [PATCH] gcc/config.gcc: fix typo for powerpc e6500 cpu_is_64bit
+
+Otherwise it is not recognized as a 64-bit powerpc and gcc will not generate
+64-bit binaries by default.
+
+Signed-off-by: Arnout Vandecappelle (Essensium/Mind) <arnout@mind.be>
+---
+ gcc/config.gcc | 2 +-
+ 2 files changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/gcc/config.gcc b/gcc/config.gcc
+index 4a7cbd2..9cc765e 100644
+--- a/gcc/config.gcc
++++ b/gcc/config.gcc
+@@ -439,7 +439,7 @@ powerpc*-*-*)
+ 	cpu_type=rs6000
+ 	extra_headers="ppc-asm.h altivec.h spe.h ppu_intrinsics.h paired.h spu2vmx.h vec_types.h si2vmx.h htmintrin.h htmxlintrin.h"
+ 	case x$with_cpu in
+-	    xpowerpc64|xdefault64|x6[23]0|x970|xG5|xpower[345678]|xpower6x|xrs64a|xcell|xa2|xe500mc64|xe5500|Xe6500)
++	    xpowerpc64|xdefault64|x6[23]0|x970|xG5|xpower[345678]|xpower6x|xrs64a|xcell|xa2|xe500mc64|xe5500|xe6500)
+ 		cpu_is_64bit=yes
+ 		;;
+ 	esac
+-- 
+2.6.2
+


### PR DESCRIPTION
This resolves crosstool-ng/crosstool-ng#405
