### PR TITLE
Fix the build of elf2flt on Cygwin

### DIFF
--- a/patches/elf2flt/4820f0dbb77cd6564d5fa0817218fe2a1fb99f32/100-no-lcygwin.patch
+++ b/patches/elf2flt/4820f0dbb77cd6564d5fa0817218fe2a1fb99f32/100-no-lcygwin.patch
@@ -1,0 +1,81 @@
+diff -urpN elf2flt-4820f0dbb77cd6564d5fa0817218fe2a1fb99f32.orig/configure elf2flt-4820f0dbb77cd6564d5fa0817218fe2a1fb99f32/configure
+--- elf2flt-4820f0dbb77cd6564d5fa0817218fe2a1fb99f32.orig/configure	2017-02-21 22:04:05.914752800 -0800
++++ elf2flt-4820f0dbb77cd6564d5fa0817218fe2a1fb99f32/configure	2017-02-21 23:06:12.088166600 -0800
+@@ -3983,46 +3983,6 @@ case $target in
+ 		;;
+ esac
+ 
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for malloc in -lc" >&5
+-$as_echo_n "checking for malloc in -lc... " >&6; }
+-if ${ac_cv_lib_c_malloc+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  ac_check_lib_save_LIBS=$LIBS
+-LIBS="-lc  $LIBS"
+-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+-/* end confdefs.h.  */
+-
+-/* Override any GCC internal prototype to avoid an error.
+-   Use char because int might match the return type of a GCC
+-   builtin and then its argument prototype would still apply.  */
+-#ifdef __cplusplus
+-extern "C"
+-#endif
+-char malloc ();
+-int
+-main ()
+-{
+-return malloc ();
+-  ;
+-  return 0;
+-}
+-_ACEOF
+-if ac_fn_c_try_link "$LINENO"; then :
+-  ac_cv_lib_c_malloc=yes
+-else
+-  ac_cv_lib_c_malloc=no
+-fi
+-rm -f core conftest.err conftest.$ac_objext \
+-    conftest$ac_exeext conftest.$ac_ext
+-LIBS=$ac_check_lib_save_LIBS
+-fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_c_malloc" >&5
+-$as_echo "$ac_cv_lib_c_malloc" >&6; }
+-if test "x$ac_cv_lib_c_malloc" = xyes; then :
+-  LIBS="-lc $LIBS"
+-fi
+-
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for dlopen in -ldl" >&5
+ $as_echo_n "checking for dlopen in -ldl... " >&6; }
+ if ${ac_cv_lib_dl_dlopen+:} false; then :
+diff -urpN elf2flt-4820f0dbb77cd6564d5fa0817218fe2a1fb99f32.orig/configure.ac elf2flt-4820f0dbb77cd6564d5fa0817218fe2a1fb99f32/configure.ac
+--- elf2flt-4820f0dbb77cd6564d5fa0817218fe2a1fb99f32.orig/configure.ac	2017-02-21 22:04:05.915751600 -0800
++++ elf2flt-4820f0dbb77cd6564d5fa0817218fe2a1fb99f32/configure.ac	2017-02-21 23:06:07.431134300 -0800
+@@ -187,12 +187,6 @@ case $target in
+ 		;;
+ esac
+ 
+-dnl Make sure we resolve system symbols before libiberty/libbfd ones.
+-dnl Otherwise, things like getopt get screwed up because the system headers
+-dnl redirect some functions to the system symbols, but other local symbols
+-dnl come from libiberty/libbfd.
+-dnl int getopt(int, char * const [], const char *) __asm("_" "getopt" "$UNIX2003");
+-AC_CHECK_LIB(c, malloc, LIBS="-lc $LIBS")
+ AC_CHECK_LIB(dl, dlopen, LIBS="$LIBS -ldl")
+ 
+ dnl Checks for header files.
+diff -urpN elf2flt-4820f0dbb77cd6564d5fa0817218fe2a1fb99f32.orig/Makefile.in elf2flt-4820f0dbb77cd6564d5fa0817218fe2a1fb99f32/Makefile.in
+--- elf2flt-4820f0dbb77cd6564d5fa0817218fe2a1fb99f32.orig/Makefile.in	2017-02-21 22:04:05.939740400 -0800
++++ elf2flt-4820f0dbb77cd6564d5fa0817218fe2a1fb99f32/Makefile.in	2017-02-21 22:06:54.970169200 -0800
+@@ -38,11 +38,6 @@ ifneq (,$(findstring mingw32,$(HOST)))
+    LDLIBS += -lws2_32
+ endif
+ 
+-# force link order under cygwin to avoid getopts / libiberty clash
+-ifneq ($(strip $(shell gcc -v 2>&1 | grep "cygwin")),)
+-   LDLIBS := -lcygwin $(LDLIBS)
+-endif
+-
+ LDFILE= elf2flt.ld
+ ifeq ($(strip $(CPU)),e1)
+ SRC_LDFILE= $(srcdir)/$(CPU)-elf2flt.ld

--- a/scripts/build/binutils/binutils.sh
+++ b/scripts/build/binutils/binutils.sh
@@ -300,7 +300,6 @@ do_elf2flt_backend() {
     CT_DoExecLog CFG                                            \
     CFLAGS="${cflags}"                                          \
     LDFLAGS="${ldflags}"                                        \
-    LIBS="-ldl"                                                 \
     ${CONFIG_SHELL}                                             \
     "${CT_SRC_DIR}/elf2flt-${CT_ELF2FLT_VERSION}/configure"     \
         --build=${CT_BUILD}                                     \


### PR DESCRIPTION
The -lcygwin -lc actually breaks the build: elf2flt picks up the symbols for getopt/optarg via
<getopt.h> in binutils-X.Y/include, where optarg is declared without dllimport attribute.
Therefore it pulls in getopt() from libc/libcygwin, but since optarg is not prefixed with
_imp__, it is pulled from libiberty. But the object file in libiberty also contains getopt()
thus resulting in multiple definitions thereof.

While there, kill extraneous -ldl passed into configure - configure detects -ldl successfully.

Signed-off-by: Alexey Neyman <stilor@att.net>