### PR TITLE
canadian build: fix mingw32

### DIFF
--- a/patches/gcc/linaro-4.9-2015.06/001-go-fix.patch
+++ b/patches/gcc/linaro-4.9-2015.06/001-go-fix.patch
@@ -1,0 +1,26 @@
+From 151f14a124d1b1e5fb4497244a7ad4d6daa0148d Mon Sep 17 00:00:00 2001
+From: Matthieu Crapet <mcrapet@gmail.com>
+Date: Fri, 16 Sep 2016 11:42:06 +0200
+Subject: [PATCH] go: initialize variable to avoid compiler warning
+
+https://github.com/crosstool-ng/crosstool-ng/issues/96
+---
+ libgo/runtime/mprof.goc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libgo/runtime/mprof.goc b/libgo/runtime/mprof.goc
+index 7507dfc..44d5669 100644
+--- a/libgo/runtime/mprof.goc
++++ b/libgo/runtime/mprof.goc
+@@ -465,7 +465,7 @@ func ThreadCreateProfile(p Slice) (n int, ok bool) {
+ 
+ func Stack(b Slice, all bool) (n int) {
+ 	byte *pc, *sp;
+-	bool enablegc;
++	bool enablegc = false;
+ 	
+ 	sp = runtime_getcallersp(&b);
+ 	pc = (byte*)(uintptr)runtime_getcallerpc(&b);
+-- 
+1.9.1
+


### PR DESCRIPTION
Makes libgcc compilation fail because of broken "sys/types.h" include (missing __caddr_t typedef).
This issue is around for a while and apply on both eglibc and glibc.

Tested on glib-2.23 with target=arm, build=linux, host=mingw32.

Signed-off-by: Matthieu Crapet mcrapet@gmail.com
