### PR TITLE
cross: Only make 'build tools' for the 'build'

### DIFF
--- a/scripts/crosstool-NG.sh.in
+++ b/scripts/crosstool-NG.sh.in
@@ -345,7 +345,7 @@ if [ -z "${CT_RESTART}" ]; then
             build_mangle="build_"
             host_mangle="build_"
             target_mangle=""
-            install_build_tools_for="BUILD HOST"
+            install_build_tools_for="BUILD"
             ;;
         canadian)
             build_mangle="build_"
@@ -472,7 +472,7 @@ if [ -z "${CT_RESTART}" ]; then
     CT_CFLAGS_FOR_BUILD+=" ${CT_EXTRA_CFLAGS_FOR_BUILD}"
     CT_LDFLAGS_FOR_BUILD=
     CT_LDFLAGS_FOR_BUILD+=" ${CT_EXTRA_LDFLAGS_FOR_BUILD}"
-    
+
     # Help host gcc
     # Explicitly optimise, else the lines below will overide the
     # package's default optimisation flags


### PR DESCRIPTION
For a cross-compiler, we only need to make the 'build tools' for the
'build'. We also build the 'build tools' for the 'host' when building a
cross-canadian toolchain.

Closes #430

Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>