### PR TITLE
gcc: backport fix for xtensa PR target/78603

### DIFF
--- a/patches/gcc/5.4.0/878-xtensa-Fix-PR-target-78603.patch
+++ b/patches/gcc/5.4.0/878-xtensa-Fix-PR-target-78603.patch
@@ -1,0 +1,35 @@
+From b18fe564ed233ee0965b3a980edc5dbe069b80ea Mon Sep 17 00:00:00 2001
+From: Max Filippov <jcmvbkbc@gmail.com>
+Date: Tue, 29 Nov 2016 13:09:17 -0800
+Subject: [PATCH] xtensa: Fix PR target/78603
+
+2016-11-29  Max Filippov  <jcmvbkbc@gmail.com>
+gcc/
+	* config/xtensa/xtensa.c (hwloop_optimize): Don't emit zero
+	overhead loop start between a call and its CALL_ARG_LOCATION
+	note.
+
+Signed-off-by: Max Filippov <jcmvbkbc@gmail.com>
+---
+ gcc/config/xtensa/xtensa.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/gcc/config/xtensa/xtensa.c b/gcc/config/xtensa/xtensa.c
+index 206ff80..36ab1e3 100644
+--- a/gcc/config/xtensa/xtensa.c
++++ b/gcc/config/xtensa/xtensa.c
+@@ -4182,7 +4182,10 @@ hwloop_optimize (hwloop_info loop)
+       entry_after = BB_END (entry_bb);
+       while (DEBUG_INSN_P (entry_after)
+              || (NOTE_P (entry_after)
+-                 && NOTE_KIND (entry_after) != NOTE_INSN_BASIC_BLOCK))
++                 && NOTE_KIND (entry_after) != NOTE_INSN_BASIC_BLOCK
++		 /* Make sure we don't split a call and its corresponding
++		    CALL_ARG_LOCATION note.  */
++                 && NOTE_KIND (entry_after) != NOTE_INSN_CALL_ARG_LOCATION))
+         entry_after = PREV_INSN (entry_after);
+ 
+       emit_insn_after (seq, entry_after);
+-- 
+2.1.4
+

--- a/patches/gcc/6.2.0/872-xtensa-Fix-PR-target-78603.patch
+++ b/patches/gcc/6.2.0/872-xtensa-Fix-PR-target-78603.patch
@@ -1,0 +1,35 @@
+From a568f3a84ff41ca272301a5fcf31071143e97e0f Mon Sep 17 00:00:00 2001
+From: Max Filippov <jcmvbkbc@gmail.com>
+Date: Tue, 29 Nov 2016 13:09:17 -0800
+Subject: [PATCH] xtensa: Fix PR target/78603
+
+2016-11-29  Max Filippov  <jcmvbkbc@gmail.com>
+gcc/
+	* config/xtensa/xtensa.c (hwloop_optimize): Don't emit zero
+	overhead loop start between a call and its CALL_ARG_LOCATION
+	note.
+
+Signed-off-by: Max Filippov <jcmvbkbc@gmail.com>
+---
+ gcc/config/xtensa/xtensa.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/gcc/config/xtensa/xtensa.c b/gcc/config/xtensa/xtensa.c
+index e49f784..70f698a 100644
+--- a/gcc/config/xtensa/xtensa.c
++++ b/gcc/config/xtensa/xtensa.c
+@@ -4158,7 +4158,10 @@ hwloop_optimize (hwloop_info loop)
+       entry_after = BB_END (entry_bb);
+       while (DEBUG_INSN_P (entry_after)
+              || (NOTE_P (entry_after)
+-                 && NOTE_KIND (entry_after) != NOTE_INSN_BASIC_BLOCK))
++                 && NOTE_KIND (entry_after) != NOTE_INSN_BASIC_BLOCK
++		 /* Make sure we don't split a call and its corresponding
++		    CALL_ARG_LOCATION note.  */
++                 && NOTE_KIND (entry_after) != NOTE_INSN_CALL_ARG_LOCATION))
+         entry_after = PREV_INSN (entry_after);
+ 
+       emit_insn_after (seq, entry_after);
+-- 
+2.1.4
+


### PR DESCRIPTION
Hello,

please pull the fix for xtensa PR target/78603 backported to gcc 5.x and 6.x.