### PR TITLE
elf2flt: use CT_ARCH to set target CPU, not CT_TARGET

### DIFF
--- a/scripts/build/binutils/binutils.sh
+++ b/scripts/build/binutils/binutils.sh
@@ -313,7 +313,7 @@ do_elf2flt_backend() {
         "${CT_ELF2FLT_EXTRA_CONFIG_ARRAY[@]}"
 
     CT_DoLog EXTRA "Building elf2flt"
-    CT_DoExecLog ALL ${make} ${JOBSFLAGS}
+    CT_DoExecLog ALL ${make} ${JOBSFLAGS} CPU=${CT_ARCH}
 
     CT_DoLog EXTRA "Installing elf2flt"
     CT_DoExecLog ALL ${make} install


### PR DESCRIPTION
CT_TARGET is composed as "${CT_ARCH}${CT_ARCH_SUFFIX}", so CT_TARGET may
become something like "armv7", for example. This is used by the configure
script to set the "CPU" variable in the Makefile, leading to a commad line
containing

```
-DTARGET_armv7 -DTARGET_CPU="armv7"
```

In this case the compilation of elf2flt.c fails with "Don't know how to
support your CPU architecture??". Passsing "CPU=${CT_ARCH}" in the make
command line overrides the configured value and solves the problem.

Signed-off-by: Carlos Santos casantos@datacom.ind.br
