### PR TITLE
Determine whether -E/-r option selects extended regexp

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -62,6 +62,7 @@ export awk             := @AWK@
 export grep            := @GREP@
 export make            := @MAKE@
 export sed             := @SED@
+export sed_r           := @SED_R@
 export wget            := @wget@
 export curl            := @curl@
 export libtool         := @LIBTOOL@
@@ -180,7 +181,7 @@ docs/$(PROG_NAME).1.gz: docs/$(PROG_NAME).1
 
 define sed_it
 	@echo "  SED    '$@'"
-	@$(sed) -r -e 's,@@CT_BINDIR@@,$(bindir),g;'        \
+	@$(sed_r)  -e 's,@@CT_BINDIR@@,$(bindir),g;'        \
 	           -e 's,@@CT_LIBDIR@@,$(libdir),g;'        \
 	           -e 's,@@CT_DOCDIR@@,$(docdir),g;'        \
 	           -e 's,@@CT_MANDIR@@,$(mandir),g;'        \
@@ -214,6 +215,7 @@ paths.mk: FORCE
 	  echo 'export grep=$(grep)';               \
 	  echo 'export make=$(make)';               \
 	  echo 'export sed=$(sed)';                 \
+	  echo 'export sed_r=$(sed_r)';             \
 	  echo 'export libtool=$(libtool)';         \
 	  echo 'export libtoolize=$(libtoolize)';   \
 	  echo 'export objcopy=$(objcopy)';         \
@@ -231,6 +233,7 @@ paths.sh: FORCE
 	  echo 'export grep="$(grep)"';             \
 	  echo 'export make="$(make)"';             \
 	  echo 'export sed="$(sed)"';               \
+	  echo 'export sed_r="$(sed_r)"';           \
 	  echo 'export libtool="$(libtool)"';       \
 	  echo 'export libtoolize="$(libtoolize)"'; \
 	  echo 'export objcopy="$(objcopy)"';       \

