### PR TITLE
Remove "pre-declaration" of config options

### DIFF
--- a/config/target.in
+++ b/config/target.in
@@ -5,41 +5,6 @@ menu "Target options"
 config ARCH
     string
 
-# Pre-declare target optimisation variables
-config ARCH_SUPPORTS_BOTH_MMU
-config ARCH_SUPPORTS_BOTH_ENDIAN
-config ARCH_SUPPORTS_8
-config ARCH_SUPPORTS_32
-config ARCH_SUPPORTS_64
-config ARCH_SUPPORTS_WITH_ARCH
-config ARCH_SUPPORTS_WITH_ABI
-config ARCH_SUPPORTS_WITH_CPU
-config ARCH_SUPPORTS_WITH_TUNE
-config ARCH_SUPPORTS_WITH_FLOAT
-config ARCH_SUPPORTS_WITH_FPU
-config ARCH_SUPPORTS_SOFTFP
-
-config ARCH_DEFAULT_HAS_MMU
-config ARCH_DEFAULT_BE
-config ARCH_DEFAULT_LE
-config ARCH_DEFAULT_32
-config ARCH_DEFAULT_64
-
-config ARCH_ARCH
-config ARCH_ABI
-config ARCH_CPU
-config ARCH_TUNE
-config ARCH_FPU
-config ARCH_BE
-config ARCH_LE
-config ARCH_32
-config ARCH_64
-config ARCH_BITNESS
-config ARCH_FLOAT_HW
-config ARCH_FLOAT_SW
-config TARGET_CFLAGS
-config TARGET_LDFLAGS
-
 source "config.gen/arch.in"
 
 config ARCH_SUFFIX


### PR DESCRIPTION
... these are apparently not needed with the current kconfig and only
result in warnings like "SYMBOL changed state" and "reassigning SYMBOL".

Perhaps, it was necessary to run kconfig without first generating
config.gen? But now all the targets that invoke $(CONF) have
`config_files` as a dependency.

Signed-off-by: Alexey Neyman <stilor@att.net>