### PR TITLE
Add uclibc-ng 1.0.20.

### DIFF
--- a/config/libc/uClibc.in
+++ b/config/libc/uClibc.in
@@ -81,24 +81,9 @@ choice
 # Don't remove next line
 # CT_INSERT_VERSION_BELOW
 
-# List 1.0.17 first to make it default:
-# - 1.0.18 has issues with static libs.
-# - 1.0.19 fails to build native GDB (unresolved references to libdl functions)
-config LIBC_UCLIBC_NG_V_1_0_17
+config LIBC_UCLIBC_NG_V_1_0_20
     bool
-    prompt "1.0.17"
-    select LIBC_UCLIBC_NG_1_0_15_or_later
-
-config LIBC_UCLIBC_NG_V_1_0_19
-    bool
-    prompt "1.0.19"
-    depends on EXPERIMENTAL
-    select LIBC_UCLIBC_NG_1_0_15_or_later
-
-config LIBC_UCLIBC_NG_V_1_0_18
-    bool
-    prompt "1.0.18"
-    depends on EXPERIMENTAL
+    prompt "1.0.20"
     select LIBC_UCLIBC_NG_1_0_15_or_later
 
 config LIBC_UCLIBC_V_0_9_33_2
@@ -112,9 +97,7 @@ config LIBC_VERSION
     string
 # Don't remove next line
 # CT_INSERT_VERSION_STRING_BELOW
-    default "1.0.19" if LIBC_UCLIBC_NG_V_1_0_19
-    default "1.0.18" if LIBC_UCLIBC_NG_V_1_0_18
-    default "1.0.17" if LIBC_UCLIBC_NG_V_1_0_17
+    default "1.0.20" if LIBC_UCLIBC_NG_V_1_0_20
     default "0.9.33.2" if LIBC_UCLIBC_V_0_9_33_2
 
 endif # ! LIBC_UCLIBC_CUSTOM


### PR DESCRIPTION
Retire 1.0.{17,18,19}. Both static link & dlopen issues are now
apparently fixed.

Signed-off-by: Alexey Neyman <stilor@att.net>