### PR TITLE
Allow some tunables for ncurses

### DIFF
--- a/config/companion_libs/ncurses.in
+++ b/config/companion_libs/ncurses.in
@@ -18,15 +18,58 @@ config NCURSES_VERSION
 # CT_INSERT_VERSION_STRING_BELOW
     default "6.0" if NCURSES_V_6_0
 
-if NCURSES
-
 config NCURSES_NEW_ABI
-    bool
-    prompt "ncurses 6.0 ABI support"
+    bool "ncurses 6.0 ABI support"
     depends on EXPERIMENTAL
-    depends on NCURSES
     help
       This option allows you to use the new ncurses-6 ABI.
       It's wise to leave this disabled and stick with the ncurses-5 ABI!
 
-endif # NCURSES
+config NCURSES_HOST_CONFIG_ARGS
+    string "Extra configure arguments for host ncurses"
+    help
+      Extra arguments that are passed verbatim to the configure when
+      building host ncurses.
+
+config NCURSES_HOST_DISABLE_DB
+    bool "Disable terminfo DB on the host"
+    default y
+    help
+      The terminfo database is not currently not installed on the host
+      as a part of the toolchain built by crosstool-ng.  This means the
+      library will not be able to use the terminals, unless that database
+      comes preinstalled.
+
+      Selecting this option allows one to embed some popular terminal
+      definitions into the library itself.
+
+      If not select, the path to the terminfo database on the host will
+      likely need to be passed as an argument to configure.
+
+config NCURSES_HOST_FALLBACKS
+    string "List of fallback terminals for the host"
+    default "linux,xterm,xterm-color,xterm-256color,vt100"
+    help
+      List of terminal descriptions that will be compiled into the curses
+      library for the host.
+
+config NCURSES_TARGET_CONFIG_ARGS
+    string "Extra configure arguments for target ncurses"
+    help
+      Extra arguments that are passed verbatim to the configure when
+      building target ncurses.
+
+config NCURSES_TARGET_DISABLE_DB
+    bool "Disable terminfo DB on the target"
+    default n
+    help
+      The terminfo database is installed with the terminfo database for the
+      target. If you want to configure ncurses with preselected terminals,
+      select Y here.
+
+config NCURSES_TARGET_FALLBACKS
+    string "List of fallback terminals for the target"
+    help
+      List of terminal descriptions that will be compiled into the curses
+      library for the target.
+

--- a/patches/ncurses/6.0/999-create-run_tic.patch
+++ b/patches/ncurses/6.0/999-create-run_tic.patch
@@ -1,0 +1,22 @@
+diff -urpN ncurses-6.0.orig/configure ncurses-6.0/configure
+--- ncurses-6.0.orig/configure	2017-02-05 11:06:35.342548609 -0800
++++ ncurses-6.0/configure	2017-02-05 11:07:02.878754676 -0800
+@@ -22254,7 +22254,6 @@ else
+ fi
+ 
+ ################################################################################
+-test "x$use_database" = xyes && \
+ SUB_MAKEFILES="$SUB_MAKEFILES misc/run_tic.sh:misc/run_tic.in"
+ 
+ SUB_MAKEFILES="$SUB_MAKEFILES misc/ncurses-config:misc/ncurses-config.in"
+diff -urpN ncurses-6.0.orig/configure.in ncurses-6.0/configure.in
+--- ncurses-6.0.orig/configure.in	2017-02-05 11:06:35.326548489 -0800
++++ ncurses-6.0/configure.in	2017-02-05 11:07:08.926799658 -0800
+@@ -2032,7 +2032,6 @@ CF_SUBST_IF(["x$ac_cv_header_termio_h" =
+ CF_SUBST_IF(["x$ac_cv_header_termios_h" = xyes], HAVE_TERMIOS_H, 1, 0)
+ 
+ ################################################################################
+-test "x$use_database" = xyes && \
+ SUB_MAKEFILES="$SUB_MAKEFILES misc/run_tic.sh:misc/run_tic.in"
+ 
+ SUB_MAKEFILES="$SUB_MAKEFILES misc/ncurses-config:misc/ncurses-config.in"

--- a/scripts/build/companion_libs/220-ncurses.sh
+++ b/scripts/build/companion_libs/220-ncurses.sh
@@ -32,6 +32,18 @@ do_ncurses_for_build() {
           "--without-cxx" \
           "--without-cxx-binding" \
           "--without-ada")
+    # If we are not canadian, this is also our host curses
+    # Unlike other companion libs, we skip host build if build==host
+    # (i.e. in simple cross or native): ncurses may not be needed for
+    # host, but we still need them on build to produce 'tic'.
+    case "${CT_TOOLCHAIN_TYPE}" in
+        native|cross)
+            if [ "${CT_NCURSES_HOST_DISABLE_DB}" = "y" ]; then
+                opts+=( "--disable-database" "--with-fallbacks=${CT_NCURSES_HOST_FALLBACKS}" )
+            fi
+            opts+=( "${CT_NCURSES_HOST_CONFIG_ARGS[@]}" )
+            ;;
+    esac
     do_ncurses_backend host="${CT_BUILD}" \
                        destdir="${CT_BUILDTOOLS_PREFIX_DIR}" \
                        cflags="${CT_CFLAGS_FOR_BUILD}" \
@@ -59,7 +71,11 @@ do_ncurses_for_host() {
           "--without-tests" \
           "--without-cxx" \
           "--without-cxx-binding" \
-          "--without-ada")
+          "--without-ada" )
+    if [ "${CT_NCURSES_HOST_DISABLE_DB}" = "y" ]; then
+        opts+=( "--disable-database" "--with-fallbacks=${CT_NCURSES_HOST_FALLBACKS}" )
+    fi
+    opts+=( "${CT_NCURSES_HOST_CONFIG_ARGS[@]}" )
     do_ncurses_backend host="${CT_HOST}" \
                        prefix="${CT_HOST_COMPLIBS_DIR}" \
                        cflags="${CT_CFLAGS_FOR_HOST}" \
@@ -79,6 +95,10 @@ do_ncurses_for_target() {
     opts=("--without-sysmouse")
     [ "${CT_CC_LANG_CXX}" = "y" ] || opts+=("--without-cxx" "--without-cxx-binding")
     [ "${CT_CC_LANG_ADA}" = "y" ] || opts+=("--without-ada")
+    if [ "${CT_NCURSES_TARGET_DISABLE_DB}" = "y" ]; then
+        opts+=( "--disable-database" "--with-fallbacks=${CT_NCURSES_TARGET_FALLBACKS}" )
+    fi
+    opts+=( "${CT_NCURSES_TARGET_CONFIG_ARGS[@]}" )
     case "${CT_TARGET}" in
         *-*-mingw*)
             prefix="/mingw"


### PR DESCRIPTION
- Allow user to specify configure arguments to pass through to host/target
ncurses.
- Checkbox for --disable-database
- String option for --with-fallbacks

Signed-off-by: Alexey Neyman <stilor@att.net>