### PR TITLE
debug/gdb: properly link with expat

### DIFF
--- a/scripts/build/companion_libs/200-libelf.sh
+++ b/scripts/build/companion_libs/200-libelf.sh
@@ -69,13 +69,24 @@ if [ "${CT_LIBELF_TARGET}" = "y" ]; then
 
 do_libelf_for_target() {
     local -a libelf_opts
+    local prefix
 
     CT_DoStep INFO "Installing libelf for the target"
     CT_mkdir_pushd "${CT_BUILD_DIR}/build-libelf-target-${CT_TARGET}"
 
+    case "${CT_TARGET}" in
+        *-*-mingw*)
+            prefix="/mingw"
+            ;;
+        *)
+            prefix="/usr"
+            ;;
+    esac
+
     libelf_opts+=( "destdir=${CT_SYSROOT_DIR}" )
     libelf_opts+=( "host=${CT_TARGET}" )
-    libelf_opts+=( "prefix=/usr" )
+
+    libelf_opts+=( "prefix=${prefix}" )
     libelf_opts+=( "shared=y" )
     do_libelf_backend "${libelf_opts[@]}"
 

--- a/scripts/build/companion_libs/210-expat.sh
+++ b/scripts/build/companion_libs/210-expat.sh
@@ -43,12 +43,21 @@ fi
 if [ "${CT_EXPAT_TARGET}" = "y" ]; then
 do_expat_for_target() {
     local -a expat_opts
+    local prefix
 
     CT_DoStep INFO "Installing expat for target"
     CT_mkdir_pushd "${CT_BUILD_DIR}/build-expat-target-${CT_TARGET}"
 
     expat_opts+=( "host=${CT_TARGET}" )
-    expat_opts+=( "prefix=/usr" )
+    case "${CT_TARGET}" in
+        *-*-mingw*)
+            prefix="/mingw"
+            ;;
+        *)
+            prefix="/usr"
+            ;;
+    esac
+    expat_opts+=( "prefix=${prefix}" )
     expat_opts+=( "destdir=${CT_SYSROOT_DIR}" )
     expat_opts+=( "static_build=y" )
 

--- a/scripts/build/companion_libs/220-ncurses.sh
+++ b/scripts/build/companion_libs/220-ncurses.sh
@@ -72,13 +72,23 @@ fi
 
 if [ "${CT_NCURSES_TARGET}" = "y" ]; then
 do_ncurses_for_target() {
+    local prefix
+
     CT_DoStep INFO "Installing ncurses for target"
     CT_mkdir_pushd "${CT_BUILD_DIR}/build-ncurses-target-${CT_TARGET}"
     opts=("--without-sysmouse")
     [ "${CT_CC_LANG_CXX}" = "y" ] || opts+=("--without-cxx" "--without-cxx-binding")
     [ "${CT_CC_LANG_ADA}" = "y" ] || opts+=("--without-ada")
+    case "${CT_TARGET}" in
+        *-*-mingw*)
+            prefix="/mingw"
+            ;;
+        *)
+            prefix="/usr"
+            ;;
+    esac
     do_ncurses_backend host="${CT_TARGET}" \
-                       prefix="/usr" \
+                       prefix="${prefix}" \
                        destdir="${CT_SYSROOT_DIR}" \
                        "${opts[@]}"
     CT_Popd

