### PR TITLE
Require C++ support for gdbserver 7.12 or newer

### DIFF
--- a/config/debug/gdb.in.cross
+++ b/config/debug/gdb.in.cross
@@ -7,7 +7,6 @@ config GDB_CROSS
     bool
     prompt "Cross-gdb"
     default y
-    select GDB_GDBSERVER if ! BARE_METAL
     select EXPAT_NEEDED
     select NCURSES_NEEDED
     help

--- a/config/debug/gdb.in.gdbserver
+++ b/config/debug/gdb.in.gdbserver
@@ -4,6 +4,7 @@ config GDB_GDBSERVER
     bool
     prompt "gdbserver"
     depends on ! BARE_METAL
+    depends on CC_LANG_CXX || !GDB_7_12_or_later
     help
       Build and install a gdbserver for the target, to run on the target.
 


### PR DESCRIPTION
Also, do not select gdbserver for cross-gdb automatically, or it may
be selected even without meeting the dependencies (if C++ is not enabled)

Signed-off-by: Alexey Neyman <stilor@att.net>