### PR TITLE
Disable libmpx in x86-musl.

### DIFF
--- a/config/cc/gcc.in
+++ b/config/cc/gcc.in
@@ -160,6 +160,7 @@ config CC_GCC_5
     select CC_GCC_HAS_LNK_HASH_STYLE
     select CC_GCC_HAS_LIBQUADMATH
     select CC_GCC_HAS_LIBSANITIZER
+    select CC_GCC_HAS_LIBMPX
     select CC_SUPPORT_GOLANG
 
 config CC_GCC_5_or_later
@@ -178,6 +179,7 @@ config CC_GCC_6
     select CC_GCC_HAS_LNK_HASH_STYLE
     select CC_GCC_HAS_LIBQUADMATH
     select CC_GCC_HAS_LIBSANITIZER
+    select CC_GCC_HAS_LIBMPX
     select CC_SUPPORT_GOLANG
 
 config CC_GCC_6_or_later
@@ -274,6 +276,9 @@ config CC_GCC_HAS_LIBQUADMATH
     bool
 
 config CC_GCC_HAS_LIBSANITIZER
+    bool
+
+config CC_GCC_HAS_LIBMPX
     bool
 
 if ! CC_GCC_CUSTOM

--- a/config/cc/gcc.in.2
+++ b/config/cc/gcc.in.2
@@ -182,6 +182,16 @@ config CC_GCC_LIBSANITIZER
 
       The default is 'N'. Say 'Y' if you need it, and report success/failure.
 
+config CC_GCC_LIBMPX
+    bool
+    default y
+    prompt "Compile libmpx"
+    depends on CC_GCC_HAS_LIBMPX
+    depends on ARCH_x86
+    depends on !LIBC_musl # MUSL does not define libc types that GCC requires
+    help
+      Enable GCC support for Intel Memory Protection Extensions (MPX).
+
 #-----------------------------------------------------------------------------
 
 comment "Misc. obscure options."

--- a/scripts/build/cc/100-gcc.sh
+++ b/scripts/build/cc/100-gcc.sh
@@ -436,6 +436,7 @@ do_gcc_core_backend() {
 
     extra_config+=(--disable-libgomp)
     extra_config+=(--disable-libmudflap)
+    extra_config+=(--disable-libmpx)
 
     if [ "${CT_CC_GCC_LIBSSP}" = "y" ]; then
         extra_config+=(--enable-libssp)
@@ -901,6 +902,14 @@ do_gcc_backend() {
             extra_config+=(--enable-libsanitizer)
         else
             extra_config+=(--disable-libsanitizer)
+        fi
+    fi
+
+    if [ "${CT_CC_GCC_HAS_LIBMPX}" = "y" ]; then
+        if [ "${CT_CC_GCC_LIBMPX}" = "y" ]; then
+            extra_config+=(--enable-libmpx)
+        else
+            extra_config+=(--disable-libmpx)
         fi
     fi
 


### PR DESCRIPTION
GCC 6.1.0 (final compiler) fails to compile against musl.

Signed-off-by: Alexey Neyman <stilor@att.net>