### PR TITLE
Avoid creating include/include

### DIFF
--- a/config/toolchain.in
+++ b/config/toolchain.in
@@ -4,12 +4,13 @@ comment "General toolchain options"
 
 config FORCE_SYSROOT
     bool
-    default y if !OBSOLETE
+    default y if !OBSOLETE && !BARE_METAL
     select USE_SYSROOT
 
 config USE_SYSROOT
     bool
     prompt "Use sysroot'ed toolchain"
+    depends on !BARE_METAL
     default y
     help
       Use the 'shinny new' sysroot feature of gcc: libraries split between

--- a/scripts/build/cc/100-gcc.sh
+++ b/scripts/build/cc/100-gcc.sh
@@ -409,9 +409,6 @@ do_gcc_core_backend() {
             ;;
     esac
 
-    CT_DoLog DEBUG "Copying headers to install area of core C compiler"
-    CT_DoExecLog ALL cp -a "${CT_HEADERS_DIR}" "${prefix}/${CT_TARGET}/include"
-
     for tmp in ARCH ABI CPU TUNE FPU FLOAT; do
         eval tmp="\${CT_ARCH_WITH_${tmp}}"
         if [ -n "${tmp}" ]; then

--- a/scripts/build/libc/newlib.sh
+++ b/scripts/build/libc/newlib.sh
@@ -142,7 +142,7 @@ ENABLE_TARGET_OPTSPACE:target-optspace
     CT_DoExecLog ALL make ${JOBSFLAGS}
 
     CT_DoLog EXTRA "Installing C library"
-    CT_DoExecLog ALL make install install_root="${CT_SYSROOT_DIR}"
+    CT_DoExecLog ALL make install
 
     if [ "${CT_BUILD_MANUALS}" = "y" ]; then
         local -a doc_dir="${CT_BUILD_DIR}/build-libc/${CT_TARGET}"

--- a/scripts/build/libc/newlib.sh
+++ b/scripts/build/libc/newlib.sh
@@ -119,8 +119,6 @@ ENABLE_TARGET_OPTSPACE:target-optspace
     [ "${CT_LIBC_NEWLIB_LTO}" = "y" ] && \
         CT_LIBC_NEWLIB_TARGET_CFLAGS="${CT_LIBC_NEWLIB_TARGET_CFLAGS} -flto"
 
-    [ "${CT_LIBC_NEWLIB_ENABLE_TARGET_OPTSPACE}" = "y" ] && newlib_opts+=("--enable-target-optspace")
-
     cflags_for_target="${CT_TARGET_CFLAGS} ${CT_LIBC_NEWLIB_TARGET_CFLAGS}"
 
     # Note: newlib handles the build/host/target a little bit differently

--- a/scripts/build/libc/newlib.sh
+++ b/scripts/build/libc/newlib.sh
@@ -5,10 +5,6 @@
 # Edited by Martin Lund <mgl@doredevelopment.dk>
 #
 
-LIBC_NEWLIB_AVR_HDRS_URI="http://www.atmel.com/Images"
-LIBC_NEWLIB_AVR_HDRS_BASE="avr-headers-3.2.3.970"
-LIBC_NEWLIB_AVR_HDRS_EXT=".zip"
-
 do_libc_get() {
     local libc_src="{http://mirrors.kernel.org/sourceware/newlib,
                      ftp://sourceware.org/pub/newlib}"


### PR DESCRIPTION
This is caused by doing "cp <src-dir>/include <dst-dir>/include" twice. First it creates <dst-dir>/include, second time it creates <dst-dir>/include/include.

On top of that, it turned out that newlib samples copied headers into both <sysroot>/usr/include and <prefix>/<target>/include. The former is not needed for bare metal, as there is no system root FS to speak of. Moreover, installing newlib into sysroot does not work, as it does not handle "install_root" variable.

Hope this untangles the current mess a bit.