### PR TITLE
debug/duma: disable shared libs if necessary

### DIFF
--- a/config/debug/duma.in
+++ b/config/debug/duma.in
@@ -14,6 +14,7 @@ config DUMA_A
 config DUMA_SO
     bool
     prompt "Build a shared library"
+    depends on SHARED_LIBS
     default y if SHARED_LIBS
 
 choice


### PR DESCRIPTION
Propagate CT_SHARED_LIBS option to D.U.M.A. debug tool.

Signed-off-by: Kirill Smirnov <kirill.k.smirnov@gmail.com>