--- a/scripts/build/debug/300-gdb.sh
+++ b/scripts/build/debug/300-gdb.sh
@@ -68,6 +68,10 @@ do_debug_gdb_build() {
         cd "${CT_BUILD_DIR}/build-gdb-cross"
 
         cross_extra_config=("${extra_config[@]}")
+
+        # For gdb-cross this combination of flags forces
+        # gdb configure to fall back to default '-lexpat' flag
+        # which is acceptable.
         cross_extra_config+=("--with-expat")
         cross_extra_config+=("--without-libexpat-prefix")
 
@@ -169,6 +173,16 @@ do_debug_gdb_build() {
             native_extra_config+=("--with-curses")
         fi
 
+        # Target libexpat resides in sysroot and does not have
+        # any dependencies, so just passing '-lexpat' to gcc is enough.
+        #
+        # By default gdb configure looks for expat in '$prefix/lib'
+        # directory. In our case '$prefix/lib' resolves to '/usr/lib'
+        # where libexpat for build platform lives, which is
+        # unacceptable for cross-compiling.
+        #
+        # To prevent this '--without-libexpat-prefix' flag must be passed.
+        # Thus configure falls back to '-lexpat', which is exactly what we want.
         native_extra_config+=("--with-expat")
         native_extra_config+=("--without-libexpat-prefix")
 

--- a/scripts/build/debug/300-gdb.sh
+++ b/scripts/build/debug/300-gdb.sh
@@ -69,11 +69,8 @@ do_debug_gdb_build() {
 
         cross_extra_config=("${extra_config[@]}")
         cross_extra_config+=("--with-expat")
-        # NOTE: DO NOT USE --with-libexpat-prefix (until GDB configure is smarter)!!!
-        # It conflicts with a static build: GDB's configure script will find the shared
-        # version of expat and will attempt to link that, despite the -static flag.
-        # The link will fail, and configure will abort with "expat missing or unusable"
-        # message.
+        cross_extra_config+=("--without-libexpat-prefix")
+
         case "${CT_THREADS}" in
             none)   cross_extra_config+=("--disable-threads");;
             *)      cross_extra_config+=("--enable-threads");;
@@ -173,11 +170,7 @@ do_debug_gdb_build() {
         fi
 
         native_extra_config+=("--with-expat")
-        # NOTE: DO NOT USE --with-libexpat-prefix (until GDB configure is smarter)!!!
-        # It conflicts with a static build: GDB's configure script will find the shared
-        # version of expat and will attempt to link that, despite the -static flag.
-        # The link will fail, and configure will abort with "expat missing or unusable"
-        # message.
+        native_extra_config+=("--without-libexpat-prefix")
 
         CT_DoLog EXTRA "Configuring native gdb"
 

--- a/scripts/build/debug/300-gdb.sh
+++ b/scripts/build/debug/300-gdb.sh
@@ -72,6 +72,12 @@ do_debug_gdb_build() {
         # For gdb-cross this combination of flags forces
         # gdb configure to fall back to default '-lexpat' flag
         # which is acceptable.
+        #
+        # NOTE: DO NOT USE --with-libexpat-prefix (until GDB configure is smarter)!!!
+        # It conflicts with a static build: GDB's configure script will find the shared
+        # version of expat and will attempt to link that, despite the -static flag.
+        # The link will fail, and configure will abort with "expat missing or unusable"
+        # message.
         cross_extra_config+=("--with-expat")
         cross_extra_config+=("--without-libexpat-prefix")
 
@@ -183,6 +189,12 @@ do_debug_gdb_build() {
         #
         # To prevent this '--without-libexpat-prefix' flag must be passed.
         # Thus configure falls back to '-lexpat', which is exactly what we want.
+        #
+        # NOTE: DO NOT USE --with-libexpat-prefix (until GDB configure is smarter)!!!
+        # It conflicts with a static build: GDB's configure script will find the shared
+        # version of expat and will attempt to link that, despite the -static flag.
+        # The link will fail, and configure will abort with "expat missing or unusable"
+        # message.
         native_extra_config+=("--with-expat")
         native_extra_config+=("--without-libexpat-prefix")
 


### PR DESCRIPTION
This patch fixes libexpat detection for gdb-native and
gdb-cross static builds.

For gdb-native build configure should not touch system
/usr/{lib,include} directories while looking for libexpat.
To fix this we pass --without-libexpat-prefix flag
to configure script.

For gdb-cross build configure is allowed to investigate
system /usr/{lib,include} directories, but it does not
hurt to disable this behavior. In this case configure
falls back to -lexpat, which works as expected.

For more info:
http://marc.info/?l=gnulib-bug&m=129660262901148&w=2

Signed-off-by: Kirill Smirnov kirill.k.smirnov@gmail.com
