### PR TITLE
Fix xtensa static link.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ env:
     - CT_SAMPLE=mips64el-multilib-linux-uclibc
     - CT_SAMPLE=powerpc-e500v2-linux-gnuspe
     - CT_SAMPLE=x86_64-unknown-linux-uclibc
-    - CT_SAMPLE=xtensa-unknown-linux-uclibc
+    - CT_SAMPLE=xtensa-fsf-linux-uclibc
 
 # Building the standard samples
 script:

--- a/patches/uClibc-ng/1.0.20/100-xtensa-static-link.patch
+++ b/patches/uClibc-ng/1.0.20/100-xtensa-static-link.patch
@@ -1,0 +1,34 @@
+diff -urpN uClibc-ng-1.0.20.orig/libpthread/nptl/sysdeps/Makefile.commonarch uClibc-ng-1.0.20/libpthread/nptl/sysdeps/Makefile.commonarch
+--- uClibc-ng-1.0.20.orig/libpthread/nptl/sysdeps/Makefile.commonarch	2016-12-06 13:02:51.385861492 -0800
++++ uClibc-ng-1.0.20/libpthread/nptl/sysdeps/Makefile.commonarch	2016-12-06 19:08:53.150146970 -0800
+@@ -32,10 +32,11 @@ libpthread_arch_SOBJ = $(patsubst %.S,$(
+ libpthread_arch_OBJS = $(libpthread_subarch_OBJS) $(libpthread_arch_COBJ) $(libpthread_arch_SOBJ)
+ 
+ libc_arch_COBJ = $(patsubst %.c,$(libpthread_arch_OUT)/%.o,$(libc_arch_CSRC))
+-libc_arch_SOBJ = $(patsubst %.c,$(libpthread_arch_OUT)/%.o,$(libc_arch_SSRC))
++libc_arch_SOBJ = $(patsubst %.S,$(libpthread_arch_OUT)/%.o,$(libc_arch_SSRC))
+ libc_arch_OBJS = $(libc_arch_COBJ) $(libc_arch_SOBJ)
+ libc_arch_a_COBJ = $(patsubst %.c,$(libpthread_arch_OUT)/%.o,$(libc_arch_a_CSRC))
+-libc_arch_a_OBJS = $(libc_arch_a_COBJ)
++libc_arch_a_SOBJ = $(patsubst %.S,$(libpthread_arch_OUT)/%.o,$(libc_arch_a_SSRC))
++libc_arch_a_OBJS = $(libc_arch_a_COBJ) $(libc_arch_a_SOBJ)
+ 
+ librt_arch_COBJ = $(patsubst %.c,$(libpthread_arch_OUT)/%.o,$(librt_arch_CSRC))
+ librt_arch_SOBJ = $(patsubst %.S,$(libpthread_arch_OUT)/%.o,$(librt_arch_SSRC))
+diff -urpN uClibc-ng-1.0.20.orig/libpthread/nptl/sysdeps/xtensa/libc-dl-tlsdesc.S uClibc-ng-1.0.20/libpthread/nptl/sysdeps/xtensa/libc-dl-tlsdesc.S
+--- uClibc-ng-1.0.20.orig/libpthread/nptl/sysdeps/xtensa/libc-dl-tlsdesc.S	1969-12-31 16:00:00.000000000 -0800
++++ uClibc-ng-1.0.20/libpthread/nptl/sysdeps/xtensa/libc-dl-tlsdesc.S	2016-12-06 19:08:53.150146970 -0800
+@@ -0,0 +1 @@
++#include <ldso/ldso/xtensa/dl-tlsdesc.S>
+diff -urpN uClibc-ng-1.0.20.orig/libpthread/nptl/sysdeps/xtensa/Makefile.arch uClibc-ng-1.0.20/libpthread/nptl/sysdeps/xtensa/Makefile.arch
+--- uClibc-ng-1.0.20.orig/libpthread/nptl/sysdeps/xtensa/Makefile.arch	2016-12-06 13:02:51.401861642 -0800
++++ uClibc-ng-1.0.20/libpthread/nptl/sysdeps/xtensa/Makefile.arch	2016-12-06 19:08:53.150146970 -0800
+@@ -20,7 +20,7 @@
+ ASFLAGS-pthread_spin_trylock.S = -DNOT_IN_libc -DIS_IN_libpthread
+ 
+ libc_arch_a_CSRC = libc-tls.c
+-librt_arch_a_SSRC = dl-tlsdesc.S
++libc_arch_a_SSRC = libc-dl-tlsdesc.S
+ 
+ CFLAGS-gen_tlsdesc.c = -S
+ $(libpthread_arch_OUT)/gen_tlsdesc.c: $(libpthread_arch_DIR)/tlsdesc.sym | $(libpthread_arch_OUT)


### PR DESCRIPTION
uClibc-ng 1.0.20 fixed static linking with "libdl" by adding all libdl functions
into the libc. On xtensa, though, libdl contains an unresolved reference that is
satisfied by the ld.so - which is not a part of the linking in a static case.

Signed-off-by: Alexey Neyman <stilor@att.net>