### PR TITLE
uClibc/glibc: add -fno-lto when making dummy shared libs

### DIFF
--- a/scripts/build/libc/glibc.sh
+++ b/scripts/build/libc/glibc.sh
@@ -431,6 +431,7 @@ do_libc_backend_once() {
                                            -nostartfiles              \
                                            -shared                    \
                                            -x c /dev/null             \
+                                           -fno-lto                   \
                                            -o "${startfiles_dir}/libc.so"
         fi # threads == nptl
     fi # libc_mode = startfiles

--- a/scripts/build/libc/uClibc.sh
+++ b/scripts/build/libc/uClibc.sh
@@ -197,7 +197,7 @@ do_libc_backend_once() {
             # libm.so is needed for ppc, as libgcc is linked against libm.so
             # No problem to create it for other archs.
             CT_DoLog EXTRA "Building dummy shared libs"
-            CT_DoExecLog ALL "${CT_TARGET}-${CT_CC}" -nostdlib -nostartfiles \
+            CT_DoExecLog ALL "${CT_TARGET}-${CT_CC}" -nostdlib -nostartfiles -fno-lto \
                 -shared ${multi_flags} -x c /dev/null -o libdummy.so
 
             CT_DoLog EXTRA "Installing start files"


### PR DESCRIPTION
Otherwise the build machine's lto plugin gets loaded and
that segfaults when processing your host machine's dummy
shared lib

Signed-off-by: Ray Donnelly <mingw.android@gmail.com>