### PR TITLE
Gcc compilation fix when fortran is enabled

### DIFF
--- a/patches/gcc/6.3.0/900-libgfortran-missing-include.patch
+++ b/patches/gcc/6.3.0/900-libgfortran-missing-include.patch
@@ -1,0 +1,10 @@
+--- gcc-6.3.0/libgfortran/io/close.c.org	2017-01-17 09:43:48.395850000 +0100
++++ gcc-6.3.0/libgfortran/io/close.c	2017-01-17 09:21:05.000000000 +0100
+@@ -25,6 +25,7 @@
+ #include "io.h"
+ #include "unix.h"
+ #include <limits.h>
++#include <stdlib.h>
+ 
+ typedef enum
+ { CLOSE_DELETE, CLOSE_KEEP, CLOSE_UNSPECIFIED }


### PR DESCRIPTION
When building a mingw toolchain with fortran enabled as a language for gcc the build fails due to an implicit declaration of free caused by a missing include in combination with the werror=implicit-function-declaration compilation flag.

This patch adds the missing include