### PR TITLE
Refine previous fix to uClibc verbosity setting

### DIFF
--- a/config/libc/uClibc.in
+++ b/config/libc/uClibc.in
@@ -151,22 +151,28 @@ config LIBC_UCLIBC_VERBOSITY_0
 
 config LIBC_UCLIBC_VERBOSITY_1
     bool
-    prompt "Very verbose build"
+    prompt "Brief build (show defines, ld flags)"
     help
       Print simplified command lines.
 
 config LIBC_UCLIBC_VERBOSITY_2
     bool
-    prompt "Brief build (show defines, ld flags)"
+    prompt "Very verbose build"
     help
       Print full command lines.
 
 endchoice
 
+# uClibc-ng has reverted the meaning of V=1 and V=2 compared to its
+# ancestor, uClibc, in order to match kernel's Kbuild settings.
+# Hence, for uClibc-ng supply V=2 if "brief build" is selected,
+# and so forth.
 config LIBC_UCLIBC_VERBOSITY
     string
     default ""      if LIBC_UCLIBC_VERBOSITY_0
+    default "V=2"   if LIBC_UCLIBC_VERBOSITY_1 && LIBC_UCLIBC_NG
     default "V=1"   if LIBC_UCLIBC_VERBOSITY_1
+    default "V=1"   if LIBC_UCLIBC_VERBOSITY_2 && LIBC_UCLIBC_NG
     default "V=2"   if LIBC_UCLIBC_VERBOSITY_2
 
 choice


### PR DESCRIPTION
The V={1,2} have opposite meaning in uClibc and uClibc-ng, reflect that.

Signed-off-by: Alexey Neyman <stilor@att.net>