### PR TITLE
Switch travis-ci to use the trusty beta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 # Using container-based infrastructure
-sudo: false
+sudo: required
+
+# Use ubuntu trusty 14.04 container
+dist: trusty
 
 # 'bash' will define a generic environment without interfering environment
 # settings like "CC=gcc"


### PR DESCRIPTION
Issues with SSL and other weirdness are creeping into our build.
Switch to the new trusty beta on travis-ci.

Signed-off-by: Bryan Hundven bryanhundven@gmail.com
