### PR TITLE
glibc 2.18 configure patch

### DIFF
--- a/patches/glibc/2.18/140-Add make 4.x to configure.patch
+++ b/patches/glibc/2.18/140-Add make 4.x to configure.patch
@@ -1,0 +1,11 @@
+--- configure_	2013-08-11 00:52:55.000000000 +0200
++++ configure	2017-02-14 16:47:20.000000000 +0100
+@@ -4772,7 +4772,7 @@
+   ac_prog_version=`$MAKE --version 2>&1 | sed -n 's/^.*GNU Make[^0-9]*\([0-9][0-9.]*\).*$/\1/p'`
+   case $ac_prog_version in
+     '') ac_prog_version="v. ?.??, bad"; ac_verc_fail=yes;;
+-    3.79* | 3.[89]*)
++    3.79* | 3.[89]* | 4*)
+        ac_prog_version="$ac_prog_version, ok"; ac_verc_fail=no;;
+     *) ac_prog_version="$ac_prog_version, bad"; ac_verc_fail=yes;;
+ 


### PR DESCRIPTION
./configure checks for make fail for version 4.x
This patch fixes that.

Have a nice day,
Jorge.