### PR TITLE
binutils: make symlinks in a consistent way

### DIFF
--- a/scripts/build/binutils/binutils.sh
+++ b/scripts/build/binutils/binutils.sh
@@ -132,7 +132,7 @@ do_binutils_for_host() {
             mkdir -p "${CT_BUILDTOOLS_PREFIX_DIR}/bin"
             for t in "${binutils_tools[@]}"; do
                 CT_DoExecLog ALL ln -sv                                         \
-                                    "${CT_PREFIX_DIR}/bin/${CT_TARGET}-${t}"    \
+                                    "${CT_PREFIX_DIR}/${CT_TARGET}/bin/${t}"    \
                                     "${CT_BUILDTOOLS_PREFIX_DIR}/${CT_TARGET}/bin/${t}"
                 CT_DoExecLog ALL ln -sv                                         \
                                     "${CT_PREFIX_DIR}/bin/${CT_TARGET}-${t}"    \


### PR DESCRIPTION
On the stage "core gcc pass-2" the following layout is created:

1) buildtools/bin/TARGET-{ar,as,elf2flt,flthdr,ld,ld.bfd,ranlib,strip}
2) buildtools/TARGET/bin/{ar,as,elf2flt,flthdr,ld,ld.bfd,ranlib,strip}
3) x-tools/TARGET/bin/TARGET-{ar,as,elf2flt,flthdr,ld,ld.bfd,ranlib,strip}
4) x-tools/TARGET/TARGET/bin{ar,as,elf2flt,flthdr,ld,ld.bfd,ranlib,strip}

where both (1) and (2) are symlinks to (3). This inconsistent and effectively
renders core pass-2 gcc with elf2flt linker unusable. Make (1) links point to (3)
and (2) links point to (4).

Related elf2flt discussion:
https://github.com/uclinux-dev/elf2flt/pull/4

Signed-off-by: Kirill K. Smirnov <kirill.k.smirnov@gmail.com>