--- a/configure.ac
+++ b/configure.ac
@@ -171,15 +171,27 @@ AS_IF([test "$EGREP" != "$GREP -E"],
 ACX_WITH_DEPRECATED([sed], [SED])
 AC_ARG_VAR([INSTALL], [Specify the full path to GNU sed])
 AC_PROG_SED
-AC_MSG_CHECKING([whether sed understands -r -i -e])
-echo foo > .ct-ng.sed.test
-${SED} -r -i -e 's/f(o)o/b\1ar/' .ct-ng.sed.test >/dev/null 2>&1
-rc=$?
-content=`cat .ct-ng.sed.test`
-rm -f .ct-ng.sed.test
-AS_IF([test "$rc:$content" = "0:boar"],
-    [AC_MSG_RESULT([yes])],
-    [AC_MSG_ERROR([sed does not accept -r -i -e])])
+AC_CACHE_CHECK([whether $SED understands -i -e],
+    [acx_cv_sed_i_e],
+    [echo foo > .ct-ng.sed.test
+     ${SED} -i -e 's/foo/bar/' .ct-ng.sed.test >/dev/null 2>&1
+     rc=$?
+     content=`cat .ct-ng.sed.test`
+     rm -f .ct-ng.sed.test
+     AS_IF([test "$rc:$content" = "0:bar"],
+           [acx_cv_sed_i_e=yes],
+           [AC_MSG_ERROR([sed does not accept -i -e])])])
+AC_CACHE_CHECK([which $SED option selects extended regexp],
+    [acx_cv_sed_r],
+    [opt_r=`echo foo | $SED -r -e 's/f(o)o/b\1ar/' 2>/dev/null`
+     opt_E=`echo foo | $SED -E -e 's/f(o)o/b\1ar/' 2>/dev/null`
+     AS_IF([test "$opt_r" = "boar"],
+           [acx_cv_sed_r=-r],
+           [test "$opt_E" = "boar"],
+           [acx_cv_sed_r=-E],
+           [AC_MSG_ERROR([neither -r nor -E enables extended regexp])])])
+SED_R="$SED $acx_cv_sed_r"
+AC_SUBST([SED_R])
 
 AC_PROG_LN_S
 

--- a/kconfig/Makefile
+++ b/kconfig/Makefile
@@ -65,7 +65,7 @@ DEPS += $(nconf_DEP)
 # Build the dependency for C files
 %.dep: %.c
 	@echo "  DEP    '$@'"
-	@$(CC) $(CFLAGS) $(EXTRA_CFLAGS) -MM $< |$(sed) -r -e 's|([^:]+.o)( *:+)|$(<:.c=.o) $@\2|;' >$@
+	@$(CC) $(CFLAGS) $(EXTRA_CFLAGS) -MM $< |$(sed_r) -e 's|([^:]+.o)( *:+)|$(<:.c=.o) $@\2|;' >$@
 
 # Generate the grammar parser
 zconf.tab.o: zconf.tab.c zconf.hash.c zconf.lex.c

--- a/scripts/addToolVersion.sh
+++ b/scripts/addToolVersion.sh
@@ -73,7 +73,7 @@ addToolVersion() {
 
     [ -f "${file}" ] || return 0
 
-    v=$(echo "${version}" |"${sed}" -r -e 's/-/_/g; s/\./_/g;')
+    v=$(echo "${version}" |"${sed_r}" -e 's/-/_/g; s/\./_/g;')
 
     config_ver_option="${cat}_V_${v}"
 

--- a/scripts/build/arch.sh
+++ b/scripts/build/arch.sh
@@ -23,7 +23,7 @@ CT_DoArchUClibcSelectArch() {
     local cfg="${1}"
     local arch="${2}"
 
-    sed -i -r -e '/^TARGET_.*/d' "${cfg}"
+    sed_r -i -e '/^TARGET_.*/d' "${cfg}"
     CT_KconfigEnableOption "TARGET_${arch}" "${cfg}"
     CT_KconfigSetOption "TARGET_ARCH" "${arch}" "${cfg}"
 }

--- a/scripts/build/binutils/binutils.sh
+++ b/scripts/build/binutils/binutils.sh
@@ -257,7 +257,7 @@ do_binutils_backend() {
         CT_DoLog EXTRA "Installing ld wrapper"
         rm -f "${prefix}/bin/${CT_TARGET}-ld"
         rm -f "${prefix}/${CT_TARGET}/bin/ld"
-        sed -r -e "s/@@DEFAULT_LD@@/${CT_BINUTILS_LINKER_DEFAULT}/" \
+        sed_r -e "s/@@DEFAULT_LD@@/${CT_BINUTILS_LINKER_DEFAULT}/" \
             "${CT_LIB_DIR}/scripts/build/binutils/binutils-ld.in"      \
             >"${prefix}/bin/${CT_TARGET}-ld"
         chmod +x "${prefix}/bin/${CT_TARGET}-ld"

--- a/scripts/build/cc/100-gcc.sh
+++ b/scripts/build/cc/100-gcc.sh
@@ -661,7 +661,7 @@ do_gcc_core_backend() {
 
         CT_DoExecLog ALL make ${JOBSFLAGS} -C gcc ${libgcc_rule} \
                               ${repair_cc}
-        sed -r -i -e 's@-lc@@g' gcc/${libgcc_rule}
+        sed_r -i -e 's@-lc@@g' gcc/${libgcc_rule}
     else # build_libgcc
         core_targets=( gcc )
     fi   # ! build libgcc

--- a/scripts/build/debug/200-duma.sh
+++ b/scripts/build/debug/200-duma.sh
@@ -48,7 +48,7 @@ do_debug_duma_build() {
     if [ "${CT_DUMA_CUSTOM_WRAPPER}" = "y" ]; then
         # The shared library needs some love: some version have libduma.so.0.0,
         # while others have libduma.so.0.0.0
-        duma_so=$( make "${make_args[@]}" printvars | sed -n -r -e 's/^DUMASO \[(.*)\]$/\1/p' )
+        duma_so=$( make "${make_args[@]}" printvars | sed_r -n -e 's/^DUMASO \[(.*)\]$/\1/p' )
 
         CT_DoLog EXTRA "Installing wrapper script"
         CT_DoExecLog ALL mkdir -p "${CT_DEBUGROOT_DIR}/usr/bin"
@@ -56,7 +56,7 @@ do_debug_duma_build() {
         CT_DoExecLog ALL rm -f "${CT_DEBUGROOT_DIR}/usr/bin/duma"
         CT_DoExecLog ALL cp "${CT_LIB_DIR}/scripts/build/debug/duma.in" \
                             "${CT_DEBUGROOT_DIR}/usr/bin/duma"
-        CT_DoExecLog ALL sed -i -r -e "s:^LIBDUMA_SO=.*:LIBDUMA_SO=/usr/lib/${duma_so}:;" \
+        CT_DoExecLog ALL sed_r -i -e "s:^LIBDUMA_SO=.*:LIBDUMA_SO=/usr/lib/${duma_so}:;" \
                             "${CT_DEBUGROOT_DIR}/usr/bin/duma"
         CT_DoExecLog ALL chmod 755 "${CT_DEBUGROOT_DIR}/usr/bin/duma"
     fi

--- a/scripts/build/debug/300-gdb.sh
+++ b/scripts/build/debug/300-gdb.sh
@@ -156,11 +156,11 @@ do_debug_gdb_build() {
             if [ -f "${CT_SRC_DIR}/gcc-${CT_CC_GCC_VERSION}/gcc/BASE-VER" ]; then
                 gcc_version=$( cat "${CT_SRC_DIR}/gcc-${CT_CC_GCC_VERSION}/gcc/BASE-VER" )
             else
-                gcc_version=$(sed -r -e '/version_string/!d; s/^.+= "([^"]+)".*$/\1/;'   \
+                gcc_version=$(sed_r -e '/version_string/!d; s/^.+= "([^"]+)".*$/\1/;'   \
                                    "${CT_SRC_DIR}/gcc-${CT_CC_GCC_VERSION}/gcc/version.c"   \
                              )
             fi
-            sed -r                                               \
+            sed_r                                                   \
                    -e "s:@@PREFIX@@:${CT_PREFIX_DIR}:;"             \
                    -e "s:@@VERSION@@:${gcc_version}:;"              \
                    "${CT_LIB_DIR}/scripts/build/debug/gdbinit.in"   \

--- a/scripts/build/debug/duma.in
+++ b/scripts/build/debug/duma.in
@@ -16,7 +16,7 @@ case "$1" in
     # We use a suposedly POSIX-compliant shell: /bin/sh
     #  -> we can't use "${LD_PRELOAD//${LIBDUMA_SO}/}", it's not POSIX
     # We don't know if sed will be present on the target
-    #  -> we can't use $(echo "${LD_PRELOAD}" |sed -r -e "s|${LIBDUMA_SO}||;")
+    #  -> we can't use $(echo "${LD_PRELOAD}" |${sed_r} -e "s|${LIBDUMA_SO}||;")
     # So, iterate through LD_PRELOAD, and keep only those libs that
     # are not "${LIBDUMA_SO}"
     old_LD_PRELOAD="${LD_PRELOAD}"

--- a/scripts/build/internals.sh
+++ b/scripts/build/internals.sh
@@ -47,7 +47,7 @@ do_finish() {
             if [ -f "${CT_SRC_DIR}/gcc-${CT_CC_GCC_VERSION}/gcc/BASE-VER" ]; then
                 gcc_version=$( cat "${CT_SRC_DIR}/gcc-${CT_CC_GCC_VERSION}/gcc/BASE-VER" )
             else
-                gcc_version=$(sed -r -e '/version_string/!d; s/^.+= "([^"]+)".*$/\1/;' \
+                gcc_version=$(sed_r -e '/version_string/!d; s/^.+= "([^"]+)".*$/\1/;' \
                                    "${CT_SRC_DIR}/gcc-${CT_CC_GCC_VERSION}/gcc/version.c" \
                              )
             fi
@@ -71,13 +71,14 @@ do_finish() {
 
     if [ "${CT_BARE_METAL}" != "y" ]; then
         CT_DoLog EXTRA "Installing the populate helper"
-        sed -r -e 's|@@CT_TARGET@@|'"${CT_TARGET}"'|g;' \
-               -e 's|@@CT_install@@|'"install"'|g;'     \
-               -e 's|@@CT_awk@@|'"awk"'|g;'             \
+        sed_r  -e 's|@@CT_TARGET@@|'"${CT_TARGET}"'|g;' \
+               -e 's|@@CT_install@@|'"${install}"'|g;'     \
+               -e 's|@@CT_awk@@|'"${awk}"'|g;'             \
                -e 's|@@CT_bash@@|'"${bash}"'|g;'           \
-               -e 's|@@CT_grep@@|'"grep"'|g;'           \
-               -e 's|@@CT_make@@|'"make"'|g;'           \
-               -e 's|@@CT_sed@@|'"sed"'|g;'             \
+               -e 's|@@CT_grep@@|'"${grep}"'|g;'           \
+               -e 's|@@CT_make@@|'"${make}"'|g;'           \
+               -e 's|@@CT_sed@@|'"${sed}"'|g;'             \
+               -e 's|@@CT_sed_r@@|'"${sed_r}"'|g;'         \
                "${CT_LIB_DIR}/scripts/populate.in"         \
                >"${CT_PREFIX_DIR}/bin/${CT_TARGET}-populate"
         CT_DoExecLog ALL chmod 755 "${CT_PREFIX_DIR}/bin/${CT_TARGET}-populate"
@@ -85,14 +86,15 @@ do_finish() {
 
     if [ "${CT_LIBC_XLDD}" = "y" ]; then
         CT_DoLog EXTRA "Installing a cross-ldd helper"
-        sed -r -e 's|@@CT_VERSION@@|'"${CT_VERSION}"'|g;' \
+        sed_r  -e 's|@@CT_VERSION@@|'"${CT_VERSION}"'|g;' \
                -e 's|@@CT_TARGET@@|'"${CT_TARGET}"'|g;'      \
                -e 's|@@CT_BITS@@|'"${CT_ARCH_BITNESS}"'|g;'  \
-               -e 's|@@CT_install@@|'"install"'|g;'       \
+               -e 's|@@CT_install@@|'"${install}"'|g;'       \
                -e 's|@@CT_bash@@|'"${bash}"'|g;'             \
-               -e 's|@@CT_grep@@|'"grep"'|g;'             \
-               -e 's|@@CT_make@@|'"make"'|g;'             \
-               -e 's|@@CT_sed@@|'"sed"'|g;'               \
+               -e 's|@@CT_grep@@|'"${grep}"'|g;'             \
+               -e 's|@@CT_make@@|'"${make}"'|g;'             \
+               -e 's|@@CT_sed@@|'"${sed}"'|g;'               \
+               -e 's|@@CT_sed_r@@|'"${sed_r}"'|g;'         \
                "${CT_LIB_DIR}/scripts/xldd.in"               \
                >"${CT_PREFIX_DIR}/bin/${CT_TARGET}-ldd"
         CT_DoExecLog ALL chmod 755 "${CT_PREFIX_DIR}/bin/${CT_TARGET}-ldd"
@@ -103,11 +105,11 @@ do_finish() {
     CT_Pushd "${CT_PREFIX_DIR}/bin"
     for t in "${CT_TARGET}-"*; do
         if [ -n "${CT_TARGET_ALIAS}" ]; then
-            _t=$(echo "$t" |sed -r -e 's/^'"${CT_TARGET}"'-/'"${CT_TARGET_ALIAS}"'-/;')
+            _t=$(echo "$t" |sed_r -e 's/^'"${CT_TARGET}"'-/'"${CT_TARGET_ALIAS}"'-/;')
             CT_DoExecLog ALL ln -sfv "${t}" "${_t}"
         fi
         if [ -n "${CT_TARGET_ALIAS_SED_EXPR}" ]; then
-            _t=$(echo "$t" |sed -r -e "${CT_TARGET_ALIAS_SED_EXPR}")
+            _t=$(echo "$t" |sed_r -e "${CT_TARGET_ALIAS_SED_EXPR}")
             if [ "${_t}" = "${t}" ]; then
                 CT_DoLog WARN "The sed expression '${CT_TARGET_ALIAS_SED_EXPR}' has no effect on '${t}'"
             else

--- a/scripts/build/kernel/linux.sh
+++ b/scripts/build/kernel/linux.sh
@@ -80,7 +80,7 @@ do_kernel_extract() {
     # to version - patching each particular Linux version would be
     # too cumbersome.
     CT_Pushd "${CT_SRC_DIR}/linux-${CT_KERNEL_VERSION}"
-    sed -i -r 's/(\$\(MAKE\) .* relocs)$/:/' arch/*/Makefile
+    sed_r -i 's/(\$\(MAKE\) .* relocs)$/:/' arch/*/Makefile
     CT_Popd
 }
 

--- a/scripts/build/libc/glibc.sh
+++ b/scripts/build/libc/glibc.sh
@@ -473,7 +473,7 @@ do_libc_backend_once() {
 do_libc_add_ons_list() {
     local sep="$1"
     local addons_list="$( echo "${CT_LIBC_ADDONS_LIST}"            \
-                          |sed -r -e "s/[[:space:],]/${sep}/g;" \
+                          |sed_r -e "s/[[:space:],]/${sep}/g;" \
                         )"
     if [ "${CT_LIBC_GLIBC_2_20_or_later}" != "y" ]; then
         case "${CT_THREADS}" in
@@ -483,7 +483,7 @@ do_libc_add_ons_list() {
     fi
     [ "${CT_LIBC_GLIBC_USE_PORTS}" = "y" ] && addons_list="${addons_list}${sep}ports"
     # Remove duplicate, leading and trailing separators
-    echo "${addons_list}" |sed -r -e "s/${sep}+/${sep}/g; s/^${sep}//; s/${sep}\$//;"
+    echo "${addons_list}" |sed_r -e "s/${sep}+/${sep}/g; s/^${sep}//; s/${sep}\$//;"
 }
 
 # Compute up the minimum supported Linux kernel version
@@ -512,7 +512,7 @@ do_libc_min_kernel_config() {
             elif [ "${CT_LIBC_GLIBC_KERNEL_VERSION_CHOSEN}" = "y" ]; then
                 # Trim the fourth part of the linux version, keeping only the first three numbers
                 min_kernel_config="$( echo "${CT_LIBC_GLIBC_MIN_KERNEL_VERSION}"               \
-                                      |sed -r -e 's/^([^.]+\.[^.]+\.[^.]+)(|\.[^.]+)$/\1/;' \
+                                      |sed_r -e 's/^([^.]+\.[^.]+\.[^.]+)(|\.[^.]+)$/\1/;' \
                                     )"
             fi
             echo "--enable-kernel=${min_kernel_config}"

--- a/scripts/build/test_suite/gcc.sh
+++ b/scripts/build/test_suite/gcc.sh
@@ -21,7 +21,7 @@ do_test_suite_gcc_build() {
                             "${CT_SRC_DIR}/gcc-${CT_CC_GCC_VERSION}/gcc/testsuite"  \
                             "${CT_TEST_SUITE_DIR}/gcc"
 
-    CT_DoExecLog ALL sed -i -r -e "s/@@DG_TARGET@@/${CT_TARGET}/g;"     \
+    CT_DoExecLog ALL sed_r -i -e "s/@@DG_TARGET@@/${CT_TARGET}/g;"     \
                          "${CT_TEST_SUITE_DIR}/gcc/Makefile"
 
     CT_EndStep

--- a/scripts/crosstool-NG.sh.in
+++ b/scripts/crosstool-NG.sh.in
@@ -117,7 +117,7 @@ cat "${CT_LIB_DIR}/paths.sh" |while read trash line; do
     fi
     CT_DoLog DEBUG "Creating script-override for '${tool}' -> '${path}' using '${tmpl}' template"
     CT_DoExecLog ALL cp "${tmpl}" "${CT_TOOLS_OVERRIDE_DIR}/bin/${tool}"
-    CT_DoExecLog ALL ${sed} -i -r \
+    CT_DoExecLog ALL ${sed_r} -i \
               -e "s#@CONFIG_SHELL@#${CT_CONFIG_SHELL}#g" \
               -e "s#@TOOL_PATH@#${path}#g" \
               -e "s#@TOOLS_OVERRIDE_DIR@#${CT_TOOLS_OVERRIDE_DIR}#g" \
@@ -148,7 +148,7 @@ CT_DoLog INFO "Building environment variables"
 CT_TestAndAbort "'CT_PREFIX_DIR' is not set: where should I install?" -z "${CT_PREFIX_DIR}"
 
 # Avoid multiple '/' in the prefix dir, it breaks relocatability
-CT_PREFIX_DIR="$( "${sed}" -r -e 's:/+:/:g; s:/*$::;' <<<"${CT_PREFIX_DIR}" )"
+CT_PREFIX_DIR="$( ${sed_r} -e 's:/+:/:g; s:/*$::;' <<<"${CT_PREFIX_DIR}" )"
 
 # Second kludge: merge user-supplied target CFLAGS with architecture-provided
 # target CFLAGS. Do the same for LDFLAGS in case it happens in the future.

--- a/scripts/functions
+++ b/scripts/functions
@@ -4,6 +4,10 @@
 # Copyright 2007 Yann E. MORIN
 # Licensed under the GPL v2. See COPYING in the root of this package
 
+# NOTE: The functions in this file may be used before the tools override
+# directory is created (or in the scripts that don't create the tools override
+# directory at all). Therefore, use the variables exported by paths.sh.
+
 CT_LoadConfig() {
     local o
 
@@ -49,7 +53,7 @@ CT_LoadConfig() {
     fi
     # Double eval: first eval substitutes option name, second eval unescapes quotes
     # and whitespace.
-    for o in `set | sed -rn 's/^(CT_[A-Za-z0-9_]*_ARRAY)=.*/\1/p'`; do
+    for o in `set | ${sed_r} -n 's/^(CT_[A-Za-z0-9_]*_ARRAY)=.*/\1/p'`; do
         eval "eval $o=(\"\$$o\")"
     done
 }
@@ -394,7 +398,7 @@ CT_SanitizeVarDir() {
 
     for var in "$@"; do
         eval "old_dir=\"\${${var}}\""
-        new_dir=$( echo "${old_dir}" | awk '
+        new_dir=$( echo "${old_dir}" | ${awk} '
 {
     isabs = $1 == "" # Started with a slash
     trail = $NF == "" # Ending with a slash
@@ -491,7 +495,7 @@ CT_Which() {
 # to the highest entire second
 # Usage: CT_DoDate <fmt>
 CT_DoDate() {
-    date "$1" |sed -r -e 's/%?N$/000000000/;'
+    date "$1" | ${sed_r} -e 's/%?N$/000000000/;'
 }
 
 CT_STEP_COUNT=1
@@ -514,7 +518,7 @@ CT_DoStep() {
 CT_EndStep() {
     local stop=$(CT_DoDate +%s%N)
     local duration=$(printf "%032d" $((stop-${CT_STEP_START[${CT_STEP_COUNT}]})) \
-                     |sed -r -e 's/([[:digit:]]{2})[[:digit:]]{7}$/\.\1/; s/^0+//; s/^\./0\./;'
+                     | ${sed_r} -e 's/([[:digit:]]{2})[[:digit:]]{7}$/\.\1/; s/^0+//; s/^\./0\./;'
                     )
     local elapsed=$(printf "%02d:%02d" $((SECONDS/60)) $((SECONDS%60)))
     local level="${CT_STEP_LEVEL[${CT_STEP_COUNT}]}"
@@ -1002,7 +1006,7 @@ CT_GetGit() {
     local url="${3}"
     local _out_cset="${4}"
 
-    local ref=$(echo "${cset_or_ref}" | sed -n 's/^ref=\(.*\)/\1/p')
+    local ref=$(echo "${cset_or_ref}" | ${sed_r} -n 's/^ref=(.*)/\1/p')
     if [ -n "$ref" ]; then
         local matches=$(git ls-remote --exit-code "$url" --refs "${ref}")
         local result=$?
@@ -1182,9 +1186,9 @@ CT_ExtractGit() {
     if [ -z "${ref}" ]; then
         ref_type=head
         ref=$(git rev-list -n1 HEAD)
-    elif git tag |grep -E "^${ref}$" >/dev/null 2>&1; then
+    elif git tag |${grep} -E "^${ref}$" >/dev/null 2>&1; then
         ref_type=tag
-    elif git branch -a --no-color |grep -E "^. ${ref}$" >/dev/null 2>&1; then
+    elif git branch -a --no-color |${grep} -E "^. ${ref}$" >/dev/null 2>&1; then
         ref_type=branch
     elif date -d "${ref}" >/dev/null 2>&1; then
         ref_type=date
@@ -1425,7 +1429,7 @@ CT_DoBuildTargetTuple() {
     # Sanity checks
     __sed_alias=""
     if [ -n "${CT_TARGET_ALIAS_SED_EXPR}" ]; then
-        __sed_alias=$(echo "${CT_TARGET}" |sed -r -e "${CT_TARGET_ALIAS_SED_EXPR}")
+        __sed_alias=$(echo "${CT_TARGET}" | ${sed_r} -e "${CT_TARGET_ALIAS_SED_EXPR}")
     fi
     case ":${CT_TARGET_VENDOR}:${CT_TARGET_ALIAS}:${__sed_alias}:" in
       :*" "*:*:*:) CT_Abort "Don't use spaces in the vendor string, it breaks things.";;
@@ -1498,7 +1502,7 @@ CT_DoTarballIfExists() {
         CT_DoLog DEBUG "  Saving '${dir}'"
         { tar c -C "${dir}" -v -f - "${extra_tar_opts[@]}" .    \
           |"${compress[@]}" >"${tarball}.tar${tar_ext}"         ;
-        } 2>&1 |sed -r -e 's/^/    /;' |CT_DoLog STATE
+        } 2>&1 | ${sed_r} -e 's/^/    /;' |CT_DoLog STATE
     else
         CT_DoLog STATE "  Not saving '${dir}': does not exist"
     fi
@@ -1525,7 +1529,7 @@ CT_DoExtractTarballIfExists() {
         CT_DoExecLog DEBUG mkdir -p "${dir}"
         { "${uncompress[@]}" "${tarball}.tar${tar_ext}"     \
           |tar x -C "${dir}" -v -f - "${extra_tar_opts[@]}" ;
-        } 2>&1 |sed -r -e 's/^/    /;' |CT_DoLog STATE
+        } 2>&1 | ${sed_r} -e 's/^/    /;' |CT_DoLog STATE
     else
         CT_DoLog STATE "  Not restoring '${dir}': does not exist"
     fi
@@ -1548,12 +1552,12 @@ CT_DoSaveState() {
     # We must omit shell functions, and some specific bash variables
     # that break when restoring the environment, later. We could do
     # all the processing in the awk script, but a sed is easier...
-    set |awk '
+    set |${awk} '
               BEGIN { _p = 1; }
               $0~/^[^ ]+ \(\)/ { _p = 0; }
               _p == 1
               $0 == "}" { _p = 1; }
-              ' |sed -r -e '/^BASH_(ARGC|ARGV|LINENO|SOURCE|VERSINFO)=/d;
+              ' | ${sed_r} -e '/^BASH_(ARGC|ARGV|LINENO|SOURCE|VERSINFO)=/d;
                            /^(UID|EUID)=/d;
                            /^(FUNCNAME|GROUPS|PPID|SHELLOPTS)=/d;' >"${state_dir}/env.sh"
 
@@ -1613,10 +1617,10 @@ CT_KconfigSetOption() {
     local value="$2"
     local file="$3"
 
-    grep -E -q "^${option}=.*" "${file}" && \
-        sed -i -r -e "s;^${option}=.*$;${option}=${value};" "${file}" || \
-    grep -E -q "^# ${option} is not set$" "${file}" && \
-        sed -i -r -e "s;^# ${option} is not set$;${option}=${value};" "${file}" || \
+    ${grep} -E -q "^${option}=.*" "${file}" && \
+        ${sed_r} -i -e "s;^${option}=.*$;${option}=${value};" "${file}" || \
+    ${grep} -E -q "^# ${option} is not set$" "${file}" && \
+        ${sed_r} -i -e "s;^# ${option} is not set$;${option}=${value};" "${file}" || \
     echo "${option}=${value}" >> "${file}"
 }
 
@@ -1635,9 +1639,9 @@ CT_KconfigDisableOption() {
     local option="${1}"
     local file="${2}"
 
-    grep -E -q "^# ${option} is not set$" "${file}" || \
-    grep -E -q "^${option}=.*$" "${file}" && \
-        sed -i -r -e "s;^${option}=.*$;# ${option} is not set;" "${file}" || \
+    ${grep} -E -q "^# ${option} is not set$" "${file}" || \
+    ${grep} -E -q "^${option}=.*$" "${file}" && \
+        ${sed_r} -i -e "s;^${option}=.*$;# ${option} is not set;" "${file}" || \
     echo "# ${option} is not set" >> "${file}"
 }
 
@@ -1648,10 +1652,10 @@ CT_KconfigDeleteOption() {
     local option="${1}"
     local file="${2}"
 
-    grep -E -q "^# ${option} is not set$" "${file}" && \
-        sed -i -r -e "/^# ${option} is not set$/d" "${file}" || \
-    grep -E -q "^${option}=.*$" "${file}" && \
-        sed -i -r -e "/^${option}=.*$/d" "${file}" || true
+    ${grep} -E -q "^# ${option} is not set$" "${file}" && \
+        ${sed_r} -i -e "/^# ${option} is not set$/d" "${file}" || \
+    ${grep} -E -q "^${option}=.*$" "${file}" && \
+        ${sed_r} -i -e "/^${option}=.*$/d" "${file}" || true
 }
 
 # Multilib iterator. The caller should be in a directory where the directories
@@ -1720,7 +1724,7 @@ CT_IterateMultilibs() {
         # We do supply original multi_os_dir for consumers that need to look inside
         # GCC's directories (e.g. to locate the libraries), under the name of
         # multi_os_dir_gcc.
-        multi_flags=$( echo "${multilib#*;}" | sed -r -e 's/@/ -/g;' )
+        multi_flags=$( echo "${multilib#*;}" | ${sed_r} -e 's/@/ -/g;' )
         multi_dir="${multilib%%;*}"
         multi_os_dir=$( "${CT_TARGET}-${CT_CC}" -print-multi-os-directory ${multi_flags} )
         multi_root=$( "${CT_TARGET}-${CT_CC}" -print-sysroot ${multi_flags} )
@@ -1740,7 +1744,7 @@ CT_IterateMultilibs() {
     # the architecture-specific functions.
     multi_index=1
     for multilib in "${multilibs[@]}"; do
-        multi_flags=$( echo "${multilib#*;}" | sed -r -e 's/@/ -/g;' )
+        multi_flags=$( echo "${multilib#*;}" | ${sed_r} -e 's/@/ -/g;' )
         multi_dir="${multilib%%;*}"
         multi_os_dir=$( "${CT_TARGET}-${CT_CC}" -print-multi-os-directory ${multi_flags} )
         multi_os_dir_gcc="${multi_os_dir}"

--- a/scripts/gen_in_frags.sh
+++ b/scripts/gen_in_frags.sh
@@ -65,18 +65,18 @@ gen_choice() {
     printf '\n'
     for entry in "${@}"; do
         file="${base_dir}/${entry}.in"
-        _entry=$(printf '%s\n' "${entry}" |"${sed}" -r -s -e 's/[-.+]/_/g;')
+        _entry=$(printf '%s\n' "${entry}" |${sed_r} -s -e 's/[-.+]/_/g;')
         printf 'config %s_%s\n' "${cfg_prefix}" "${_entry}"
         printf '    bool\n'
         printf '    prompt "%s"\n' "${entry}"
         if [ "${cond}" = "Y" -o "${cond}" = "y" ]; then
             printf '    depends on %s_%s_AVAILABLE\n' "${cfg_prefix}" "${_entry}"
         fi
-        "${sed}" -r -e '/^## depends on /!d; s/^## /    /;' ${file} 2>/dev/null
-        "${sed}" -r -e '/^## select /!d; s/^## /    /;' ${file} 2>/dev/null
-        if "${grep}" -E '^## help' ${file} >/dev/null 2>&1; then
+        ${sed_r} -e '/^## depends on /!d; s/^## /    /;' ${file} 2>/dev/null
+        ${sed_r} -e '/^## select /!d; s/^## /    /;' ${file} 2>/dev/null
+        if ${grep} -E '^## help' ${file} >/dev/null 2>&1; then
             printf '    help\n'
-            "${sed}" -r -e '/^## help ?/!d; s/^## help ?/      /;' ${file} 2>/dev/null
+            ${sed_r} -e '/^## help ?/!d; s/^## help ?/      /;' ${file} 2>/dev/null
         fi
         printf '\n'
     done
@@ -84,7 +84,7 @@ gen_choice() {
 
     for entry in "${@}"; do
         file="${base_dir}/${entry}.in"
-        _entry=$(printf '%s\n' "${entry}" |"${sed}" -r -s -e 's/[-.+]/_/g;')
+        _entry=$(printf '%s\n' "${entry}" |${sed_r} -s -e 's/[-.+]/_/g;')
         printf '\n'
         if [ "${cond}" = "Y" -o "${cond}" = "y" ]; then
             printf 'config %s_%s_AVAILABLE\n' "${cfg_prefix}" "${_entry}"
@@ -107,7 +107,7 @@ gen_choice() {
     printf '# Generated file, do not edit!!!\n'
     for entry in "${@}"; do
         file="${base_dir}/${entry}.in"
-        _entry=$(printf '%s\n' "${entry}" |"${sed}" -r -s -e 's/[-.+]/_/g;')
+        _entry=$(printf '%s\n' "${entry}" |${sed_r} -s -e 's/[-.+]/_/g;')
         if [ -f "${file}.2" ]; then
             printf '\n'
             printf 'if %s_%s\n' "${cfg_prefix}" "${_entry}"
@@ -135,18 +135,18 @@ gen_menu() {
     printf '\n'
     for entry in "${@}"; do
         file="${base_dir}/${entry}.in"
-        _entry=$(printf '%s\n' "${entry}" |"${sed}" -r -s -e 's/[-.+]/_/g;')
+        _entry=$(printf '%s\n' "${entry}" |${sed_r} -s -e 's/[-.+]/_/g;')
         printf 'menuconfig %s_%s\n' "${cfg_prefix}" "${_entry}"
         printf '    bool\n'
-        if "${grep}" -E '^## default' ${file} >/dev/null 2>&1; then
-            "${sed}" -r -e '/^## default ?/!d; s/^## default ?/    default /;' ${file} 2>/dev/null
+        if ${grep} -E '^## default' ${file} >/dev/null 2>&1; then
+            ${sed_r} -e '/^## default ?/!d; s/^## default ?/    default /;' ${file} 2>/dev/null
         fi
         printf '    prompt "%s"\n' "${entry}"
-        "${sed}" -r -e '/^## depends on /!d; s/^## /    /;' ${file} 2>/dev/null
-        "${sed}" -r -e '/^## select /!d; s/^## /    /;' ${file} 2>/dev/null
-        if "${grep}" -E '^## help' ${file} >/dev/null 2>&1; then
+        ${sed_r} -e '/^## depends on /!d; s/^## /    /;' ${file} 2>/dev/null
+        ${sed_r} -e '/^## select /!d; s/^## /    /;' ${file} 2>/dev/null
+        if ${grep} -E '^## help' ${file} >/dev/null 2>&1; then
             printf '    help\n'
-            "${sed}" -r -e '/^## help ?/!d; s/^## help ?/      /;' ${file} 2>/dev/null
+            ${sed_r} -e '/^## help ?/!d; s/^## help ?/      /;' ${file} 2>/dev/null
         fi
         printf '\n'
         printf 'if %s_%s\n' "${cfg_prefix}" "${_entry}"

--- a/scripts/patch-renumber.sh
+++ b/scripts/patch-renumber.sh
@@ -59,7 +59,7 @@ for p in "${src}/"*.patch*; do
     newname="$(printf "%03d-%s"                                     \
                       "${cpt}"                                      \
                       "$( basename "${p}"                           \
-                          |"${sed}" -r -e 's/^[[:digit:]]+[-_]//'   \
+                          |"${sed_r}" -e 's/^[[:digit:]]+[-_]//'   \
                                        -e "${sed_re}"               \
                         )"                                          \
               )"

--- a/scripts/populate.in
+++ b/scripts/populate.in
@@ -8,6 +8,7 @@ set -e
 install="@@CT_install@@"
 grep="@@CT_grep@@"
 sed="@@CT_sed@@"
+sed_r="@@CT_sed_r@@"
 awk="@@CT_awk@@"
 
 # Detect where the toolchain is:
@@ -25,8 +26,8 @@ CT_CFG_SYSROOT_DIR="$("${CT_GCC}" -v 2>&1                   \
                       |cut -d = -f 2-
                      )"
 CT_SYSROOT_DIR="$(printf "${CT_CFG_SYSROOT_DIR}\n"                              \
-                  |"${sed}" -r -e "s:^${CT_CFG_PREFIX_DIR}:${CT_PREFIX_DIR}:;"  \
-                  |"${sed}" -r -e 's,/+,/,g;'                                   \
+                  |"${sed_r}" -e "s:^${CT_CFG_PREFIX_DIR}:${CT_PREFIX_DIR}:;"  \
+                  |"${sed_r}" -e 's,/+,/,g;'                                   \
                  )"
 
 myname=$(basename "$0")
@@ -199,7 +200,7 @@ do_add_lib() {
             mkdir -p "${dir}"
             true_libname=$("${CT_READELF}" -d "${libfile}"          \
                            |"${grep}" "Library soname:"             \
-                           |"${sed}" -r -e 's,.+\[(.+)\] *$,\1,;'   \
+                           |"${sed_r}" -e 's,.+\[(.+)\] *$,\1,;'   \
                           )
             case "${libfile}" in
                 */ld*)  mode=0755;;
@@ -226,7 +227,7 @@ do_resolve_deps() {
     
     for libname in $("${CT_READELF}" -d "${file}"                           \
                      |"${grep}" -E '\(NEEDED\)[[:space:]]+Shared library:'  \
-                     |"${sed}" -r -e 's,.+\[(.+)\] *$,\1,;'                 \
+                     |"${sed_r}" -e 's,.+\[(.+)\] *$,\1,;'                 \
                     ); do
         [ -n "${libname}" ] || continue
         ${CT_PRINTF} "Searching for '%s' needed by '%s'\n" "${libname}" "${file}"
@@ -243,7 +244,7 @@ cd "${CT_ROOT_DST_DIR}"
 # First of, copy the forced libraries into the working copy
 lib_list=
 if [ -n "${CT_LIB_FILE}" ]; then
-    lib_list=$("${sed}" -r -e ':loop; s/#.*//;'         \
+    lib_list=$("${sed_r}" -e ':loop; s/#.*//;'         \
                            -e 's/[[:space:]]+//g;'      \
                            -e 's/([^:])$/\1:/;'         \
                            -e '/$/N; s/\n//; tloop;'    \
@@ -251,7 +252,7 @@ if [ -n "${CT_LIB_FILE}" ]; then
               )
 fi
 CT_LIB_LIST=$(printf "${CT_LIB_LIST}:${lib_list}\n"         \
-              |"${sed}" -r -e 's/^:+//; s/:+$//; s/:+/ /g;' \
+              |"${sed_r}" -e 's/^:+//; s/:+$//; s/:+/ /g;' \
              )
 if [ -n "${CT_LIB_LIST}" ]; then
     for name in ${CT_LIB_LIST}; do

--- a/scripts/saveSample.sh.in
+++ b/scripts/saveSample.sh.in
@@ -50,7 +50,7 @@ force_default_opts=( \
     )
 regexp=${force_default_opts[*]}
 regexp=${regexp// /|}
-grep -v -E '^(# )?CT_('"${regexp}"')' .config > .defconfig
+${grep} -v -E '^(# )?CT_('"${regexp}"')' .config > .defconfig
 
 # Function to copy a file to the sample directory
 # Needed in case the file is already there (think of a previously available sample)
@@ -75,7 +75,7 @@ fi
 if [ -n "${CT_LIBC_UCLIBC_CONFIG_FILE}" ]; then
     # We save the file, and then point the saved sample to this file
     CT_DoAddFileToSample "${CT_LIBC_UCLIBC_CONFIG_FILE}" "${samp_dir}/${CT_LIBC}-${CT_LIBC_VERSION}.config"
-    "${sed}" -r -i -e 's|^(CT_LIBC_UCLIBC_CONFIG_FILE)=.+$|\1="'"${samp_top_dir}"'/samples/${CT_TARGET}/${CT_LIBC}-${CT_LIBC_VERSION}.config"|;' \
+    "${sed_r}" -i -e 's|^(CT_LIBC_UCLIBC_CONFIG_FILE)=.+$|\1="'"${samp_top_dir}"'/samples/${CT_TARGET}/${CT_LIBC}-${CT_LIBC_VERSION}.config"|;' \
              .defconfig
 else
     # remove any dangling files
@@ -98,7 +98,7 @@ read -p "Reporter name [${reporter_name}]: " reporter_name
 read -p "Reporter URL [${reporter_url}]: " reporter_url
 if [ -n "${reporter_comment}" ]; then
   echo "Old comment:"
-  printf "${reporter_comment}\n" | ${sed} -r -e 's/^/  > /;'
+  printf "${reporter_comment}\n" | ${sed_r} -e 's/^/  > /;'
 fi
 echo "Reporter comment (Ctrl-D to finish, '.' to use previous):"
 reporter_comment=$(cat)

--- a/scripts/showSamples.sh
+++ b/scripts/showSamples.sh
@@ -129,7 +129,7 @@ dump_single_sample() {
                 ;;
             canadian)
                 printf "| ''"
-                printf "${sample}" |${sed} -r -e 's/.*,//'
+                printf "${sample}" |${sed_r} -e 's/.*,//'
                 printf "''  | ${CT_HOST}  "
                 ;;
             *)          ;;

--- a/scripts/xldd.in
+++ b/scripts/xldd.in
@@ -5,6 +5,7 @@ export LC_ALL=C
 version="@@CT_VERSION@@"
 bits="@@CT_BITS@@"
 sed="${SED:-@@CT_sed@@}"
+sed_r="${SED_R:-@@CT_sed_r@@}"
 grep="${GREP:-@@CT_grep@@}"
 
 my_name="$( basename "${0}" )"
@@ -159,7 +160,7 @@ fi
 sysroot="$( "${gcc}" -print-sysroot 2>/dev/null )"
 if [ -z "${sysroot}" ]; then
     sysroot="$( "${gcc}" -print-file-name=libc.so 2>/dev/null \
-                |${sed} -r -e 's:/usr/lib/libc.so$::;'        \
+                |${sed_r} -e 's:/usr/lib/libc.so$::;'        \
               )"
 fi
 if [ -z "${sysroot}" ]; then
@@ -259,7 +260,7 @@ do_process_file() {
     save_search_rpath=( "${search_rpath[@]}" )
     for n in $( "${readelf}" -d "${file}"                                           \
                 |"${grep}" -E '\((RPATH|RUNPATH)\)'                                 \
-                |"${sed}" -r -e 's/^.*Library r(|un)path:[[:space:]]+\[(.*)\]$/\2/;'\
+                |"${sed_r}" -e 's/^.*Library r(|un)path:[[:space:]]+\[(.*)\]$/\2/;'\
               ); do
         do_trace "-> adding rpath '%s'\n" "${n}"
         search_rpath+=( "${n}" )
@@ -272,7 +273,7 @@ do_process_file() {
 
     for n in $( "${readelf}" -d "${file}"                                               \
                 |"${grep}" -E '\(NEEDED\)'                                              \
-                |"${sed}" -r -e 's/^.*Shared library:[[:space:]]+\[([^]]+)\].*/\1/;'    \
+                |"${sed_r}" -e 's/^.*Shared library:[[:space:]]+\[([^]]+)\].*/\1/;'    \
               ); do
         found=0
         for m in "${needed_list[@]}"; do


### PR DESCRIPTION
... and then use the right option. See the note in scripts/functions
on where we should use ${foo} and where just 'foo'; this boils down to
whether we can expect the build tools override to be in effect (e.g. in
the actual build scripts) or not (i.e. outside of scripts/build).
While running in scripts/functions, or in scripts/crosstool-NG.sh the
build tools override directory (.build/tools/bin) may have not been
set up (yet, or at all).

Also, modify the installed scripts (populate, xldd) accordingly.

Signed-off-by: Alexey Neyman <stilor@att.net>