### PR TITLE
Fix ct-ng show-config.

### DIFF
--- a/ct-ng.in
+++ b/ct-ng.in
@@ -10,7 +10,7 @@ MAKEFLAGS += --no-print-directory --no-builtin-rules
 .NOTPARALLEL:
 
 # This is where ct-ng is:
-export CT_NG:=$(lastword $(MAKEFILE_LIST))
+export CT_NG:=$(abspath $(lastword $(MAKEFILE_LIST)))
 # and this is where we're working in:
 export CT_TOP_DIR:=$(shell pwd)
 


### PR DESCRIPTION
If configured with --enable-local, CT_NG is exported as plain 'ct-ng'
without any path. showSamples.sh then fails to invoke ct-ng (as current
directory is not in $PATH).

Signed-off-by: Alexey Neyman <stilor@att.net>