### PR TITLE
Require xz to be present

### DIFF
--- a/config/debug/strace.in
+++ b/config/debug/strace.in
@@ -11,66 +11,55 @@ choice
 config STRACE_V_4_16
     bool
     prompt "4.16"
-    depends on CONFIGURE_has_xz
 
 config STRACE_V_4_15
     bool
     prompt "4.15"
-    depends on CONFIGURE_has_xz
 
 config STRACE_V_4_14
     bool
     prompt "4.14 (OBSOLETE)"
     depends on OBSOLETE
-    depends on CONFIGURE_has_xz
 
 config STRACE_V_4_13
     bool
     prompt "4.13 (OBSOLETE)"
     depends on OBSOLETE
-    depends on CONFIGURE_has_xz
 
 config STRACE_V_4_12
     bool
     prompt "4.12 (OBSOLETE)"
     depends on OBSOLETE
-    depends on CONFIGURE_has_xz
 
 config STRACE_V_4_11
     bool
     prompt "4.11 (OBSOLETE)"
     depends on OBSOLETE
-    depends on CONFIGURE_has_xz
 
 config STRACE_V_4_10
     bool
     prompt "4.10 (OBSOLETE)"
     depends on OBSOLETE
-    depends on CONFIGURE_has_xz
 
 config STRACE_V_4_9
     bool
     prompt "4.9 (OBSOLETE)"
     depends on OBSOLETE
-    depends on CONFIGURE_has_xz
 
 config STRACE_V_4_8
     bool
     prompt "4.8 (OBSOLETE)"
     depends on OBSOLETE
-    depends on CONFIGURE_has_xz
 
 config STRACE_V_4_7
     bool
     prompt "4.7 (OBSOLETE)"
     depends on OBSOLETE
-    depends on CONFIGURE_has_xz
 
 config STRACE_V_4_6
     bool
     prompt "4.6 (OBSOLETE)"
     depends on OBSOLETE
-    depends on CONFIGURE_has_xz
 
 config STRACE_V_4_5_20
     bool

--- a/configure.ac
+++ b/configure.ac
@@ -214,6 +214,7 @@ ACX_CHECK_PROGS_REQ([readlink], [readlink])
 ACX_CHECK_PROGS_REQ([tar], [tar])
 ACX_CHECK_PROGS_REQ([gzip], [gzip])
 ACX_CHECK_PROGS_REQ([bzip2], [bzip2])
+ACX_CHECK_PROGS_REQ([xz], [xz])
 ACX_CHECK_PROGS_REQ([help2man], [help2man])
 
 # Not a fatal failure even if we have neither - the tarballs may
@@ -346,14 +347,6 @@ AC_SUBST([GPERF_LEN_TYPE])
 # Boring again... But still a bit of work to do...
 #--------------------------------------------------------------------
 AC_SUBST([kconfig_options])
-
-#----------------------------------------
-AC_CHECK_PROGS([xz],   [xz])
-ACX_SET_KCONFIG_OPTION([xz])
-AS_IF(
-    [test -z "$xz"],
-    [AC_CHECK_PROGS([lzma], [lzma])])
-ACX_SET_KCONFIG_OPTION([lzma])
 
 #----------------------------------------
 AC_CHECK_PROGS([cvs], [cvs])

--- a/scripts/functions
+++ b/scripts/functions
@@ -618,13 +618,8 @@ CT_SetLibPath() {
 # Build up the list of allowed tarball extensions
 # Add them in the prefered order; most preferred comes first
 CT_DoListTarballExt() {
-    if [ "${CT_CONFIGURE_has_xz}" = "y" ]; then
-        printf ".tar.xz\n"
-    fi
-    if [    "${CT_CONFIGURE_has_lzma}" = "y"    \
-         -o "${CT_CONFIGURE_has_xz}" = "y" ]; then
-        printf ".tar.lzma\n"
-    fi
+    printf ".tar.xz\n"
+    printf ".tar.lzma\n"
     printf ".tar.bz2\n"
     printf ".tar.gz\n.tgz\n"
     printf ".tar\n"
@@ -1085,7 +1080,6 @@ CT_Extract() {
     local nochdir="$1"
     local basename
     local ext
-    local lzma_prog
     local -a tar_opts
 
     if [ "${nochdir}" = "nochdir" ]; then
@@ -1128,19 +1122,9 @@ CT_Extract() {
     tar_opts+=( "-C" "${basename}" )
     tar_opts+=( "-xv" )
 
-    # One note here:
-    # - lzma can be handled either with 'xz' or 'lzma'
-    # - we get lzma tarball only if either or both are available
-    # - so, if we get an lzma tarball, and either 'xz' or 'lzma' is
-    #   missing, we can assume the other is available
-    if [ "${CT_CONFIGURE_has_lzma}" = "y" ]; then
-        lzma_prog="lzma -fdc"
-    else
-        lzma_prog="xz -fdc"
-    fi
     case "${ext}" in
         .tar.xz)      xz -fdc "${full_file}" | CT_DoExecLog FILE tar "${tar_opts[@]}" -f -;;
-        .tar.lzma)    ${lzma_prog} "${full_file}" | CT_DoExecLog FILE tar "${tar_opts[@]}" -f -;;
+        .tar.lzma)    xz -fdc "${full_file}" | CT_DoExecLog FILE tar "${tar_opts[@]}" -f -;;
         .tar.bz2)     bzip2 -dc "${full_file}" | CT_DoExecLog FILE tar "${tar_opts[@]}" -f -;;
         .tar.gz|.tgz) gzip -dc "${full_file}" | CT_DoExecLog FILE tar "${tar_opts[@]}" -f -;;
         .tar)         CT_DoExecLog FILE tar "${tar_opts[@]}" -f "${full_file}";;


### PR DESCRIPTION
Some software starts to adopt xz-only distribution (strace,
gcc-linaro, ...). Better that than deal with cryptic errors like
"cannot find strace-.tar.bz2".

Signed-off-by: Alexey Neyman <stilor@att.net>