### PR TITLE
Revert "elf2flt: do not treat warnings as errors"

### DIFF
--- a/scripts/build/binutils/binutils.sh
+++ b/scripts/build/binutils/binutils.sh
@@ -309,7 +309,6 @@ do_elf2flt_backend() {
         --with-binutils-include-dir=${binutils_src}/include     \
         --with-libbfd=${binutils_bld}/bfd/libbfd.a              \
         --with-libiberty=${binutils_bld}/libiberty/libiberty.a  \
-        --disable-werror                                        \
         ${elf2flt_opts}                                         \
         "${CT_ELF2FLT_EXTRA_CONFIG_ARRAY[@]}"
 


### PR DESCRIPTION
Reverts crosstool-ng/crosstool-ng#454

Warnings for elf2flt should be reported upstream!

Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>