### PR TITLE
Restore copying headers for gcc_build

### DIFF
--- a/scripts/build/cc/100-gcc.sh
+++ b/scripts/build/cc/100-gcc.sh
@@ -397,6 +397,13 @@ do_gcc_core_backend() {
             ;;
     esac
 
+    # This is only needed when building libstdc++ in a canadian environment with
+    # this function being used for final step (i.e., when building for bare metal).
+    if [ "${build_step}" = "gcc_build" ]; then
+        CT_DoLog DEBUG "Copying headers to install area of core C compiler"
+        CT_DoExecLog ALL cp -a "${CT_HEADERS_DIR}" "${prefix}/${CT_TARGET}/include"
+    fi
+
     for tmp in ARCH ABI CPU TUNE FPU FLOAT; do
         eval tmp="\${CT_ARCH_WITH_${tmp}}"
         if [ -n "${tmp}" ]; then


### PR DESCRIPTION
Only needed in canadian configurations to build libstdc++ (broken by removal of include/include headers)

Signed-off-by: Alexey Neyman <stilor@att.net>