### PR TITLE
Gmake link fix

### DIFF
--- a/config/companion_tools.in
+++ b/config/companion_tools.in
@@ -2,14 +2,9 @@
 
 menu "Companion tools"
 
-# Tools that require make-3.81 to build should select this:
-config COMP_TOOLS_make_3_81_NEEDED
-    bool
-
 config COMP_TOOLS_FORCE_make_3_81
     def_bool y
-    depends on COMP_TOOLS_make_3_81_NEEDED
-    depends on ! CONFIGURE_has_make381
+    depends on ! CONFIGURE_has_make_3_81_or_newer
     select COMP_TOOLS
     select COMP_TOOLS_make
 
@@ -20,7 +15,7 @@ config COMP_TOOLS
     prompt "Build some companion tools"
     help
       Crosstool-NG relies on some external tools to be recent enough, namely:
-        make = 3.81 (in some cases)
+        make >= 3.81
         m4 >= 1.4.12
         autoconf >= 2.63
         automake >= 1.10.2
@@ -30,32 +25,7 @@ config COMP_TOOLS
       but you are strongly encouraged to update your system instead!
 
 if COMP_TOOLS
-
-config COMP_TOOLS_make
-    bool
-    prompt "make"
-
-config COMP_TOOLS_make_gmake
-    bool
-    prompt "Add gmake symlink to companion gnu/make"
-    depends on COMP_TOOLS_make
-
-config COMP_TOOLS_m4
-    bool
-    prompt "m4"
-
-config COMP_TOOLS_autoconf
-    bool
-    prompt "autoconf"
-
-config COMP_TOOLS_automake
-    bool
-    prompt "automake"
-
-config COMP_TOOLS_libtool
-    bool
-    prompt "libtool"
-
+source "config.gen/companion_tools.in"
 endif
 
 endmenu

--- a/config/companion_tools/autoconf.in
+++ b/config/companion_tools/autoconf.in
@@ -1,0 +1,26 @@
+# Autoconf
+
+## help Autoconf
+
+choice
+    bool
+    prompt "Autoconf version"
+# Don't remove next line
+# CT_INSERT_VERSION_BELOW
+
+config AUTOCONF_V_2_69
+    bool
+    prompt "2.69"
+
+config AUTOCONF_V_2_65
+    bool
+    prompt "2.65"
+
+endchoice
+
+config AUTOCONF_VERSION
+    string
+# Don't remove next line
+# CT_INSERT_VERSION_STRING_BELOW
+    default "2.69" if AUTOCONF_V_2_69
+    default "2.65" if AUTOCONF_V_2_65

--- a/config/companion_tools/automake.in
+++ b/config/companion_tools/automake.in
@@ -1,0 +1,36 @@
+# Automake
+
+## help Automake
+
+choice
+    bool
+    prompt "Automake version"
+# Don't remove next line
+# CT_INSERT_VERSION_BELOW
+
+config AUTOMAKE_V_1_15
+    bool
+    prompt "1.15"
+
+config AUTOMAKE_V_1_14
+    bool
+    prompt "1.14"
+
+config AUTOMAKE_V_1_11_6
+    bool
+    prompt "1.11.6"
+
+config AUTOMAKE_V_1_11_1
+    bool
+    prompt "1.11.1"
+
+endchoice
+
+config AUTOMAKE_VERSION
+    string
+# Don't remove next line
+# CT_INSERT_VERSION_STRING_BELOW
+    default "1.15" if AUTOMAKE_V_1_15
+    default "1.14" if AUTOMAKE_V_1_14
+    default "1.11.6" if AUTOMAKE_V_1_11_6
+    default "1.11.1" if AUTOMAKE_V_1_11_1

--- a/config/companion_tools/libtool.in
+++ b/config/companion_tools/libtool.in
@@ -1,0 +1,21 @@
+# Libtool
+
+## help Libtool
+
+choice
+    bool
+    prompt "Libtool version"
+# Don't remove next line
+# CT_INSERT_VERSION_BELOW
+
+config LIBTOOL_V_2_4_6
+    bool
+    prompt "2.4.6"
+
+endchoice
+
+config LIBTOOL_VERSION
+    string
+# Don't remove next line
+# CT_INSERT_VERSION_STRING_BELOW
+    default "2.4.6" if LIBTOOL_V_2_4_6

--- a/config/companion_tools/m4.in
+++ b/config/companion_tools/m4.in
@@ -1,0 +1,26 @@
+# GNU m4
+
+## help GNU m4
+
+choice
+    bool
+    prompt "m4 version"
+# Don't remove next line
+# CT_INSERT_VERSION_BELOW
+
+config M4_V_1_4_17
+    bool
+    prompt "1.4.17"
+
+config M4_V_1_4_13
+    bool
+    prompt "1.4.13"
+
+endchoice
+
+config M4_VERSION
+    string
+# Don't remove next line
+# CT_INSERT_VERSION_STRING_BELOW
+    default "1.4.17" if M4_V_1_4_17
+    default "1.4.13" if M4_V_1_4_13

--- a/config/companion_tools/make.in
+++ b/config/companion_tools/make.in
@@ -1,0 +1,41 @@
+# GNU make
+
+## help GNU make
+
+choice
+    bool
+    prompt "make version"
+# Don't remove next line
+# CT_INSERT_VERSION_BELOW
+
+config MAKE_V_4_2_1
+    bool
+    prompt "4.2.1"
+
+config MAKE_V_4_1
+    bool
+    prompt "4.1"
+
+config MAKE_V_4_0
+    bool
+    prompt "4.0"
+
+config MAKE_V_3_81
+    bool
+    prompt "3.81"
+
+endchoice
+
+config MAKE_GMAKE_SYMLINK
+    bool
+    prompt "Add gmake symlink to companion gnu/make"
+    depends on COMP_TOOLS_make
+
+config MAKE_VERSION
+    string
+# Don't remove next line
+# CT_INSERT_VERSION_STRING_BELOW
+    default "4.2.1" if MAKE_V_4_2_1
+    default "4.1" if MAKE_V_4_1
+    default "4.0" if MAKE_V_4_0
+    default "3.81" if MAKE_V_3_81

