### PR TITLE
Propagate caddr_t patch to other glibc versions

### DIFF
--- a/patches/glibc/2.20/910-typedef-caddr.patch
+++ b/patches/glibc/2.20/910-typedef-caddr.patch
@@ -1,0 +1,15 @@
+diff -urN glibc-2.23-orig/posix/sys/types.h glibc-2.23/posix/sys/types.h
+--- glibc-2.23-orig/posix/sys/types.h   2016-02-18 12:54:00.000000000 -0500
++++ glibc-2.23/posix/sys/types.h        2017-01-06 11:40:05.842147165 -0500
+@@ -113,7 +113,10 @@
+ #ifdef __USE_MISC
+ # ifndef __daddr_t_defined
+ typedef __daddr_t daddr_t;
++#  if ! defined(caddr_t) && ! defined(__caddr_t_defined)
+ typedef __caddr_t caddr_t;
++#   define __caddr_t_defined
++#  endif
+ #  define __daddr_t_defined
+ # endif
+ #endif
+

--- a/patches/glibc/2.21/910-typedef-caddr.patch
+++ b/patches/glibc/2.21/910-typedef-caddr.patch
@@ -1,0 +1,15 @@
+diff -urN glibc-2.23-orig/posix/sys/types.h glibc-2.23/posix/sys/types.h
+--- glibc-2.23-orig/posix/sys/types.h   2016-02-18 12:54:00.000000000 -0500
++++ glibc-2.23/posix/sys/types.h        2017-01-06 11:40:05.842147165 -0500
+@@ -113,7 +113,10 @@
+ #ifdef __USE_MISC
+ # ifndef __daddr_t_defined
+ typedef __daddr_t daddr_t;
++#  if ! defined(caddr_t) && ! defined(__caddr_t_defined)
+ typedef __caddr_t caddr_t;
++#   define __caddr_t_defined
++#  endif
+ #  define __daddr_t_defined
+ # endif
+ #endif
+

--- a/patches/glibc/2.22/910-typedef-caddr.patch
+++ b/patches/glibc/2.22/910-typedef-caddr.patch
@@ -1,0 +1,15 @@
+diff -urN glibc-2.23-orig/posix/sys/types.h glibc-2.23/posix/sys/types.h
+--- glibc-2.23-orig/posix/sys/types.h   2016-02-18 12:54:00.000000000 -0500
++++ glibc-2.23/posix/sys/types.h        2017-01-06 11:40:05.842147165 -0500
+@@ -113,7 +113,10 @@
+ #ifdef __USE_MISC
+ # ifndef __daddr_t_defined
+ typedef __daddr_t daddr_t;
++#  if ! defined(caddr_t) && ! defined(__caddr_t_defined)
+ typedef __caddr_t caddr_t;
++#   define __caddr_t_defined
++#  endif
+ #  define __daddr_t_defined
+ # endif
+ #endif
+

--- a/patches/glibc/2.24/910-typedef-caddr.patch
+++ b/patches/glibc/2.24/910-typedef-caddr.patch
@@ -1,0 +1,15 @@
+diff -urN glibc-2.23-orig/posix/sys/types.h glibc-2.23/posix/sys/types.h
+--- glibc-2.23-orig/posix/sys/types.h   2016-02-18 12:54:00.000000000 -0500
++++ glibc-2.23/posix/sys/types.h        2017-01-06 11:40:05.842147165 -0500
+@@ -113,7 +113,10 @@
+ #ifdef __USE_MISC
+ # ifndef __daddr_t_defined
+ typedef __daddr_t daddr_t;
++#  if ! defined(caddr_t) && ! defined(__caddr_t_defined)
+ typedef __caddr_t caddr_t;
++#   define __caddr_t_defined
++#  endif
+ #  define __daddr_t_defined
+ # endif
+ #endif
+


### PR DESCRIPTION
... 2.20, 2.21, 2.22 and 2.24.

Signed-off-by: Alexey Neyman <stilor@att.net>