### PR TITLE
uClibc: improve managing shared libs

### DIFF
--- a/scripts/build/libc/uClibc.sh
+++ b/scripts/build/libc/uClibc.sh
@@ -231,7 +231,7 @@ do_libc_backend_once() {
         # - "make install" calls install_runtime and install_dev
         # - so we're left with re-installing the headers... Sigh...
         CT_DoLog EXTRA "Installing C library"
-        CT_DoExecLog ALL ${make} "${make_args[@]}" install
+        CT_DoExecLog ALL ${make} "${make_args[@]}" install install_utils
     fi # libc_mode == final
 
     # Now, if installing headers into a subdirectory, put everything in its place.

--- a/scripts/build/libc/uClibc.sh
+++ b/scripts/build/libc/uClibc.sh
@@ -278,6 +278,12 @@ manage_uClibc_config() {
         CT_KconfigDisableOption "ARCH_USE_MMU" "${dst}"
     fi
 
+    if [ "${CT_SHARED_LIBS}" = "y" ]; then
+        CT_KconfigEnableOption "HAVE_SHARED" "${dst}"
+    else
+        CT_KconfigDisableOption "HAVE_SHARED" "${dst}"
+    fi
+
     # Accomodate for old and new uClibc version, where the
     # way to select between hard/soft float has changed
     case "${CT_ARCH_FLOAT}" in


### PR DESCRIPTION
Build and install shared libs only if requested, i.e. CT_SHARED_LIBS=y. Without this patch sysroot was always populated with shared libs.
Install native ldd and ldconfig utils to sysroot.