### PR TITLE
backport support patch for gcc 5 to glibc 2.13 arm ports

### DIFF
--- a/patches/glibc/ports-2.13/100-Fix-ARM-build-with-GCC-trunk.patch
+++ b/patches/glibc/ports-2.13/100-Fix-ARM-build-with-GCC-trunk.patch
@@ -1,0 +1,50 @@
+--- a/ports/sysdeps/unix/sysv/linux/arm/nptl/unwind-forcedunwind.c
++++ b/ports/sysdeps/unix/sysv/linux/arm/nptl/unwind-forcedunwind.c
+@@ -23,7 +23,8 @@
+ #include <pthreadP.h>
+
+ static void *libgcc_s_handle;
+-static void (*libgcc_s_resume) (struct _Unwind_Exception *exc);
++static void (*libgcc_s_resume) (struct _Unwind_Exception *exc)
++  __attribute_used__;
+ static _Unwind_Reason_Code (*libgcc_s_personality)
+   (int, _Unwind_Action, _Unwind_Exception_Class, struct _Unwind_Exception *,
+    struct _Unwind_Context *);
+ static _Unwind_Reason_Code (*libgcc_s_forcedunwind)
+diff --git a/sysdeps/unix/sysv/linux/arm/unwind-resume.c b/sysdeps/unix/sysv/linux/arm/unwind-resume.c
+index bff3e2b..1f1eb71 100644
+--- a/ports/sysdeps/unix/sysv/linux/arm/nptl/unwind-resume.c
++++ b/ports/sysdeps/unix/sysv/linux/arm/nptl/unwind-resume.c
+@@ -21,7 +21,8 @@
+ #include <stdio.h>
+ #include <unwind.h>
+
+-static void (*libgcc_s_resume) (struct _Unwind_Exception *exc);
++static void (*libgcc_s_resume) (struct _Unwind_Exception *exc)
++  __attribute_used__;
+ static _Unwind_Reason_Code (*libgcc_s_personality)
+   (int, _Unwind_Action, _Unwind_Exception_Class, struct _Unwind_Exception *,
+    struct _Unwind_Context *);
+--- a/ports/sysdeps/unix/sysv/linux/arm/eabi/nptl/unwind-forcedunwind.c
++++ b/ports/sysdeps/unix/sysv/linux/arm/eabi/nptl/unwind-forcedunwind.c
+@@ -23,7 +23,8 @@
+ #include <pthreadP.h>
+
+ static void *libgcc_s_handle;
+-static void (*libgcc_s_resume) (struct _Unwind_Exception *exc);
++static void (*libgcc_s_resume) (struct _Unwind_Exception *exc)
++  __attribute_used__;
+ static _Unwind_Reason_Code (*libgcc_s_personality)
+   (_Unwind_State, struct _Unwind_Exception *, struct _Unwind_Context *);
+ static _Unwind_Reason_Code (*libgcc_s_forcedunwind)
+--- a/ports/sysdeps/unix/sysv/linux/arm/eabi/nptl/unwind-resume.c
++++ b/ports/sysdeps/unix/sysv/linux/arm/eabi/nptl/unwind-resume.c
+@@ -21,7 +21,8 @@
+ #include <stdio.h>
+ #include <unwind.h>
+
+-static void (*libgcc_s_resume) (struct _Unwind_Exception *exc);
++static void (*libgcc_s_resume) (struct _Unwind_Exception *exc)
++  __attribute_used__;
+ static _Unwind_Reason_Code (*libgcc_s_personality)
+   (_Unwind_State, struct _Unwind_Exception *, struct _Unwind_Context *);


### PR DESCRIPTION
This patch ports back an issue with gcc 5 where it would remove some "unused symbols", to allow building a glibc 2.13 toolchain for ARM.