### PR TITLE
Update x86.sh

### DIFF
--- a/scripts/build/arch/x86.sh
+++ b/scripts/build/arch/x86.sh
@@ -15,7 +15,9 @@ CT_DoArchTupleValues() {
             winchip*)                     CT_TARGET_ARCH=i486;;
             pentium|pentium-mmx|c3*)      CT_TARGET_ARCH=i586;;
             pentiumpro|pentium*|athlon*)  CT_TARGET_ARCH=i686;;
-            prescott)                     CT_TARGET_ARCH=i686;;
+            core2|atom)                   CT_TARGET_ARCH=i686;;
+            prescott|nocona)              CT_TARGET_ARCH=i686;;
+            k8*|opteron*)                 CT_TARGET_ARCH=i686;;
             *)                            CT_TARGET_ARCH=i586;;
         esac
     fi


### PR DESCRIPTION
Added additional x86 architectures, like core2, that also map to i686. Otherwise, when setting the x86 gcc to build optimized for core2 you get i585.