--- a/config/config.mk
+++ b/config/config.mk
@@ -26,14 +26,16 @@ BINUTILS_CONFIG_FILES_2 = $(patsubst $(CT_LIB_DIR)/%,%,$(sort $(wildcard $(CT_LI
 LIBC_CONFIG_FILES       = $(patsubst $(CT_LIB_DIR)/%,%,$(sort $(wildcard $(CT_LIB_DIR)/config/libc/*.in)))
 LIBC_CONFIG_FILES_2     = $(patsubst $(CT_LIB_DIR)/%,%,$(sort $(wildcard $(CT_LIB_DIR)/config/libc/*.in.2)))
 DEBUG_CONFIG_FILES      = $(patsubst $(CT_LIB_DIR)/%,%,$(sort $(wildcard $(CT_LIB_DIR)/config/debug/*.in)))
+COMP_TOOLS_CONFIG_FILES = $(patsubst $(CT_LIB_DIR)/%,%,$(sort $(wildcard $(CT_LIB_DIR)/config/companion_tools/*.in)))
 
 # Build the list of generated config files
-GEN_CONFIG_FILES = config.gen/arch.in     \
-                   config.gen/kernel.in   \
-                   config.gen/cc.in       \
-                   config.gen/binutils.in \
-                   config.gen/libc.in     \
-                   config.gen/debug.in
+GEN_CONFIG_FILES = config.gen/arch.in            \
+                   config.gen/kernel.in          \
+                   config.gen/cc.in              \
+                   config.gen/binutils.in        \
+                   config.gen/libc.in            \
+                   config.gen/debug.in           \
+                   config.gen/companion_tools.in
 # ... and how to access them:
 # Generated files depends on the gen_in_frags script because it has the
 # functions needed to build the genrated files, and thus they might need
@@ -67,6 +69,7 @@ CCS       = $(patsubst config/cc/%.in,%,$(CC_CONFIG_FILES))
 BINUTILSS = $(patsubst config/binutils/%.in,%,$(BINUTILS_CONFIG_FILES))
 LIBCS     = $(patsubst config/libc/%.in,%,$(LIBC_CONFIG_FILES))
 DEBUGS    = $(patsubst config/debug/%.in,%,$(DEBUG_CONFIG_FILES))
+COMP_TOOLS= $(patsubst config/companion_tools/%.in,%,$(COMP_TOOLS_CONFIG_FILES))
 
 #-----------------------------------------------------------
 # The rules for the generated config files
@@ -96,6 +99,10 @@ config.gen/libc.in: $(LIBC_CONFIG_FILES) $(LIBC_CONFIG_FILES_2)
 config.gen/debug.in: $(DEBUG_CONFIG_FILES)
 	@$(CT_ECHO) '  IN    $(@)'
 	$(SILENT)$(CT_LIB_DIR)/scripts/gen_in_frags.sh menu "$@" "Debug facilities" "DEBUG" "config/debug" $(DEBUGS)
+
+config.gen/companion_tools.in: $(COMP_TOOLS_CONFIG_FILES)
+	@$(CT_ECHO) '  IN    $(@)'
+	$(SILENT)$(CT_LIB_DIR)/scripts/gen_in_frags.sh menu "$@" "Companion tools" "COMP_TOOLS" "config/companion_tools" $(COMP_TOOLS)
 
 #-----------------------------------------------------------
 # Cleaning up the mess...

--- a/configure.ac
+++ b/configure.ac
@@ -241,19 +241,21 @@ AC_CACHE_CHECK([for GNU make >= 3.80], [ac_cv_path_MAKE],
 AC_SUBST([MAKE], [$ac_cv_path_MAKE])
 AC_PROG_MAKE_SET
 
-# Check for GNU make 3.81 exactly, otherwise
+# Check for GNU make 3.81 or newer, otherwise
 # it will be built as a companion tool.
-AC_MSG_CHECKING([for make 3.81])
+AC_MSG_CHECKING([if make is 3.81 or newer])
 AS_IF(
-      [test "$MAKE_ver" = "GNU Make 3.81"],
-      [make381="y"
+      [[MAKE_ver2=$(echo "$MAKE_ver" \
+                    |$EGREP '^GNU Make (3.81|3.9[0-9]|[4-9])')
+        test -n "$MAKE_ver2"]],
+      [make_3_81_or_newer="y"
        AC_MSG_RESULT([yes])
       ],
-      [make381=
+      [make_3_81_or_newer=
        AC_MSG_RESULT([no])
       ]
      )
-ACX_SET_KCONFIG_OPTION([make381])
+ACX_SET_KCONFIG_OPTION([make_3_81_or_newer])
 
 #----------------------------------------
 # Check for libtool >= 1.5.26

--- a/scripts/addToolVersion.sh
+++ b/scripts/addToolVersion.sh
@@ -143,6 +143,16 @@ addToolVersion() {
                 SedExpr1="${SedExpr1}\n    select LIBC_UCLIBC_0_9_33_2_or_later"
             fi
             ;;
+        uClibc-ng)
+            # uClibc-ng-1.0.15 changed threading configuration, no longer compatible
+            # with the rest of uClibc gang.
+            ver_M=$(getVersionField "${version}" . 1)
+            ver_m=$(getVersionField "${version}" . 2)
+            ver_p=$(getVersionField "${version}" . 3)
+            if [  ${ver_M} -eq 0 -a ${ver_m} -eq 9 -a ${ver_p} -eq 33 ]; then
+                SedExpr1="${SedExpr1}\n    select LIBC_UCLIBC_NG_1_0_15_or_later"
+            fi
+            ;;
         gdb)
             # gdb-7.0 and above have special handling
             ver_M=$(getVersionField "${version}" . 1)
@@ -175,27 +185,32 @@ fi
 while [ $# -gt 0 ]; do
     case "$1" in
         # Tools:
-        --gcc)      EXP=; OBS=; cat=CC_GCC;         tool=gcc;       tool_prefix=cc;             dot2suffix=;;
-        --binutils) EXP=; OBS=; cat=BINUTILS;       tool=binutils;  tool_prefix=binutils;       dot2suffix=;;
-        --glibc)    EXP=; OBS=; cat=LIBC_GLIBC;     tool=glibc;     tool_prefix=libc;           dot2suffix=;;
-        --uClibc)   EXP=; OBS=; cat=LIBC_UCLIBC;    tool=uClibc;    tool_prefix=libc;           dot2suffix=;;
-        --uClibc-ng)EXP=; OBS=; cat=LIBC_UCLIBC_NG; tool=uClibc;    tool_prefix=libc;           dot2suffix=;;
-        --newlib)   EXP=; OBS=; cat=LIBC_NEWLIB;    tool=newlib;    tool_prefix=libc;           dot2suffix=;;
-        --mingw-w64)EXP=; OBS=; cat=WINAPI;         tool=mingw;     tool_prefix=libc;           dot2suffix=;;
-        --linux)    EXP=; OBS=; cat=KERNEL;         tool=linux;     tool_prefix=kernel;         dot2suffix=;;
-        --gdb)      EXP=; OBS=; cat=GDB;            tool=gdb;       tool_prefix=debug;          dot2suffix=;;
-        --dmalloc)  EXP=; OBS=; cat=DMALLOC;        tool=dmalloc;   tool_prefix=debug;          dot2suffix=;;
-        --duma)     EXP=; OBS=; cat=DUMA;           tool=duma;      tool_prefix=debug;          dot2suffix=;;
-        --strace)   EXP=; OBS=; cat=STRACE;         tool=strace;    tool_prefix=debug;          dot2suffix=;;
-        --ltrace)   EXP=; OBS=; cat=LTRACE;         tool=ltrace;    tool_prefix=debug;          dot2suffix=;;
-        --gmp)      EXP=; OBS=; cat=GMP;            tool=gmp;       tool_prefix=companion_libs; dot2suffix=;;
-        --mpfr)     EXP=; OBS=; cat=MPFR;           tool=mpfr;      tool_prefix=companion_libs; dot2suffix=;;
-        --isl)      EXP=; OBS=; cat=ISL;            tool=isl;       tool_prefix=companion_libs; dot2suffix=;;
-        --cloog)    EXP=; OBS=; cat=CLOOG;          tool=cloog;     tool_prefix=companion_libs; dot2suffix=;;
-        --mpc)      EXP=; OBS=; cat=MPC;            tool=mpc;       tool_prefix=companion_libs; dot2suffix=;;
-        --libelf)   EXP=; OBS=; cat=LIBELF;         tool=libelf;    tool_prefix=companion_libs; dot2suffix=;;
-        --expat)    EXP=; OBS=; cat=EXPAT;          tool=expat;     tool_prefix=companion_libs; dot2suffix=;;
-        --ncurses)  EXP=; OBS=; cat=NCURSES;        tool=ncurses;   tool_prefix=companion_libs; dot2suffix=;;
+        --gcc)      EXP=; OBS=; cat=CC_GCC;         tool=gcc;       tool_prefix=cc;              dot2suffix=;;
+        --binutils) EXP=; OBS=; cat=BINUTILS;       tool=binutils;  tool_prefix=binutils;        dot2suffix=;;
+        --glibc)    EXP=; OBS=; cat=LIBC_GLIBC;     tool=glibc;     tool_prefix=libc;            dot2suffix=;;
+        --uClibc)   EXP=; OBS=; cat=LIBC_UCLIBC;    tool=uClibc;    tool_prefix=libc;            dot2suffix=;;
+        --uClibc-ng)EXP=; OBS=; cat=LIBC_UCLIBC_NG; tool=uClibc;    tool_prefix=libc;            dot2suffix=;;
+        --newlib)   EXP=; OBS=; cat=LIBC_NEWLIB;    tool=newlib;    tool_prefix=libc;            dot2suffix=;;
+        --mingw-w64)EXP=; OBS=; cat=WINAPI;         tool=mingw;     tool_prefix=libc;            dot2suffix=;;
+        --linux)    EXP=; OBS=; cat=KERNEL;         tool=linux;     tool_prefix=kernel;          dot2suffix=;;
+        --gdb)      EXP=; OBS=; cat=GDB;            tool=gdb;       tool_prefix=debug;           dot2suffix=;;
+        --dmalloc)  EXP=; OBS=; cat=DMALLOC;        tool=dmalloc;   tool_prefix=debug;           dot2suffix=;;
+        --duma)     EXP=; OBS=; cat=DUMA;           tool=duma;      tool_prefix=debug;           dot2suffix=;;
+        --strace)   EXP=; OBS=; cat=STRACE;         tool=strace;    tool_prefix=debug;           dot2suffix=;;
+        --ltrace)   EXP=; OBS=; cat=LTRACE;         tool=ltrace;    tool_prefix=debug;           dot2suffix=;;
+        --gmp)      EXP=; OBS=; cat=GMP;            tool=gmp;       tool_prefix=companion_libs;  dot2suffix=;;
+        --mpfr)     EXP=; OBS=; cat=MPFR;           tool=mpfr;      tool_prefix=companion_libs;  dot2suffix=;;
+        --isl)      EXP=; OBS=; cat=ISL;            tool=isl;       tool_prefix=companion_libs;  dot2suffix=;;
+        --cloog)    EXP=; OBS=; cat=CLOOG;          tool=cloog;     tool_prefix=companion_libs;  dot2suffix=;;
+        --mpc)      EXP=; OBS=; cat=MPC;            tool=mpc;       tool_prefix=companion_libs;  dot2suffix=;;
+        --libelf)   EXP=; OBS=; cat=LIBELF;         tool=libelf;    tool_prefix=companion_libs;  dot2suffix=;;
+        --expat)    EXP=; OBS=; cat=EXPAT;          tool=expat;     tool_prefix=companion_libs;  dot2suffix=;;
+        --ncurses)  EXP=; OBS=; cat=NCURSES;        tool=ncurses;   tool_prefix=companion_libs;  dot2suffix=;;
+        --make)     EXP=; OBS=; cat=MAKE;           tool=make;      tool_prefix=companion_tools; dot2suffix=;;
+        --m4)       EXP=; OBS=; cat=M4;             tool=m4;        tool_prefix=companion_tools; dot2suffix=;;
+        --autoconf) EXP=; OBS=; cat=AUTOCONF;       tool=autoconf;  tool_prefix=companion_tools; dot2suffix=;;
+        --automake) EXP=; OBS=; cat=AUTOMAKE;       tool=automake;  tool_prefix=companion_tools; dot2suffix=;;
+        --libtool)  EXP=; OBS=; cat=LIBTOOL;        tool=libtool;   tool_prefix=companion_tools; dot2suffix=;;
 
         # Tools options:
         -x|--experimental|+s)   EXP=1;;

--- a/scripts/build/arch.sh
+++ b/scripts/build/arch.sh
@@ -23,7 +23,7 @@ CT_DoArchUClibcSelectArch() {
     local cfg="${1}"
     local arch="${2}"
 
-    ${sed} -i -r -e '/^TARGET_.*/d' "${cfg}"
+    sed -i -r -e '/^TARGET_.*/d' "${cfg}"
     CT_KconfigEnableOption "TARGET_${arch}" "${cfg}"
     CT_KconfigSetOption "TARGET_ARCH" "${arch}" "${cfg}"
 }

--- a/scripts/build/binutils/binutils.sh
+++ b/scripts/build/binutils/binutils.sh
@@ -8,8 +8,8 @@ do_binutils_get() {
         CT_GetCustom "binutils" "${CT_BINUTILS_CUSTOM_VERSION}" \
             "${CT_BINUTILS_CUSTOM_LOCATION}"
     else
-        if echo ${CT_BINUTILS_VERSION} |${grep} -q linaro; then
-            YYMM=`echo ${CT_BINUTILS_VERSION} |cut -d- -f3 |${sed} -e 's,^..,,'`
+        if echo ${CT_BINUTILS_VERSION} |grep -q linaro; then
+            YYMM=`echo ${CT_BINUTILS_VERSION} |cut -d- -f3 |sed -e 's,^..,,'`
             CT_GetFile "binutils-${CT_BINUTILS_VERSION}"                                        \
                        https://releases.linaro.org/${YYMM}/components/toolchain/binutils-linaro \
                        http://cbuild.validation.linaro.org/snapshots
@@ -230,14 +230,14 @@ do_binutils_backend() {
     if [ "${static_build}" = "y" ]; then
         extra_make_flags+=("LDFLAGS=${ldflags} -all-static")
         CT_DoLog EXTRA "Prepare binutils for static build"
-        CT_DoExecLog ALL ${make} ${JOBSFLAGS} configure-host
+        CT_DoExecLog ALL make ${JOBSFLAGS} configure-host
     fi
 
     CT_DoLog EXTRA "Building binutils"
-    CT_DoExecLog ALL ${make} "${extra_make_flags[@]}" ${JOBSFLAGS}
+    CT_DoExecLog ALL make "${extra_make_flags[@]}" ${JOBSFLAGS}
 
     CT_DoLog EXTRA "Installing binutils"
-    CT_DoExecLog ALL ${make} install
+    CT_DoExecLog ALL make install
 
     if [ "${build_manuals}" = "y" ]; then
         CT_DoLog EXTRA "Building and installing the binutils manuals"
@@ -247,8 +247,8 @@ do_binutils_backend() {
         fi
         manuals_install=( "${manuals_for[@]/\#/install-pdf-}" )
         manuals_install+=( "${manuals_for[@]/\#/install-html-}" )
-        CT_DoExecLog ALL ${make} ${JOBSFLAGS} pdf html
-        CT_DoExecLog ALL ${make} "${manuals_install[@]}"
+        CT_DoExecLog ALL make ${JOBSFLAGS} pdf html
+        CT_DoExecLog ALL make "${manuals_install[@]}"
     fi
 
     # Install the wrapper if needed
@@ -256,7 +256,7 @@ do_binutils_backend() {
         CT_DoLog EXTRA "Installing ld wrapper"
         rm -f "${prefix}/bin/${CT_TARGET}-ld"
         rm -f "${prefix}/${CT_TARGET}/bin/ld"
-        ${sed} -r -e "s/@@DEFAULT_LD@@/${CT_BINUTILS_LINKER_DEFAULT}/" \
+        sed -r -e "s/@@DEFAULT_LD@@/${CT_BINUTILS_LINKER_DEFAULT}/" \
             "${CT_LIB_DIR}/scripts/build/binutils/binutils-ld.in"      \
             >"${prefix}/bin/${CT_TARGET}-ld"
         chmod +x "${prefix}/bin/${CT_TARGET}-ld"
@@ -314,10 +314,10 @@ do_elf2flt_backend() {
         "${CT_ELF2FLT_EXTRA_CONFIG_ARRAY[@]}"
 
     CT_DoLog EXTRA "Building elf2flt"
-    CT_DoExecLog ALL ${make} ${JOBSFLAGS}
+    CT_DoExecLog ALL make ${JOBSFLAGS}
 
     CT_DoLog EXTRA "Installing elf2flt"
-    CT_DoExecLog ALL ${make} install
+    CT_DoExecLog ALL make install
 }
 
 # Now on for the target libraries
@@ -372,9 +372,9 @@ do_binutils_for_target() {
             "${CT_BINUTILS_EXTRA_CONFIG_ARRAY[@]}"
 
         CT_DoLog EXTRA "Building binutils' libraries (${targets[*]}) for target"
-        CT_DoExecLog ALL ${make} ${JOBSFLAGS} "${build_targets[@]}"
+        CT_DoExecLog ALL make ${JOBSFLAGS} "${build_targets[@]}"
         CT_DoLog EXTRA "Installing binutils' libraries (${targets[*]}) for target"
-        CT_DoExecLog ALL ${make} DESTDIR="${CT_SYSROOT_DIR}" "${install_targets[@]}"
+        CT_DoExecLog ALL make DESTDIR="${CT_SYSROOT_DIR}" "${install_targets[@]}"
 
         CT_Popd
         CT_EndStep

--- a/scripts/build/cc/100-gcc.sh
+++ b/scripts/build/cc/100-gcc.sh
@@ -13,10 +13,10 @@ do_gcc_get() {
     else
         # Account for the Linaro versioning
         linaro_version="$( echo "${CT_CC_GCC_VERSION}"  \
-                           |${sed} -r -e 's/^linaro-//;'   \
+                           |sed -r -e 's/^linaro-//;'   \
                          )"
         linaro_series="$( echo "${linaro_version}"      \
-                          |${sed} -r -e 's/-.*//;'         \
+                          |sed -r -e 's/-.*//;'         \
                         )"
 
         # The official gcc hosts put gcc under a gcc/release/ directory,
@@ -27,7 +27,7 @@ do_gcc_get() {
                        {http,ftp,https}://ftp.gnu.org/gnu/gcc/gcc-${CT_CC_GCC_VERSION} \
                        ftp://{gcc.gnu.org,sourceware.org}/pub/gcc/releases/gcc-${CT_CC_GCC_VERSION}
         else
-            YYMM=`echo ${CT_CC_GCC_VERSION} |cut -d- -f3 |${sed} -e 's,^..,,'`
+            YYMM=`echo ${CT_CC_GCC_VERSION} |cut -d- -f3 |sed -e 's,^..,,'`
             CT_GetFile "gcc-${CT_CC_GCC_VERSION}"                                                             \
                        "https://releases.linaro.org/components/toolchain/gcc-linaro/${linaro_version}"        \
                        "https://releases.linaro.org/${YYMM}/components/toolchain/gcc-linaro/${linaro_series}" \
@@ -185,7 +185,7 @@ cc_gcc_multilib_housekeeping() {
 
     # sed: prepend dashes or do nothing if default is empty string
     multilib_defaults=( $( cc_gcc_get_spec multilib_defaults "${cc}" | \
-        ${sed} 's/\(^\|[[:space:]]\+\)\([^[:space:]]\)/ -\2/g' ) )
+        sed 's/\(^\|[[:space:]]\+\)\([^[:space:]]\)/ -\2/g' ) )
     CT_DoLog EXTRA "gcc default flags: '${multilib_defaults}'"
 
     multilibs=( $( "${cc}" -print-multi-lib ) )
@@ -238,7 +238,7 @@ cc_gcc_multilib_housekeeping() {
         sysroot=$( "${cc}" -print-sysroot )
         if [ -n "${base}" ]; then
             CT_DoExecLog ALL mkdir -p "${sysroot}${base}"
-            lnk=$( echo "${base#/}" | ${sed} -e 's,[^/]*,..,g' )
+            lnk=$( echo "${base#/}" | sed -e 's,[^/]*,..,g' )
         else
             lnk=.
         fi
@@ -629,23 +629,23 @@ do_gcc_core_backend() {
         # Next we have to configure gcc, create libgcc.mk then edit it...
         # So much easier if we just edit the source tree, but hey...
         if [ ! -f "${CT_SRC_DIR}/gcc-${CT_CC_GCC_VERSION}/gcc/BASE-VER" ]; then
-            CT_DoExecLog CFG ${make} ${JOBSFLAGS} configure-libiberty
-            CT_DoExecLog ALL ${make} ${JOBSFLAGS} -C libiberty libiberty.a
-            CT_DoExecLog CFG ${make} ${JOBSFLAGS} configure-gcc configure-libcpp
-            CT_DoExecLog ALL ${make} ${JOBSFLAGS} all-libcpp
+            CT_DoExecLog CFG make ${JOBSFLAGS} configure-libiberty
+            CT_DoExecLog ALL make ${JOBSFLAGS} -C libiberty libiberty.a
+            CT_DoExecLog CFG make ${JOBSFLAGS} configure-gcc configure-libcpp
+            CT_DoExecLog ALL make ${JOBSFLAGS} all-libcpp
         else
-            CT_DoExecLog CFG ${make} ${JOBSFLAGS} configure-gcc configure-libcpp configure-build-libiberty
-            CT_DoExecLog ALL ${make} ${JOBSFLAGS} all-libcpp all-build-libiberty
+            CT_DoExecLog CFG make ${JOBSFLAGS} configure-gcc configure-libcpp configure-build-libiberty
+            CT_DoExecLog ALL make ${JOBSFLAGS} all-libcpp all-build-libiberty
         fi
         # HACK: gcc-4.2 uses libdecnumber to build libgcc.mk, so build it here.
         if [ -d "${CT_SRC_DIR}/gcc-${CT_CC_GCC_VERSION}/libdecnumber" ]; then
-            CT_DoExecLog CFG ${make} ${JOBSFLAGS} configure-libdecnumber
-            CT_DoExecLog ALL ${make} ${JOBSFLAGS} -C libdecnumber libdecnumber.a
+            CT_DoExecLog CFG make ${JOBSFLAGS} configure-libdecnumber
+            CT_DoExecLog ALL make ${JOBSFLAGS} -C libdecnumber libdecnumber.a
         fi
         # HACK: gcc-4.8 uses libbacktrace to make libgcc.mvars, so make it here.
         if [ -d "${CT_SRC_DIR}/gcc-${CT_CC_GCC_VERSION}/libbacktrace" ]; then
-            CT_DoExecLog CFG ${make} ${JOBSFLAGS} configure-libbacktrace
-            CT_DoExecLog ALL ${make} ${JOBSFLAGS} -C libbacktrace
+            CT_DoExecLog CFG make ${JOBSFLAGS} configure-libbacktrace
+            CT_DoExecLog ALL make ${JOBSFLAGS} -C libbacktrace
         fi
 
         libgcc_rule="libgcc.mvars"
@@ -663,9 +663,9 @@ do_gcc_core_backend() {
             repair_cc=""
         fi
 
-        CT_DoExecLog ALL ${make} ${JOBSFLAGS} -C gcc ${libgcc_rule} \
+        CT_DoExecLog ALL make ${JOBSFLAGS} -C gcc ${libgcc_rule} \
                               ${repair_cc}
-        ${sed} -r -i -e 's@-lc@@g' gcc/${libgcc_rule}
+        sed -r -i -e 's@-lc@@g' gcc/${libgcc_rule}
     else # build_libgcc
         core_targets=( gcc )
     fi   # ! build libgcc
@@ -694,7 +694,7 @@ do_gcc_core_backend() {
     esac
 
     CT_DoLog EXTRA "Building ${log_txt}"
-    CT_DoExecLog ALL ${make} ${JOBSFLAGS} ${core_targets_all}
+    CT_DoExecLog ALL make ${JOBSFLAGS} ${core_targets_all}
 
     # Do not pass ${JOBSFLAGS} here: recent GCC builds have been failing
     # in parallel 'make install' at random locations: libitm, libcilk,
@@ -705,7 +705,7 @@ do_gcc_core_backend() {
     # attempts to remove the destination and re-create it, but another
     # install gets in the way.
     CT_DoLog EXTRA "Installing ${log_txt}"
-    CT_DoExecLog ALL ${make} ${core_targets_install}
+    CT_DoExecLog ALL make ${core_targets_install}
 
     # Remove the libtool "pseudo-libraries": having them in the installed
     # tree makes the libtoolized utilities that are built next assume
@@ -718,9 +718,9 @@ do_gcc_core_backend() {
 
     if [ "${build_manuals}" = "yes" ]; then
         CT_DoLog EXTRA "Building the GCC manuals"
-        CT_DoExecLog ALL ${make} pdf html
+        CT_DoExecLog ALL make pdf html
         CT_DoLog EXTRA "Installing the GCC manuals"
-        CT_DoExecLog ALL ${make} install-{pdf,html}-gcc
+        CT_DoExecLog ALL make install-{pdf,html}-gcc
     fi
 
     # Create a symlink ${CT_TARGET}-cc to ${CT_TARGET}-gcc to always be able
@@ -1130,18 +1130,18 @@ do_gcc_backend() {
 
     if [ "${CT_CANADIAN}" = "y" ]; then
         CT_DoLog EXTRA "Building libiberty"
-        CT_DoExecLog ALL ${make} ${JOBSFLAGS} all-build-libiberty
+        CT_DoExecLog ALL make ${JOBSFLAGS} all-build-libiberty
     fi
 
     CT_DoLog EXTRA "Building final gcc compiler"
-    CT_DoExecLog ALL ${make} ${JOBSFLAGS} all
+    CT_DoExecLog ALL make ${JOBSFLAGS} all
 
     # See the note on issues with parallel 'make install' in GCC above.
     CT_DoLog EXTRA "Installing final gcc compiler"
     if [ "${CT_STRIP_TARGET_TOOLCHAIN_EXECUTABLES}" = "y" ]; then
-        CT_DoExecLog ALL ${make} install-strip
+        CT_DoExecLog ALL make install-strip
     else
-        CT_DoExecLog ALL ${make} install
+        CT_DoExecLog ALL make install
     fi
 
     # Remove the libtool "pseudo-libraries": having them in the installed
@@ -1155,9 +1155,9 @@ do_gcc_backend() {
 
     if [ "${build_manuals}" = "yes" ]; then
         CT_DoLog EXTRA "Building the GCC manuals"
-        CT_DoExecLog ALL ${make} pdf html
+        CT_DoExecLog ALL make pdf html
         CT_DoLog EXTRA "Installing the GCC manuals"
-        CT_DoExecLog ALL ${make} install-{pdf,html}-gcc
+        CT_DoExecLog ALL make install-{pdf,html}-gcc
     fi
 
     # Create a symlink ${CT_TARGET}-cc to ${CT_TARGET}-gcc to always be able

--- a/scripts/build/companion_libs/100-gmp.sh
+++ b/scripts/build/companion_libs/100-gmp.sh
@@ -103,15 +103,15 @@ do_gmp_backend() {
         "${extra_config}"
 
     CT_DoLog EXTRA "Building GMP"
-    CT_DoExecLog ALL ${make} ${JOBSFLAGS}
+    CT_DoExecLog ALL make ${JOBSFLAGS}
 
     if [ "${CT_COMPLIBS_CHECK}" = "y" ]; then
         CT_DoLog EXTRA "Checking GMP"
-        CT_DoExecLog ALL ${make} ${JOBSFLAGS} -s check
+        CT_DoExecLog ALL make ${JOBSFLAGS} -s check
     fi
 
     CT_DoLog EXTRA "Installing GMP"
-    CT_DoExecLog ALL ${make} install
+    CT_DoExecLog ALL make install
 }
 
 fi # CT_GMP

--- a/scripts/build/companion_libs/110-mpfr.sh
+++ b/scripts/build/companion_libs/110-mpfr.sh
@@ -53,12 +53,12 @@ do_mpfr_extract() {
                 # See: http://sourceware.org/ml/crossgcc/2008-11/msg00046.html
                 # and: http://sourceware.org/ml/crossgcc/2008-11/msg00048.html
                 libtoolize_opt=
-                case "$(${libtoolize} --version |head -n 1 |${awk} '{ print $(NF); }')" in
+                case "$(libtoolize --version |head -n 1 |awk '{ print $(NF); }')" in
                     0.*)    ;;
                     1.*)    ;;
                     *)      libtoolize_opt=-i;;
                 esac
-                CT_DoExecLog ALL ${libtoolize} -f ${libtoolize_opt}
+                CT_DoExecLog ALL libtoolize -f ${libtoolize_opt}
                 touch .autotools.ct-ng
             fi
             CT_Popd
@@ -146,15 +146,15 @@ do_mpfr_backend() {
         --enable-static
 
     CT_DoLog EXTRA "Building MPFR"
-    CT_DoExecLog ALL ${make} ${JOBSFLAGS}
+    CT_DoExecLog ALL make ${JOBSFLAGS}
 
     if [ "${CT_COMPLIBS_CHECK}" = "y" ]; then
         CT_DoLog EXTRA "Checking MPFR"
-        CT_DoExecLog ALL ${make} ${JOBSFLAGS} -s check
+        CT_DoExecLog ALL make ${JOBSFLAGS} -s check
     fi
 
     CT_DoLog EXTRA "Installing MPFR"
-    CT_DoExecLog ALL ${make} install
+    CT_DoExecLog ALL make install
 }
 
 fi # CT_MPFR

--- a/scripts/build/companion_libs/121-isl.sh
+++ b/scripts/build/companion_libs/121-isl.sh
@@ -122,15 +122,15 @@ do_isl_backend() {
         --with-clang=no
 
     CT_DoLog EXTRA "Building ISL"
-    CT_DoExecLog ALL ${make} ${JOBSFLAGS}
+    CT_DoExecLog ALL make ${JOBSFLAGS}
 
     if [ "${CT_COMPLIBS_CHECK}" = "y" ]; then
         CT_DoLog EXTRA "Checking ISL"
-        CT_DoExecLog ALL ${make} ${JOBSFLAGS} -s check
+        CT_DoExecLog ALL make ${JOBSFLAGS} -s check
     fi
 
     CT_DoLog EXTRA "Installing ISL"
-    CT_DoExecLog ALL ${make} install
+    CT_DoExecLog ALL make install
 }
 
 fi # CT_ISL

--- a/scripts/build/companion_libs/130-cloog.sh
+++ b/scripts/build/companion_libs/130-cloog.sh
@@ -109,15 +109,15 @@ do_cloog_backend() {
         "${cloog_opts[@]}"
 
     CT_DoLog EXTRA "Building CLooG"
-    CT_DoExecLog ALL ${make} ${JOBSFLAGS}
+    CT_DoExecLog ALL make ${JOBSFLAGS}
 
     if [ "${CT_COMPLIBS_CHECK}" = "y" ]; then
         CT_DoLog EXTRA "Checking CLooG"
-        CT_DoExecLog ALL ${make} ${JOBSFLAGS} -s check
+        CT_DoExecLog ALL make ${JOBSFLAGS} -s check
     fi
 
     CT_DoLog EXTRA "Installing CLooG"
-    CT_DoExecLog ALL ${make} install
+    CT_DoExecLog ALL make install
 }
 
 fi # CT_CLOOG

--- a/scripts/build/companion_libs/140-mpc.sh
+++ b/scripts/build/companion_libs/140-mpc.sh
@@ -97,15 +97,15 @@ do_mpc_backend() {
         --enable-static
 
     CT_DoLog EXTRA "Building MPC"
-    CT_DoExecLog ALL ${make} ${JOBSFLAGS}
+    CT_DoExecLog ALL make ${JOBSFLAGS}
 
     if [ "${CT_COMPLIBS_CHECK}" = "y" ]; then
         CT_DoLog EXTRA "Checking MPC"
-        CT_DoExecLog ALL ${make} ${JOBSFLAGS} -s check
+        CT_DoExecLog ALL make ${JOBSFLAGS} -s check
     fi
 
     CT_DoLog EXTRA "Installing MPC"
-    CT_DoExecLog ALL ${make} install
+    CT_DoExecLog ALL make install
 }
 
 fi # CT_MPC

--- a/scripts/build/companion_libs/200-libelf.sh
+++ b/scripts/build/companion_libs/200-libelf.sh
@@ -132,7 +132,7 @@ do_libelf_backend() {
         "${extra_config[@]}"
 
     CT_DoLog EXTRA "Building libelf"
-    CT_DoExecLog ALL ${make}
+    CT_DoExecLog ALL make
 
     CT_DoLog EXTRA "Installing libelf"
 
@@ -142,7 +142,7 @@ do_libelf_backend() {
         destdir=
     fi
 
-    CT_DoExecLog ALL ${make} instroot="${destdir}" install
+    CT_DoExecLog ALL make instroot="${destdir}" install
 }
 
 fi # CT_LIBELF || CT_LIBELF_TARGET

--- a/scripts/build/companion_libs/210-expat.sh
+++ b/scripts/build/companion_libs/210-expat.sh
@@ -93,9 +93,9 @@ do_expat_backend() {
         "${extra_config[@]}"
 
     CT_DoLog EXTRA "Building expat"
-    CT_DoExecLog ALL ${make} ${JOBSFLAGS}
+    CT_DoExecLog ALL make ${JOBSFLAGS}
     CT_DoLog EXTRA "Installing expat"
-    CT_DoExecLog ALL ${make} install INSTALL_ROOT="${destdir}"
+    CT_DoExecLog ALL make install INSTALL_ROOT="${destdir}"
 }
 
 fi

--- a/scripts/build/companion_libs/220-ncurses.sh
+++ b/scripts/build/companion_libs/220-ncurses.sh
@@ -148,9 +148,9 @@ do_ncurses_backend() {
     # it also builds ncurses anyway, and dedicated targets (install.includes and
     # install.progs) do not do well with parallel make (-jX).
     CT_DoLog EXTRA "Building ncurses"
-    CT_DoExecLog ALL ${make} ${JOBSFLAGS}
+    CT_DoExecLog ALL make ${JOBSFLAGS}
     CT_DoLog EXTRA "Installing ncurses"
-    CT_DoExecLog ALL ${make} install
+    CT_DoExecLog ALL make install
 }
 
 fi

--- a/scripts/build/companion_libs/320-libiconv.sh
+++ b/scripts/build/companion_libs/320-libiconv.sh
@@ -106,10 +106,10 @@ do_libiconv_backend() {
         "${extra_config[@]}"                                  \
 
     CT_DoLog EXTRA "Building libiconv"
-    CT_DoExecLog ALL ${make} CC="${host}-gcc ${cflags}" ${JOBSFLAGS}
+    CT_DoExecLog ALL make CC="${host}-gcc ${cflags}" ${JOBSFLAGS}
 
     CT_DoLog EXTRA "Installing libiconv"
-    CT_DoExecLog ALL ${make} install CC="${host}-gcc ${cflags}"
+    CT_DoExecLog ALL make install CC="${host}-gcc ${cflags}"
 }
 
 fi

--- a/scripts/build/companion_libs/330-gettext.sh
+++ b/scripts/build/companion_libs/330-gettext.sh
@@ -128,10 +128,10 @@ do_gettext_backend() {
         "${extra_config[@]}"
 
     CT_DoLog EXTRA "Building gettext"
-    CT_DoExecLog ALL ${make} ${JOBSFLAGS}
+    CT_DoExecLog ALL make ${JOBSFLAGS}
 
     CT_DoLog EXTRA "Installing gettext"
-    CT_DoExecLog ALL ${make} install
+    CT_DoExecLog ALL make install
 }
 
 fi

--- a/scripts/build/companion_tools/050-make.sh
+++ b/scripts/build/companion_tools/050-make.sh
@@ -1,7 +1,5 @@
 # Build script for make
 
-CT_MAKE_VERSION=3.81
-
 do_companion_tools_make_get() {
     CT_GetFile "make-${CT_MAKE_VERSION}"        \
         {http,ftp,https}://ftp.gnu.org/gnu/make
@@ -22,7 +20,7 @@ do_companion_tools_make_build() {
                      --prefix="${CT_BUILDTOOLS_PREFIX_DIR}"
     CT_DoExecLog ALL make
     CT_DoExecLog ALL make install
-    if [ "${CT_COMP_TOOLS_make_gmake}" = "y" ]; then
+    if [ "${CT_MAKE_GMAKE_SYMLINK}" = "y" ]; then
         CT_DoExecLog ALL ln -sv make "${CT_BUILDTOOLS_PREFIX_DIR}/bin/gmake"
     fi
     CT_Popd

--- a/scripts/build/companion_tools/050-make.sh
+++ b/scripts/build/companion_tools/050-make.sh
@@ -23,7 +23,7 @@ do_companion_tools_make_build() {
     CT_DoExecLog ALL ${make}
     CT_DoExecLog ALL ${make} install
     if [ "${CT_COMP_TOOLS_make_gmake}" = "y" ]; then
-        CT_DoExecLog ALL ln -sv ${make} "${CT_BUILDTOOLS_PREFIX_DIR}/bin/gmake"
+        CT_DoExecLog ALL ln -sv make "${CT_BUILDTOOLS_PREFIX_DIR}/bin/gmake"
     fi
     CT_Popd
     CT_EndStep

--- a/scripts/build/companion_tools/050-make.sh
+++ b/scripts/build/companion_tools/050-make.sh
@@ -20,8 +20,8 @@ do_companion_tools_make_build() {
 
     CT_DoExecLog CFG "${CT_SRC_DIR}/make-${CT_MAKE_VERSION}/configure" \
                      --prefix="${CT_BUILDTOOLS_PREFIX_DIR}"
-    CT_DoExecLog ALL ${make}
-    CT_DoExecLog ALL ${make} install
+    CT_DoExecLog ALL make
+    CT_DoExecLog ALL make install
     if [ "${CT_COMP_TOOLS_make_gmake}" = "y" ]; then
         CT_DoExecLog ALL ln -sv make "${CT_BUILDTOOLS_PREFIX_DIR}/bin/gmake"
     fi

--- a/scripts/build/companion_tools/100-m4.sh
+++ b/scripts/build/companion_tools/100-m4.sh
@@ -1,7 +1,5 @@
 # Build script for m4
 
-CT_M4_VERSION=1.4.13
-
 do_companion_tools_m4_get() {
     CT_GetFile "m4-${CT_M4_VERSION}"          \
         {http,ftp,https}://ftp.gnu.org/gnu/m4

--- a/scripts/build/companion_tools/100-m4.sh
+++ b/scripts/build/companion_tools/100-m4.sh
@@ -20,8 +20,8 @@ do_companion_tools_m4_build() {
     CT_DoExecLog CFG \
     "${CT_SRC_DIR}/m4-${CT_M4_VERSION}/configure" \
         --prefix="${CT_BUILDTOOLS_PREFIX_DIR}"
-    CT_DoExecLog ALL ${make}
-    CT_DoExecLog ALL ${make} install
+    CT_DoExecLog ALL make
+    CT_DoExecLog ALL make install
     CT_Popd
     CT_EndStep
 }

--- a/scripts/build/companion_tools/200-autoconf.sh
+++ b/scripts/build/companion_tools/200-autoconf.sh
@@ -1,7 +1,5 @@
 # Build script for autoconf
 
-CT_AUTOCONF_VERSION=2.65
-
 do_companion_tools_autoconf_get() {
     CT_GetFile "autoconf-${CT_AUTOCONF_VERSION}"    \
         {http,ftp,https}://ftp.gnu.org/gnu/autoconf

--- a/scripts/build/companion_tools/200-autoconf.sh
+++ b/scripts/build/companion_tools/200-autoconf.sh
@@ -26,8 +26,8 @@ do_companion_tools_autoconf_build() {
     CT_DoExecLog CFG ${CONFIG_SHELL} \
     "${CT_SRC_DIR}/autoconf-${CT_AUTOCONF_VERSION}/configure" \
         --prefix="${CT_BUILDTOOLS_PREFIX_DIR}"
-    CT_DoExecLog ALL ${make}
-    CT_DoExecLog ALL ${make} install
+    CT_DoExecLog ALL make
+    CT_DoExecLog ALL make install
     CT_Popd
     CT_EndStep
 }

--- a/scripts/build/companion_tools/300-automake.sh
+++ b/scripts/build/companion_tools/300-automake.sh
@@ -1,7 +1,5 @@
 # Build script for automake
 
-CT_AUTOMAKE_VERSION=1.11.1
-
 do_companion_tools_automake_get() {
     CT_GetFile "automake-${CT_AUTOMAKE_VERSION}"    \
         {http,ftp,https}://ftp.gnu.org/gnu/automake

--- a/scripts/build/companion_tools/300-automake.sh
+++ b/scripts/build/companion_tools/300-automake.sh
@@ -21,8 +21,8 @@ do_companion_tools_automake_build() {
     CT_DoExecLog CFG \
     "${CT_SRC_DIR}/automake-${CT_AUTOMAKE_VERSION}/configure" \
         --prefix="${CT_BUILDTOOLS_PREFIX_DIR}"
-    CT_DoExecLog ALL ${make}
-    CT_DoExecLog ALL ${make} install
+    CT_DoExecLog ALL make
+    CT_DoExecLog ALL make install
     CT_Popd
     CT_EndStep
 }

--- a/scripts/build/companion_tools/400-libtool.sh
+++ b/scripts/build/companion_tools/400-libtool.sh
@@ -1,7 +1,5 @@
 # Build script for libtool
 
-CT_LIBTOOL_VERSION=2.4.6
-
 do_companion_tools_libtool_get() {
     CT_GetFile "libtool-${CT_LIBTOOL_VERSION}"     \
         {http,ftp,https}://ftp.gnu.org/gnu/libtool

--- a/scripts/build/companion_tools/400-libtool.sh
+++ b/scripts/build/companion_tools/400-libtool.sh
@@ -21,8 +21,8 @@ do_companion_tools_libtool_build() {
     CT_DoExecLog CFG \
     "${CT_SRC_DIR}/libtool-${CT_LIBTOOL_VERSION}/configure" \
         --prefix="${CT_BUILDTOOLS_PREFIX_DIR}"
-    CT_DoExecLog ALL ${make}
-    CT_DoExecLog ALL ${make} install
+    CT_DoExecLog ALL make
+    CT_DoExecLog ALL make install
     CT_Popd
     CT_EndStep
 }

--- a/scripts/build/debug/000-template.sh
+++ b/scripts/build/debug/000-template.sh
@@ -26,8 +26,8 @@ do_debug_foobar_build() {
     #     --host=${CT_TARGET}                                 \
     #     --prefix=/usr                                       \
     #     --foobar-options
-    # CT_DoExecLog ALL ${make}
-    # CT_DoExecLog ALL ${make} DESTDIR="${CT_SYSROOT_DIR}" install
+    # CT_DoExecLog ALL make
+    # CT_DoExecLog ALL make DESTDIR="${CT_SYSROOT_DIR}" install
     # CT_Popd
     :
 }

--- a/scripts/build/debug/100-dmalloc.sh
+++ b/scripts/build/debug/100-dmalloc.sh
@@ -47,11 +47,11 @@ do_debug_dmalloc_build() {
         "${extra_config[@]}"
 
     CT_DoLog EXTRA "Building dmalloc"
-    CT_DoExecLog ALL ${make}
+    CT_DoExecLog ALL make
 
     CT_DoLog EXTRA "Installing dmalloc"
-    CT_DoExecLog ALL ${make} DESTDIR="${CT_SYSROOT_DIR}" installincs installlib
-    CT_DoExecLog ALL ${make} DESTDIR="${CT_DEBUGROOT_DIR}" installutil
+    CT_DoExecLog ALL make DESTDIR="${CT_SYSROOT_DIR}" installincs installlib
+    CT_DoExecLog ALL make DESTDIR="${CT_DEBUGROOT_DIR}" installutil
 
     CT_EndStep
 }

--- a/scripts/build/debug/200-duma.sh
+++ b/scripts/build/debug/200-duma.sh
@@ -32,7 +32,7 @@ do_debug_duma_build() {
 
     # The shared library needs some love: some version have libduma.so.0.0,
     # while others have libduma.so.0.0.0
-    duma_so=$(${make} -n -p 2>&1 |${grep} -E '^libduma.so[^:]*:' |head -n 1 |cut -d : -f 1)
+    duma_so=$(make -n -p 2>&1 |grep -E '^libduma.so[^:]*:' |head -n 1 |cut -d : -f 1)
 
     libs=
     [ "${CT_DUMA_A}" = "y" ] && libs="${libs} libduma.a"
@@ -40,21 +40,21 @@ do_debug_duma_build() {
     libs="${libs# }"
     CT_DoLog EXTRA "Building libraries '${libs}'"
     CT_DoExecLog ALL                    \
-    ${make} HOSTCC="${CT_BUILD}-gcc"    \
+    make HOSTCC="${CT_BUILD}-gcc"    \
          CC="${CT_TARGET}-gcc"          \
          CXX="${CT_TARGET}-gcc"         \
          RANLIB="${CT_TARGET}-ranlib"   \
          DUMA_CPP="${DUMA_CPP}"         \
          ${libs}
     CT_DoLog EXTRA "Installing libraries '${libs}'"
-    CT_DoExecLog ALL ${install} -m 644 ${libs} "${CT_SYSROOT_DIR}/usr/lib"
+    CT_DoExecLog ALL install -m 644 ${libs} "${CT_SYSROOT_DIR}/usr/lib"
     if [ "${CT_DUMA_SO}" = "y" ]; then
         CT_DoLog EXTRA "Installing shared library link"
         ln -vsf ${duma_so} "${CT_SYSROOT_DIR}/usr/lib/libduma.so"   2>&1 |CT_DoLog ALL
         CT_DoLog EXTRA "Installing wrapper script"
         mkdir -p "${CT_DEBUGROOT_DIR}/usr/bin"
         # Install a simpler, smaller, safer wrapper than the one provided by D.U.M.A.
-        ${sed} -r -e 's:^LIBDUMA_SO=.*:LIBDUMA_SO=/usr/lib/'"${duma_so}"':;'   \
+        sed -r -e 's:^LIBDUMA_SO=.*:LIBDUMA_SO=/usr/lib/'"${duma_so}"':;'   \
             "${CT_LIB_DIR}/scripts/build/debug/duma.in"                        \
             >"${CT_DEBUGROOT_DIR}/usr/bin/duma"
         chmod 755 "${CT_DEBUGROOT_DIR}/usr/bin/duma"

--- a/scripts/build/debug/300-gdb.sh
+++ b/scripts/build/debug/300-gdb.sh
@@ -12,10 +12,10 @@ do_debug_gdb_get() {
     else
         # Account for the Linaro versioning
         linaro_version="$( echo "${CT_GDB_VERSION}"      \
-                           |${sed} -r -e 's/^linaro-//;'   \
+                           |sed -r -e 's/^linaro-//;'   \
                          )"
         linaro_series="$( echo "${linaro_version}"      \
-                          |${sed} -r -e 's/-.*//;'         \
+                          |sed -r -e 's/-.*//;'         \
                         )"
 
         if [ x"${linaro_version}" = x"${CT_GDB_VERSION}" ]; then
@@ -24,7 +24,7 @@ do_debug_gdb_get() {
                        {http,ftp,https}://ftp.gnu.org/pub/gnu/gdb          \
                        ftp://{sourceware.org,gcc.gnu.org}/pub/gdb/releases
         else
-            YYMM=`echo ${CT_GDB_VERSION} |cut -d- -f3 |${sed} -e 's,^..,,'`
+            YYMM=`echo ${CT_GDB_VERSION} |cut -d- -f3 |sed -e 's,^..,,'`
             CT_GetFile "gdb-${CT_GDB_VERSION}"                                                        \
                        "http://launchpad.net/gdb-linaro/${linaro_series}/${linaro_version}/+download" \
                        https://releases.linaro.org/${YYMM}/components/toolchain/gdb-linaro            \
@@ -128,15 +128,15 @@ do_debug_gdb_build() {
             "${CT_GDB_CROSS_EXTRA_CONFIG_ARRAY[@]}"
 
         CT_DoLog EXTRA "Building cross-gdb"
-        CT_DoExecLog ALL ${make} ${JOBSFLAGS}
+        CT_DoExecLog ALL make ${JOBSFLAGS}
 
         CT_DoLog EXTRA "Installing cross-gdb"
-        CT_DoExecLog ALL ${make} install
+        CT_DoExecLog ALL make install
 
         if [ "${CT_BUILD_MANUALS}" = "y" ]; then
             CT_DoLog EXTRA "Building and installing the cross-GDB manuals"
-            CT_DoExecLog ALL ${make} ${JOBSFLAGS} pdf html
-            CT_DoExecLog ALL ${make} install-{pdf,html}-gdb
+            CT_DoExecLog ALL make ${JOBSFLAGS} pdf html
+            CT_DoExecLog ALL make install-{pdf,html}-gdb
         fi
 
         if [ "${CT_GDB_INSTALL_GDBINIT}" = "y" ]; then
@@ -145,11 +145,11 @@ do_debug_gdb_build() {
             if [ -f "${CT_SRC_DIR}/gcc-${CT_CC_GCC_VERSION}/gcc/BASE-VER" ]; then
                 gcc_version=$( cat "${CT_SRC_DIR}/gcc-${CT_CC_GCC_VERSION}/gcc/BASE-VER" )
             else
-                gcc_version=$(${sed} -r -e '/version_string/!d; s/^.+= "([^"]+)".*$/\1/;'   \
+                gcc_version=$(sed -r -e '/version_string/!d; s/^.+= "([^"]+)".*$/\1/;'   \
                                    "${CT_SRC_DIR}/gcc-${CT_CC_GCC_VERSION}/gcc/version.c"   \
                              )
             fi
-            ${sed} -r                                               \
+            sed -r                                               \
                    -e "s:@@PREFIX@@:${CT_PREFIX_DIR}:;"             \
                    -e "s:@@VERSION@@:${gcc_version}:;"              \
                    "${CT_LIB_DIR}/scripts/build/debug/gdbinit.in"   \
@@ -230,10 +230,10 @@ do_debug_gdb_build() {
             "${native_extra_config[@]}"
 
         CT_DoLog EXTRA "Building native gdb"
-        CT_DoExecLog ALL ${make} ${JOBSFLAGS} CC=${CT_TARGET}-${CT_CC}
+        CT_DoExecLog ALL make ${JOBSFLAGS} CC=${CT_TARGET}-${CT_CC}
 
         CT_DoLog EXTRA "Installing native gdb"
-        CT_DoExecLog ALL ${make} DESTDIR="${CT_DEBUGROOT_DIR}" install
+        CT_DoExecLog ALL make DESTDIR="${CT_DEBUGROOT_DIR}" install
 
         # Building a native gdb also builds a gdbserver
         find "${CT_DEBUGROOT_DIR}" -type f -name gdbserver -exec rm -fv {} \; 2>&1 |CT_DoLog ALL
@@ -302,10 +302,10 @@ do_debug_gdb_build() {
             "${gdbserver_extra_config[@]}"
 
         CT_DoLog EXTRA "Building gdbserver"
-        CT_DoExecLog ALL ${make} ${JOBSFLAGS} CC=${CT_TARGET}-${CT_CC}
+        CT_DoExecLog ALL make ${JOBSFLAGS} CC=${CT_TARGET}-${CT_CC}
 
         CT_DoLog EXTRA "Installing gdbserver"
-        CT_DoExecLog ALL ${make} DESTDIR="${CT_DEBUGROOT_DIR}" install
+        CT_DoExecLog ALL make DESTDIR="${CT_DEBUGROOT_DIR}" install
 
         CT_EndStep
     fi

--- a/scripts/build/debug/400-ltrace.sh
+++ b/scripts/build/debug/400-ltrace.sh
@@ -52,10 +52,10 @@ do_debug_ltrace_build() {
     fi
 
     CT_DoLog EXTRA "Building ltrace"
-    CT_DoExecLog ALL ${make}
+    CT_DoExecLog ALL make
 
     CT_DoLog EXTRA "Installing ltrace"
-    CT_DoExecLog ALL ${make} DESTDIR="${CT_DEBUGROOT_DIR}" install
+    CT_DoExecLog ALL make DESTDIR="${CT_DEBUGROOT_DIR}" install
 
     CT_Popd
     CT_EndStep

--- a/scripts/build/debug/500-strace.sh
+++ b/scripts/build/debug/500-strace.sh
@@ -28,10 +28,10 @@ do_debug_strace_build() {
         --prefix=/usr
 
     CT_DoLog EXTRA "Building strace"
-    CT_DoExecLog ALL ${make}
+    CT_DoExecLog ALL make
 
     CT_DoLog EXTRA "Installing strace"
-    CT_DoExecLog ALL ${make} DESTDIR="${CT_DEBUGROOT_DIR}" install
+    CT_DoExecLog ALL make DESTDIR="${CT_DEBUGROOT_DIR}" install
 
     CT_Popd
     CT_EndStep

--- a/scripts/build/internals.sh
+++ b/scripts/build/internals.sh
@@ -47,7 +47,7 @@ do_finish() {
             if [ -f "${CT_SRC_DIR}/gcc-${CT_CC_GCC_VERSION}/gcc/BASE-VER" ]; then
                 gcc_version=$( cat "${CT_SRC_DIR}/gcc-${CT_CC_GCC_VERSION}/gcc/BASE-VER" )
             else
-                gcc_version=$(${sed} -r -e '/version_string/!d; s/^.+= "([^"]+)".*$/\1/;' \
+                gcc_version=$(sed -r -e '/version_string/!d; s/^.+= "([^"]+)".*$/\1/;' \
                                    "${CT_SRC_DIR}/gcc-${CT_CC_GCC_VERSION}/gcc/version.c" \
                              )
             fi
@@ -71,13 +71,13 @@ do_finish() {
 
     if [ "${CT_BARE_METAL}" != "y" ]; then
         CT_DoLog EXTRA "Installing the populate helper"
-        ${sed} -r -e 's|@@CT_TARGET@@|'"${CT_TARGET}"'|g;' \
-               -e 's|@@CT_install@@|'"${install}"'|g;'     \
-               -e 's|@@CT_awk@@|'"${awk}"'|g;'             \
+        sed -r -e 's|@@CT_TARGET@@|'"${CT_TARGET}"'|g;' \
+               -e 's|@@CT_install@@|'"install"'|g;'     \
+               -e 's|@@CT_awk@@|'"awk"'|g;'             \
                -e 's|@@CT_bash@@|'"${bash}"'|g;'           \
-               -e 's|@@CT_grep@@|'"${grep}"'|g;'           \
-               -e 's|@@CT_make@@|'"${make}"'|g;'           \
-               -e 's|@@CT_sed@@|'"${sed}"'|g;'             \
+               -e 's|@@CT_grep@@|'"grep"'|g;'           \
+               -e 's|@@CT_make@@|'"make"'|g;'           \
+               -e 's|@@CT_sed@@|'"sed"'|g;'             \
                "${CT_LIB_DIR}/scripts/populate.in"         \
                >"${CT_PREFIX_DIR}/bin/${CT_TARGET}-populate"
         CT_DoExecLog ALL chmod 755 "${CT_PREFIX_DIR}/bin/${CT_TARGET}-populate"
@@ -85,14 +85,14 @@ do_finish() {
 
     if [ "${CT_LIBC_XLDD}" = "y" ]; then
         CT_DoLog EXTRA "Installing a cross-ldd helper"
-        ${sed} -r -e 's|@@CT_VERSION@@|'"${CT_VERSION}"'|g;' \
+        sed -r -e 's|@@CT_VERSION@@|'"${CT_VERSION}"'|g;' \
                -e 's|@@CT_TARGET@@|'"${CT_TARGET}"'|g;'      \
                -e 's|@@CT_BITS@@|'"${CT_ARCH_BITNESS}"'|g;'  \
-               -e 's|@@CT_install@@|'"${install}"'|g;'       \
+               -e 's|@@CT_install@@|'"install"'|g;'       \
                -e 's|@@CT_bash@@|'"${bash}"'|g;'             \
-               -e 's|@@CT_grep@@|'"${grep}"'|g;'             \
-               -e 's|@@CT_make@@|'"${make}"'|g;'             \
-               -e 's|@@CT_sed@@|'"${sed}"'|g;'               \
+               -e 's|@@CT_grep@@|'"grep"'|g;'             \
+               -e 's|@@CT_make@@|'"make"'|g;'             \
+               -e 's|@@CT_sed@@|'"sed"'|g;'               \
                "${CT_LIB_DIR}/scripts/xldd.in"               \
                >"${CT_PREFIX_DIR}/bin/${CT_TARGET}-ldd"
         CT_DoExecLog ALL chmod 755 "${CT_PREFIX_DIR}/bin/${CT_TARGET}-ldd"
@@ -103,11 +103,11 @@ do_finish() {
     CT_Pushd "${CT_PREFIX_DIR}/bin"
     for t in "${CT_TARGET}-"*; do
         if [ -n "${CT_TARGET_ALIAS}" ]; then
-            _t=$(echo "$t" |${sed} -r -e 's/^'"${CT_TARGET}"'-/'"${CT_TARGET_ALIAS}"'-/;')
+            _t=$(echo "$t" |sed -r -e 's/^'"${CT_TARGET}"'-/'"${CT_TARGET_ALIAS}"'-/;')
             CT_DoExecLog ALL ln -sfv "${t}" "${_t}"
         fi
         if [ -n "${CT_TARGET_ALIAS_SED_EXPR}" ]; then
-            _t=$(echo "$t" |${sed} -r -e "${CT_TARGET_ALIAS_SED_EXPR}")
+            _t=$(echo "$t" |sed -r -e "${CT_TARGET_ALIAS_SED_EXPR}")
             if [ "${_t}" = "${t}" ]; then
                 CT_DoLog WARN "The sed expression '${CT_TARGET_ALIAS_SED_EXPR}' has no effect on '${t}'"
             else

--- a/scripts/build/kernel/linux.sh
+++ b/scripts/build/kernel/linux.sh
@@ -93,7 +93,7 @@ do_kernel_headers() {
 
     CT_DoLog EXTRA "Installing kernel headers"
     CT_DoExecLog ALL                                    \
-    ${make} -C "${kernel_path}"                         \
+    make -C "${kernel_path}"                         \
          CROSS_COMPILE="${CT_TARGET}-"                  \
          O="${CT_BUILD_DIR}/build-kernel-headers"       \
          ARCH=${kernel_arch}                            \
@@ -104,7 +104,7 @@ do_kernel_headers() {
     if [ "${CT_KERNEL_LINUX_INSTALL_CHECK}" = "y" ]; then
         CT_DoLog EXTRA "Checking installed headers"
         CT_DoExecLog ALL                                    \
-        ${make} -C "${kernel_path}"                         \
+        make -C "${kernel_path}"                         \
              CROSS_COMPILE="${CT_TARGET}-"                  \
              O="${CT_BUILD_DIR}/build-kernel-headers"       \
              ARCH=${kernel_arch}                            \

--- a/scripts/build/libc/avr-libc.sh
+++ b/scripts/build/libc/avr-libc.sh
@@ -48,10 +48,10 @@ do_libc_post_cc() {
     do_libc_configure
 
     CT_DoLog EXTRA "Building C library"
-    CT_DoExecLog ALL ${make} ${JOBSFLAGS}
+    CT_DoExecLog ALL make ${JOBSFLAGS}
 
     CT_DoLog EXTRA "Installing C library"
-    CT_DoExecLog ALL ${make} install
+    CT_DoExecLog ALL make install
 
     CT_EndStep
 }

--- a/scripts/build/libc/glibc.sh
+++ b/scripts/build/libc/glibc.sh
@@ -11,9 +11,9 @@ do_libc_get() {
         CT_GetCustom "glibc" "${CT_LIBC_GLIBC_CUSTOM_VERSION}" \
             "${CT_LIBC_GLIBC_CUSTOM_LOCATION}"
     else
-        if echo ${CT_LIBC_VERSION} |${grep} -q linaro; then
+        if echo ${CT_LIBC_VERSION} |grep -q linaro; then
             # Linaro glibc releases come from regular downloads...
-            YYMM=`echo ${CT_LIBC_VERSION} |cut -d- -f3 |${sed} -e 's,^..,,'`
+            YYMM=`echo ${CT_LIBC_VERSION} |cut -d- -f3 |sed -e 's,^..,,'`
             CT_GetFile "glibc-${CT_LIBC_VERSION}" \
                        https://releases.linaro.org/${YYMM}/components/toolchain/glibc-linaro \
                        http://cbuild.validation.linaro.org/snapshots
@@ -301,7 +301,7 @@ do_libc_backend_once() {
 
         # use the 'install-headers' makefile target to install the
         # headers
-        CT_DoExecLog ALL ${make} ${JOBSFLAGS}                       \
+        CT_DoExecLog ALL make ${JOBSFLAGS}                       \
                          install_root=${multi_root}                 \
                          install-bootstrap-headers=yes              \
                          "${extra_make_args[@]}"                    \
@@ -354,7 +354,7 @@ do_libc_backend_once() {
             # there are a few object files needed to link shared libraries,
             # which we build and install by hand
             CT_DoExecLog ALL mkdir -p "${startfiles_dir}"
-            CT_DoExecLog ALL ${make} ${JOBSFLAGS} \
+            CT_DoExecLog ALL make ${JOBSFLAGS} \
                         "${extra_make_args[@]}" \
                         csu/subdir_lib
             CT_DoExecLog ALL cp csu/crt1.o csu/crti.o csu/crtn.o    \
@@ -375,12 +375,12 @@ do_libc_backend_once() {
 
     if [ "${libc_mode}" = "final" ]; then
         CT_DoLog EXTRA "Building C library"
-        CT_DoExecLog ALL ${make} ${JOBSFLAGS}         \
+        CT_DoExecLog ALL make ${JOBSFLAGS}         \
                               "${extra_make_args[@]}" \
                               all
 
         CT_DoLog EXTRA "Installing C library"
-        CT_DoExecLog ALL ${make} ${JOBSFLAGS}                 \
+        CT_DoExecLog ALL make ${JOBSFLAGS}                 \
                               "${extra_make_args[@]}"         \
                               install_root="${multi_root}"    \
                               install
@@ -392,7 +392,7 @@ do_libc_backend_once() {
             CT_DoLog EXTRA "Building and installing the C library manual"
             # Omit JOBSFLAGS as GLIBC has problems building the
             # manuals in parallel
-            CT_DoExecLog ALL ${make} pdf html
+            CT_DoExecLog ALL make pdf html
             CT_DoExecLog ALL mkdir -p ${CT_PREFIX_DIR}/share/doc
             CT_DoExecLog ALL cp -av ${src_dir}/manual/*.pdf    \
                                     ${src_dir}/manual/libc     \
@@ -411,7 +411,7 @@ do_libc_backend_once() {
 do_libc_add_ons_list() {
     local sep="$1"
     local addons_list="$( echo "${CT_LIBC_ADDONS_LIST}"            \
-                          |${sed} -r -e "s/[[:space:],]/${sep}/g;" \
+                          |sed -r -e "s/[[:space:],]/${sep}/g;" \
                         )"
     if [ "${CT_LIBC_GLIBC_2_20_or_later}" != "y" ]; then
         case "${CT_THREADS}" in
@@ -421,7 +421,7 @@ do_libc_add_ons_list() {
     fi
     [ "${CT_LIBC_GLIBC_USE_PORTS}" = "y" ] && addons_list="${addons_list}${sep}ports"
     # Remove duplicate, leading and trailing separators
-    echo "${addons_list}" |${sed} -r -e "s/${sep}+/${sep}/g; s/^${sep}//; s/${sep}\$//;"
+    echo "${addons_list}" |sed -r -e "s/${sep}+/${sep}/g; s/^${sep}//; s/${sep}\$//;"
 }
 
 # Compute up the minimum supported Linux kernel version
@@ -440,7 +440,7 @@ do_libc_min_kernel_config() {
                 if [ ! -f "${version_code_file}" -o ! -r "${version_code_file}" ]; then
                     CT_Abort "Linux version is unavailable in installed headers files"
                 fi
-                version_code="$(${grep} -E LINUX_VERSION_CODE "${version_code_file}"  \
+                version_code="$(grep -E LINUX_VERSION_CODE "${version_code_file}"  \
                                  |cut -d' ' -f 3                                      \
                                )"
                 version=$(((version_code>>16)&0xFF))
@@ -450,7 +450,7 @@ do_libc_min_kernel_config() {
             elif [ "${CT_LIBC_GLIBC_KERNEL_VERSION_CHOSEN}" = "y" ]; then
                 # Trim the fourth part of the linux version, keeping only the first three numbers
                 min_kernel_config="$( echo "${CT_LIBC_GLIBC_MIN_KERNEL_VERSION}"               \
-                                      |${sed} -r -e 's/^([^.]+\.[^.]+\.[^.]+)(|\.[^.]+)$/\1/;' \
+                                      |sed -r -e 's/^([^.]+\.[^.]+\.[^.]+)(|\.[^.]+)$/\1/;' \
                                     )"
             fi
             echo "--enable-kernel=${min_kernel_config}"
@@ -515,7 +515,7 @@ do_libc_locales() {
         "${extra_config[@]}"
 
     CT_DoLog EXTRA "Building C library localedef"
-    CT_DoExecLog ALL ${make} ${JOBSFLAGS}
+    CT_DoExecLog ALL make ${JOBSFLAGS}
 
     # The target's endianness and uint32_t alignment should be passed as options
     # to localedef, but glibc's localedef does not support these options, which
@@ -523,7 +523,7 @@ do_libc_locales() {
     # only if it has the same endianness and uint32_t alignment as the host's.
 
     CT_DoLog EXTRA "Installing C library locales"
-    CT_DoExecLog ALL ${make} ${JOBSFLAGS}                  \
+    CT_DoExecLog ALL make ${JOBSFLAGS}                  \
                           install_root="${CT_SYSROOT_DIR}" \
                           localedata/install-locales
 }

--- a/scripts/build/libc/mingw.sh
+++ b/scripts/build/libc/mingw.sh
@@ -55,10 +55,10 @@ do_libc_start_files() {
         "${sdk_opts[@]}"
 
     CT_DoLog EXTRA "Compile Headers"
-    CT_DoExecLog ALL ${make}
+    CT_DoExecLog ALL make
 
     CT_DoLog EXTRA "Installing Headers"
-    CT_DoExecLog ALL ${make} install DESTDIR=${CT_SYSROOT_DIR}
+    CT_DoExecLog ALL make install DESTDIR=${CT_SYSROOT_DIR}
 
     CT_Popd
 
@@ -104,10 +104,10 @@ do_libc() {
     # parallel build. See https://github.com/crosstool-ng/crosstool-ng/issues/246
     # Do not pass ${JOBSFLAGS} - build serially.
     CT_DoLog EXTRA "Building mingw-w64-crt"
-    CT_DoExecLog ALL ${make}
+    CT_DoExecLog ALL make
 
     CT_DoLog EXTRA "Installing mingw-w64-crt"
-    CT_DoExecLog ALL ${make} install DESTDIR=${CT_SYSROOT_DIR}
+    CT_DoExecLog ALL make install DESTDIR=${CT_SYSROOT_DIR}
 
     CT_EndStep
 
@@ -135,10 +135,10 @@ do_pthreads() {
         --host=${CT_TARGET}                                                           \
 
     CT_DoLog EXTRA "Building mingw-w64-winpthreads"
-    CT_DoExecLog ALL ${make} ${JOBSFLAGS}
+    CT_DoExecLog ALL make ${JOBSFLAGS}
 
     CT_DoLog EXTRA "Installing mingw-w64-winpthreads"
-    CT_DoExecLog ALL ${make} install DESTDIR=${CT_SYSROOT_DIR}
+    CT_DoExecLog ALL make install DESTDIR=${CT_SYSROOT_DIR}
 
     CT_EndStep
 }

--- a/scripts/build/libc/musl.sh
+++ b/scripts/build/libc/musl.sh
@@ -120,9 +120,9 @@ do_libc_backend_once() {
 
     if [ "${libc_mode}" = "startfiles" ]; then
         CT_DoLog EXTRA "Installing C library headers"
-        CT_DoExecLog ALL ${make} DESTDIR="${multi_root}" install-headers
+        CT_DoExecLog ALL make DESTDIR="${multi_root}" install-headers
         CT_DoLog EXTRA "Building C library start files"
-        CT_DoExecLog ALL ${make} DESTDIR="${multi_root}" \
+        CT_DoExecLog ALL make DESTDIR="${multi_root}" \
             obj/crt/crt1.o obj/crt/crti.o obj/crt/crtn.o
         CT_DoLog EXTRA "Installing C library start files"
         CT_DoExecLog ALL cp -av obj/crt/crt*.o "${multi_root}${multilib_dir}"
@@ -137,10 +137,10 @@ do_libc_backend_once() {
             "${multi_root}${multilib_dir}/libc.so"
 
         CT_DoLog EXTRA "Building C library"
-        CT_DoExecLog ALL ${make} ${JOBSFLAGS}
+        CT_DoExecLog ALL make ${JOBSFLAGS}
 
         CT_DoLog EXTRA "Installing C library"
-        CT_DoExecLog ALL ${make} DESTDIR="${multi_root}" install
+        CT_DoExecLog ALL make DESTDIR="${multi_root}" install
 
         # Convert /lib/ld-* symlinks to relative paths so that they are valid
         # both on the host and on the target.

--- a/scripts/build/libc/newlib.sh
+++ b/scripts/build/libc/newlib.sh
@@ -17,8 +17,8 @@ do_libc_get() {
         CT_GetCustom "newlib" "${CT_LIBC_NEWLIB_CUSTOM_VERSION}" \
             "${CT_LIBC_NEWLIB_CUSTOM_LOCATION}"
     else # ! custom location
-        if echo ${CT_LIBC_VERSION} |${grep} -q linaro; then
-            YYMM=`echo ${CT_LIBC_VERSION} |cut -d- -f3 |${sed} -e 's,^..,,'`
+        if echo ${CT_LIBC_VERSION} |grep -q linaro; then
+            YYMM=`echo ${CT_LIBC_VERSION} |cut -d- -f3 |sed -e 's,^..,,'`
             CT_GetFile "newlib-${CT_LIBC_VERSION}" ${libc_src} \
                        https://releases.linaro.org/${YYMM}/components/toolchain/newlib-linaro \
                        http://cbuild.validation.linaro.org/snapshots
@@ -121,16 +121,16 @@ do_libc() {
         "${CT_LIBC_NEWLIB_EXTRA_CONFIG_ARRAY[@]}"
 
     CT_DoLog EXTRA "Building C library"
-    CT_DoExecLog ALL ${make} ${JOBSFLAGS}
+    CT_DoExecLog ALL make ${JOBSFLAGS}
 
     CT_DoLog EXTRA "Installing C library"
-    CT_DoExecLog ALL ${make} install install_root="${CT_SYSROOT_DIR}"
+    CT_DoExecLog ALL make install install_root="${CT_SYSROOT_DIR}"
 
     if [ "${CT_BUILD_MANUALS}" = "y" ]; then
         local -a doc_dir="${CT_BUILD_DIR}/build-libc/${CT_TARGET}"
 
         CT_DoLog EXTRA "Building and installing the C library manual"
-        CT_DoExecLog ALL ${make} pdf html
+        CT_DoExecLog ALL make pdf html
 
         # NEWLIB install-{pdf.html} fail for some versions
         CT_DoExecLog ALL mkdir -p "${CT_PREFIX_DIR}/share/doc/newlib"

--- a/scripts/build/libc/uClibc.sh
+++ b/scripts/build/libc/uClibc.sh
@@ -138,7 +138,7 @@ do_libc_backend_once() {
     fi
 
     manage_uClibc_config "${CT_LIBC_UCLIBC_CONFIG_FILE}" .config "${multi_flags}"
-    CT_DoYes | CT_DoExecLog ALL ${make} "${make_args[@]}" oldconfig
+    CT_DoYes | CT_DoExecLog ALL make "${make_args[@]}" oldconfig
 
     # Now filter the multilib flags. manage_uClibc_config did the opposite of
     # what Rules.mak in uClibc would do: by the multilib's CFLAGS, it determined
@@ -149,7 +149,7 @@ do_libc_backend_once() {
     extra_cflags="-pipe"
     { echo "include Rules.mak"; echo "show-cpu-flags:"; printf '\t@echo $(CPU_CFLAGS)\n'; } \
                 > .show-cpu-cflags.mk
-    cfg_cflags=$( ${make} "${make_args[@]}" \
+    cfg_cflags=$( make "${make_args[@]}" \
         --no-print-directory -f .show-cpu-cflags.mk show-cpu-flags )
     CT_DoExecLog ALL rm -f .show-cpu-cflags.mk
     CT_DoLog DEBUG "CPU_CFLAGS detected by uClibc: ${cfg_cflags[@]}"
@@ -178,19 +178,19 @@ do_libc_backend_once() {
 
     if [ "${libc_mode}" = "startfiles" ]; then
         CT_DoLog EXTRA "Building headers"
-        CT_DoExecLog ALL ${make} "${make_args[@]}" headers
+        CT_DoExecLog ALL make "${make_args[@]}" headers
 
         # Ensure the directory for installing multilib-specific binaries exists.
         CT_DoExecLog ALL mkdir -p "${startfiles_dir}"
 
         CT_DoLog EXTRA "Installing headers"
-        CT_DoExecLog ALL ${make} "${make_args[@]}" install_headers
+        CT_DoExecLog ALL make "${make_args[@]}" install_headers
 
         # The check might look bogus, but it is the same condition as is used
         # by GCC build script to enable/disable shared library support.
         if [ "${CT_THREADS}" = "nptl" ]; then
             CT_DoLog EXTRA "Building start files"
-            CT_DoExecLog ALL ${make} ${jflag} "${make_args[@]}" \
+            CT_DoExecLog ALL make ${jflag} "${make_args[@]}" \
                 lib/crt1.o lib/crti.o lib/crtn.o
 
             # From:  http://git.openembedded.org/cgit.cgi/openembedded/commit/?id=ad5668a7ac7e0436db92e55caaf3fdf782b6ba3b
@@ -201,12 +201,12 @@ do_libc_backend_once() {
                 -shared ${multi_flags} -x c /dev/null -o libdummy.so
 
             CT_DoLog EXTRA "Installing start files"
-            CT_DoExecLog ALL ${install} -m 0644 lib/crt1.o lib/crti.o lib/crtn.o \
+            CT_DoExecLog ALL install -m 0644 lib/crt1.o lib/crti.o lib/crtn.o \
                                              "${startfiles_dir}"
 
             CT_DoLog EXTRA "Installing dummy shared libs"
-            CT_DoExecLog ALL ${install} -m 0755 libdummy.so "${startfiles_dir}/libc.so"
-            CT_DoExecLog ALL ${install} -m 0755 libdummy.so "${startfiles_dir}/libm.so"
+            CT_DoExecLog ALL install -m 0755 libdummy.so "${startfiles_dir}/libc.so"
+            CT_DoExecLog ALL install -m 0755 libdummy.so "${startfiles_dir}/libm.so"
         fi # CT_THREADS == nptl
     fi # libc_mode == startfiles
 
@@ -219,8 +219,8 @@ do_libc_backend_once() {
                     "${startfiles_dir}/libm.so"
 
         CT_DoLog EXTRA "Building C library"
-        CT_DoExecLog ALL ${make} "${make_args[@]}" pregen
-        CT_DoExecLog ALL ${make} ${jflag} "${make_args[@]}" all
+        CT_DoExecLog ALL make "${make_args[@]}" pregen
+        CT_DoExecLog ALL make ${jflag} "${make_args[@]}" all
 
         # YEM-FIXME:
         # - we want to install 'runtime' files, eg. lib*.{a,so*}, crti.o and
@@ -231,7 +231,7 @@ do_libc_backend_once() {
         # - "make install" calls install_runtime and install_dev
         # - so we're left with re-installing the headers... Sigh...
         CT_DoLog EXTRA "Installing C library"
-        CT_DoExecLog ALL ${make} "${make_args[@]}" install install_utils
+        CT_DoExecLog ALL make "${make_args[@]}" install install_utils
     fi # libc_mode == final
 
     # Now, if installing headers into a subdirectory, put everything in its place.

--- a/scripts/build/test_suite/gcc.sh
+++ b/scripts/build/test_suite/gcc.sh
@@ -21,7 +21,7 @@ do_test_suite_gcc_build() {
                             "${CT_SRC_DIR}/gcc-${CT_CC_GCC_VERSION}/gcc/testsuite"  \
                             "${CT_TEST_SUITE_DIR}/gcc"
 
-    CT_DoExecLog ALL ${sed} -i -r -e "s/@@DG_TARGET@@/${CT_TARGET}/g;"     \
+    CT_DoExecLog ALL sed -i -r -e "s/@@DG_TARGET@@/${CT_TARGET}/g;"     \
                          "${CT_TEST_SUITE_DIR}/gcc/Makefile"
 
     CT_EndStep

--- a/scripts/functions
+++ b/scripts/functions
@@ -322,7 +322,7 @@ CT_SanitizeVarDir() {
 
     for var in "$@"; do
         eval "old_dir=\"\${${var}}\""
-        new_dir=$( echo "${old_dir}" | ${awk} '
+        new_dir=$( echo "${old_dir}" | awk '
 {
     isabs = $1 == "" # Started with a slash
     trail = $NF == "" # Ending with a slash
@@ -419,7 +419,7 @@ CT_Which() {
 # to the highest entire second
 # Usage: CT_DoDate <fmt>
 CT_DoDate() {
-    date "$1" |${sed} -r -e 's/%?N$/000000000/;'
+    date "$1" |sed -r -e 's/%?N$/000000000/;'
 }
 
 CT_STEP_COUNT=1
@@ -442,7 +442,7 @@ CT_DoStep() {
 CT_EndStep() {
     local stop=$(CT_DoDate +%s%N)
     local duration=$(printf "%032d" $((stop-${CT_STEP_START[${CT_STEP_COUNT}]})) \
-                     |${sed} -r -e 's/([[:digit:]]{2})[[:digit:]]{7}$/\.\1/; s/^0+//; s/^\./0\./;'
+                     |sed -r -e 's/([[:digit:]]{2})[[:digit:]]{7}$/\.\1/; s/^0+//; s/^\./0\./;'
                     )
     local elapsed=$(printf "%02d:%02d" $((SECONDS/60)) $((SECONDS%60)))
     local level="${CT_STEP_LEVEL[${CT_STEP_COUNT}]}"
@@ -516,7 +516,7 @@ CT_DoForceRmdir() {
 # Echoes the specified string on stdout until the pipe breaks.
 # Doesn't fail
 # $1: string to echo
-# Usage: CT_DoYes "" |${make} oldconfig
+# Usage: CT_DoYes "" |make oldconfig
 CT_DoYes() {
     yes "$1" || true
 }
@@ -899,7 +899,7 @@ CT_GetGit() {
     local url="${3}"
     local _out_cset="${4}"
 
-    local ref=$(echo "${cset_or_ref}" | ${sed} -n 's/^ref=\(.*\)/\1/p')
+    local ref=$(echo "${cset_or_ref}" | sed -n 's/^ref=\(.*\)/\1/p')
     if [ -n "$ref" ]; then
         local matches=$(git ls-remote --exit-code "$url" --refs "${ref}")
         local result=$?
@@ -1079,9 +1079,9 @@ CT_ExtractGit() {
     if [ -z "${ref}" ]; then
         ref_type=head
         ref=$(git rev-list -n1 HEAD)
-    elif git tag |${grep} -E "^${ref}$" >/dev/null 2>&1; then
+    elif git tag |grep -E "^${ref}$" >/dev/null 2>&1; then
         ref_type=tag
-    elif git branch -a --no-color |${grep} -E "^. ${ref}$" >/dev/null 2>&1; then
+    elif git branch -a --no-color |grep -E "^. ${ref}$" >/dev/null 2>&1; then
         ref_type=branch
     elif date -d "${ref}" >/dev/null 2>&1; then
         ref_type=date
@@ -1322,7 +1322,7 @@ CT_DoBuildTargetTuple() {
     # Sanity checks
     __sed_alias=""
     if [ -n "${CT_TARGET_ALIAS_SED_EXPR}" ]; then
-        __sed_alias=$(echo "${CT_TARGET}" |${sed} -r -e "${CT_TARGET_ALIAS_SED_EXPR}")
+        __sed_alias=$(echo "${CT_TARGET}" |sed -r -e "${CT_TARGET_ALIAS_SED_EXPR}")
     fi
     case ":${CT_TARGET_VENDOR}:${CT_TARGET_ALIAS}:${__sed_alias}:" in
       :*" "*:*:*:) CT_Abort "Don't use spaces in the vendor string, it breaks things.";;
@@ -1395,7 +1395,7 @@ CT_DoTarballIfExists() {
         CT_DoLog DEBUG "  Saving '${dir}'"
         { tar c -C "${dir}" -v -f - "${extra_tar_opts[@]}" .    \
           |"${compress[@]}" >"${tarball}.tar${tar_ext}"         ;
-        } 2>&1 |${sed} -r -e 's/^/    /;' |CT_DoLog STATE
+        } 2>&1 |sed -r -e 's/^/    /;' |CT_DoLog STATE
     else
         CT_DoLog STATE "  Not saving '${dir}': does not exist"
     fi
@@ -1422,7 +1422,7 @@ CT_DoExtractTarballIfExists() {
         CT_DoExecLog DEBUG mkdir -p "${dir}"
         { "${uncompress[@]}" "${tarball}.tar${tar_ext}"     \
           |tar x -C "${dir}" -v -f - "${extra_tar_opts[@]}" ;
-        } 2>&1 |${sed} -r -e 's/^/    /;' |CT_DoLog STATE
+        } 2>&1 |sed -r -e 's/^/    /;' |CT_DoLog STATE
     else
         CT_DoLog STATE "  Not restoring '${dir}': does not exist"
     fi
@@ -1445,12 +1445,12 @@ CT_DoSaveState() {
     # We must omit shell functions, and some specific bash variables
     # that break when restoring the environment, later. We could do
     # all the processing in the awk script, but a sed is easier...
-    set |${awk} '
+    set |awk '
               BEGIN { _p = 1; }
               $0~/^[^ ]+ \(\)/ { _p = 0; }
               _p == 1
               $0 == "}" { _p = 1; }
-              ' |${sed} -r -e '/^BASH_(ARGC|ARGV|LINENO|SOURCE|VERSINFO)=/d;
+              ' |sed -r -e '/^BASH_(ARGC|ARGV|LINENO|SOURCE|VERSINFO)=/d;
                            /^(UID|EUID)=/d;
                            /^(FUNCNAME|GROUPS|PPID|SHELLOPTS)=/d;' >"${state_dir}/env.sh"
 
@@ -1514,10 +1514,10 @@ CT_KconfigSetOption() {
     local value="$2"
     local file="$3"
 
-    ${grep} -E -q "^${option}=.*" "${file}" && \
-        ${sed} -i -r -e "s;^${option}=.*$;${option}=${value};" "${file}" || \
-    ${grep} -E -q "^# ${option} is not set$" "${file}" && \
-        ${sed} -i -r -e "s;^# ${option} is not set$;${option}=${value};" "${file}" || \
+    grep -E -q "^${option}=.*" "${file}" && \
+        sed -i -r -e "s;^${option}=.*$;${option}=${value};" "${file}" || \
+    grep -E -q "^# ${option} is not set$" "${file}" && \
+        sed -i -r -e "s;^# ${option} is not set$;${option}=${value};" "${file}" || \
     echo "${option}=${value}" >> "${file}"
 }
 
@@ -1536,9 +1536,9 @@ CT_KconfigDisableOption() {
     local option="${1}"
     local file="${2}"
 
-    ${grep} -E -q "^# ${option} is not set$" "${file}" || \
-    ${grep} -E -q "^${option}=.*$" "${file}" && \
-        ${sed} -i -r -e "s;^${option}=.*$;# ${option} is not set;" "${file}" || \
+    grep -E -q "^# ${option} is not set$" "${file}" || \
+    grep -E -q "^${option}=.*$" "${file}" && \
+        sed -i -r -e "s;^${option}=.*$;# ${option} is not set;" "${file}" || \
     echo "# ${option} is not set" >> "${file}"
 }
 
@@ -1549,10 +1549,10 @@ CT_KconfigDeleteOption() {
     local option="${1}"
     local file="${2}"
 
-    ${grep} -E -q "^# ${option} is not set$" "${file}" && \
-        ${sed} -i -r -e "/^# ${option} is not set$/d" "${file}" || \
-    ${grep} -E -q "^${option}=.*$" "${file}" && \
-        ${sed} -i -r -e "/^${option}=.*$/d" "${file}" || true
+    grep -E -q "^# ${option} is not set$" "${file}" && \
+        sed -i -r -e "/^# ${option} is not set$/d" "${file}" || \
+    grep -E -q "^${option}=.*$" "${file}" && \
+        sed -i -r -e "/^${option}=.*$/d" "${file}" || true
 }
 
 # Multilib iterator. The caller should be in a directory where the directories
@@ -1616,7 +1616,7 @@ CT_IterateMultilibs() {
         # will work. If not, we'll supply both multi_root/multi_os_dir (which will
         # likely break later, e.g. while building final GCC with C++ support). But,
         # we've done all we can.
-        multi_flags=$( echo "${multilib#*;}" | ${sed} -r -e 's/@/ -/g;' )
+        multi_flags=$( echo "${multilib#*;}" | sed -r -e 's/@/ -/g;' )
         multi_dir="${multilib%%;*}"
         multi_os_dir=$( "${CT_TARGET}-gcc" -print-multi-os-directory ${multi_flags} )
         multi_root=$( "${CT_TARGET}-gcc" -print-sysroot ${multi_flags} )
@@ -1636,7 +1636,7 @@ CT_IterateMultilibs() {
     # the architecture-specific functions.
     multi_index=1
     for multilib in "${multilibs[@]}"; do
-        multi_flags=$( echo "${multilib#*;}" | ${sed} -r -e 's/@/ -/g;' )
+        multi_flags=$( echo "${multilib#*;}" | sed -r -e 's/@/ -/g;' )
         multi_dir="${multilib%%;*}"
         multi_os_dir=$( "${CT_TARGET}-gcc" -print-multi-os-directory ${multi_flags} )
         multi_root=$( "${CT_TARGET}-gcc" -print-sysroot ${multi_flags} )


### PR DESCRIPTION
This supersedes PR 395 - the change is picked up and add'l changes identified during review are implemented. Then, noticed that powerpc-multilib-linux-gnu breaks with the version of make that we have companion tools, so did a bit of upgrade on companion tools as well.