### PR TITLE
Declare BACKEND obsolete.

### DIFF
--- a/config/backend.in
+++ b/config/backend.in
@@ -6,6 +6,7 @@ config IS_A_BACKEND
 
 config BACKEND
     bool
+    depends on OBSOLETE
     default y if IS_A_BACKEND = "y" || IS_A_BACKEND = "Y"
 
 if BACKEND

--- a/docs/0 - Table of content.txt
+++ b/docs/0 - Table of content.txt
@@ -21,7 +21,6 @@ _________________/
 3- Configuring a toolchain
     - Interesting config options
     - Re-building an existing toolchain
-    - Using as a backend for a build-system
 
 4- Building the toolchain
     - Stopping and restarting a build

--- a/docs/3 - Configuring a toolchain.txt
+++ b/docs/3 - Configuring a toolchain.txt
@@ -115,19 +115,3 @@ toolchain with this configuration, just redirect the output to the
 
 Then, you can review and change the configuration by running:
   ct-ng menuconfig
-
-
-Using as a backend for a build-system |
---------------------------------------+
-
-Crosstool-NG can be used as a backend for an automated build-system. In this
-case, some components that are expected to run on the target (eg. the native
-gdb, ltrace, DUMA...) are not available in the menuconfig, and they are not
-build either, as it is considered the responsibility of the build-system to
-build its own versions of those tools.
-
-If you want to use crosstool-NG as a backend to generate your toolchains for
-your build-system, you have to set and export this environment variable:
-  CT_IS_A_BACKEND=y
-
-(case is not sensitive, you can say Y).


### PR DESCRIPTION
I don't see what CT_BACKEND adds to configurability of crosstool-ng; apparently, it just increases the number of combinations to be tested (and I don't think we've tested it in a while). If you use it, please tell me what is the value of this option. Otherwise, I plan to obsolete it in the next release and retire it afterwards.