### PR TITLE
backport support for gcc 5 to glibc 2.13

### DIFF
--- a/patches/glibc/2.13/120-support-gcc5.patch
+++ b/patches/glibc/2.13/120-support-gcc5.patch
@@ -1,0 +1,10 @@
+--- a/configure
++++ b/configure
+@@ -5041,7 +5041,7 @@
+   ac_prog_version=`$CC -v 2>&1 | sed -n 's/^.*version \([egcygnustpi-]*[0-9.]*\).*$/\1/p'`
+   case $ac_prog_version in
+     '') ac_prog_version="v. ?.??, bad"; ac_verc_fail=yes;;
+-    3.4* | 4.[0-9]* )
++    3.4* | 4.[0-9]* | 5.[0-9]* )
+        ac_prog_version="$ac_prog_version, ok"; ac_verc_fail=no;;
+     *) ac_prog_version="$ac_prog_version, bad"; ac_verc_fail=yes;;


### PR DESCRIPTION
This patch modifies the configure script in glibc 2.13 to allow building with gcc 5.