### PR TITLE
Fix for Candian-Cross builds for mingw host to arm target.

### DIFF
--- a/patches/glibc/2.23/910-typedef-caddr.patch
+++ b/patches/glibc/2.23/910-typedef-caddr.patch
@@ -1,0 +1,15 @@
+diff -urN glibc-2.23-orig/posix/sys/types.h glibc-2.23/posix/sys/types.h
+--- glibc-2.23-orig/posix/sys/types.h   2016-02-18 12:54:00.000000000 -0500
++++ glibc-2.23/posix/sys/types.h        2017-01-06 11:40:05.842147165 -0500
+@@ -113,7 +113,10 @@
+ #ifdef __USE_MISC
+ # ifndef __daddr_t_defined
+ typedef __daddr_t daddr_t;
++#  if ! defined(caddr_t) && ! defined(__caddr_t_defined)
+ typedef __caddr_t caddr_t;
++#   define __caddr_t_defined
++#  endif
+ #  define __daddr_t_defined
+ # endif
+ #endif
+


### PR DESCRIPTION
This is essentially the same pull-request as "canadian build: fix mingw32". This only applies to glibc-2.23.