### PR TITLE
scripts/functions: fix log level in call to CT_DoLog

### DIFF
--- a/scripts/functions
+++ b/scripts/functions
@@ -928,7 +928,7 @@ CT_GetGit() {
     else
         # Woops...
         CT_DoExecLog ALL rm -rf "${dir}"
-        CT_DoLog Debug "Could not clone '${basename}'"
+        CT_DoLog DEBUG "Could not clone '${basename}'"
         return 1
     fi
 }


### PR DESCRIPTION
It must be "DEBUG", not "Debug"

Signed-off-by: Carlos Santos <casantos@datacom.ind.br>