### PR TITLE
Fix glibc 2.23/2.24 with --enable-static-nss.

### DIFF
--- a/patches/glibc/2.23/120-Fix-build-with-enable-static-nss.patch
+++ b/patches/glibc/2.23/120-Fix-build-with-enable-static-nss.patch
@@ -1,0 +1,30 @@
+From 3a36c1eea4fa3b6f3b3b43f7eb91152383ae4ad8 Mon Sep 17 00:00:00 2001
+From: Alexey Neyman <stilor@att.net>
+Date: Tue, 24 Jan 2017 10:31:40 -0800
+Subject: [PATCH] Fix build with --enable-static-nss
+
+* nss/nsswitch.c (nscd_init_cb, is_nscd): make the #if around definitions
+  match those around use, to avoid "defined but not used" error.
+
+Signed-off-by: Alexey Neyman <stilor@att.net>
+---
+ ChangeLog      | 5 +++++
+ nss/nsswitch.c | 2 +-
+ 2 files changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/nss/nsswitch.c b/nss/nsswitch.c
+index 0a65f6a..8f31658 100644
+--- a/nss/nsswitch.c
++++ b/nss/nsswitch.c
+@@ -94,7 +94,7 @@ static name_database *service_table;
+ static name_database_entry *defconfig_entries;
+ 
+ 
+-#ifdef USE_NSCD
++#if defined USE_NSCD && (!defined DO_STATIC_NSS || defined SHARED)
+ /* Nonzero if this is the nscd process.  */
+ static bool is_nscd;
+ /* The callback passed to the init functions when nscd is used.  */
+-- 
+2.9.3
+

--- a/patches/glibc/2.24/120-Fix-build-with-enable-static-nss.patch
+++ b/patches/glibc/2.24/120-Fix-build-with-enable-static-nss.patch
@@ -1,0 +1,30 @@
+From 3a36c1eea4fa3b6f3b3b43f7eb91152383ae4ad8 Mon Sep 17 00:00:00 2001
+From: Alexey Neyman <stilor@att.net>
+Date: Tue, 24 Jan 2017 10:31:40 -0800
+Subject: [PATCH] Fix build with --enable-static-nss
+
+* nss/nsswitch.c (nscd_init_cb, is_nscd): make the #if around definitions
+  match those around use, to avoid "defined but not used" error.
+
+Signed-off-by: Alexey Neyman <stilor@att.net>
+---
+ ChangeLog      | 5 +++++
+ nss/nsswitch.c | 2 +-
+ 2 files changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/nss/nsswitch.c b/nss/nsswitch.c
+index 0a65f6a..8f31658 100644
+--- a/nss/nsswitch.c
++++ b/nss/nsswitch.c
+@@ -94,7 +94,7 @@ static name_database *service_table;
+ static name_database_entry *defconfig_entries;
+ 
+ 
+-#ifdef USE_NSCD
++#if defined USE_NSCD && (!defined DO_STATIC_NSS || defined SHARED)
+ /* Nonzero if this is the nscd process.  */
+ static bool is_nscd;
+ /* The callback passed to the init functions when nscd is used.  */
+-- 
+2.9.3
+


### PR DESCRIPTION
2.22 and older have more warnings that break the build.

Signed-off-by: Alexey Neyman <stilor@att.net>