### PR TITLE
duma: add SHARED_LIBS dependency for DUMA shared library option

### DIFF
--- a/config/debug/duma.in
+++ b/config/debug/duma.in
@@ -14,7 +14,8 @@ config DUMA_A
 config DUMA_SO
     bool
     prompt "Build a shared library"
-    default y if SHARED_LIBS
+    depends on SHARED_LIBS
+    default y
 
 choice
     bool


### PR DESCRIPTION
Add SHARED_LIBRARY dependency to DUMA shared library option, partially fixes #440