### PR TITLE
Supply --disable-build-with-cxx instead of requiring C++

### DIFF
--- a/config/debug/gdb.in.gdbserver
+++ b/config/debug/gdb.in.gdbserver
@@ -3,8 +3,8 @@
 config GDB_GDBSERVER
     bool
     prompt "gdbserver"
+    default y
     depends on ! BARE_METAL
-    depends on CC_LANG_CXX || !GDB_7_12_or_later
     help
       Build and install a gdbserver for the target, to run on the target.
 

--- a/config/debug/gdb.in.native
+++ b/config/debug/gdb.in.native
@@ -5,7 +5,6 @@ config GDB_NATIVE
     prompt "Native gdb"
     depends on ! BARE_METAL
     depends on ! BACKEND
-    depends on CC_LANG_CXX || !GDB_7_12_or_later
     select EXPAT_TARGET
     select NCURSES_TARGET
     help

--- a/scripts/build/debug/300-gdb.sh
+++ b/scripts/build/debug/300-gdb.sh
@@ -179,6 +179,9 @@ do_debug_gdb_build() {
 
         native_extra_config=("${extra_config[@]}")
 
+        # We may not have C++ language configured for target
+        native_extra_config+=("--disable-build-with-cxx")
+
         # GDB on Mingw depends on PDcurses, not ncurses
         if [ "${CT_MINGW32}" != "y" ]; then
             native_extra_config+=("--with-curses")
@@ -292,6 +295,9 @@ do_debug_gdb_build() {
         fi
 
         gdbserver_extra_config=("${extra_config[@]}")
+
+        # We may not have C++ language configured for target
+        gdbserver_extra_config+=("--disable-build-with-cxx")
 
         if [ "${CT_GDB_GDBSERVER_HAS_IPA_LIB}" = "y" ]; then
             if [ "${CT_GDB_GDBSERVER_BUILD_IPA_LIB}" = "y" ]; then


### PR DESCRIPTION
... when building native GDB/gdbserver.

Suggested by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>
Signed-off-by: Alexey Neyman <stilor@att.net>