### PR TITLE
Backport the fix from 2.19 for cross-rpcgen on macos

### DIFF
--- a/patches/glibc/2.12.1/300-macos-cross-rpcgen.patch
+++ b/patches/glibc/2.12.1/300-macos-cross-rpcgen.patch
@@ -1,0 +1,32 @@
+commit ae7080d30c68cfa0c81ce3422dca948f64a94f50
+Author: Jia Liu <proljc@gmail.com>
+Date:   Sat Sep 7 00:01:08 2013 +0800
+
+    sunrpc/rpc/types.h: fix OS X and FreeBSD build problems
+    
+    When I build arm-linux-gcc on OS X, I find glibc will get a build error
+    in sunrpc/rpc/types.h, so I add __APPLE_CC__ to make OS X build OK.
+    For FreeBSD, Add __FreeBSD__ to make it build OK, too.
+    
+    URL: http://sourceware.org/ml/libc-alpha/2013-09/msg00155.html
+    URL: http://sourceware.org/ml/libc-alpha/2013-09/msg00217.html
+    URL: http://sourceware.org/ml/libc-alpha/2013-09/msg00240.html
+    Signed-off-by: Jia Liu <proljc@gmail.com>
+    Signed-off-by: Mike Frysinger <vapier@gentoo.org>
+
+diff --git a/sunrpc/rpc/types.h b/sunrpc/rpc/types.h
+index 3dca5c4..beded52 100644
+--- a/sunrpc/rpc/types.h
++++ b/sunrpc/rpc/types.h
+@@ -69,6 +69,11 @@ typedef unsigned long rpcport_t;
+ #include <sys/types.h>
+ #endif
+ 
++#if defined __APPLE_CC__ || defined __FreeBSD__
++# define __u_char_defined
++# define __daddr_t_defined
++#endif
++
+ #ifndef __u_char_defined
+ typedef __u_char u_char;
+ typedef __u_short u_short;

--- a/patches/glibc/2.12.2/300-macos-cross-rpcgen.patch
+++ b/patches/glibc/2.12.2/300-macos-cross-rpcgen.patch
@@ -1,0 +1,32 @@
+commit ae7080d30c68cfa0c81ce3422dca948f64a94f50
+Author: Jia Liu <proljc@gmail.com>
+Date:   Sat Sep 7 00:01:08 2013 +0800
+
+    sunrpc/rpc/types.h: fix OS X and FreeBSD build problems
+    
+    When I build arm-linux-gcc on OS X, I find glibc will get a build error
+    in sunrpc/rpc/types.h, so I add __APPLE_CC__ to make OS X build OK.
+    For FreeBSD, Add __FreeBSD__ to make it build OK, too.
+    
+    URL: http://sourceware.org/ml/libc-alpha/2013-09/msg00155.html
+    URL: http://sourceware.org/ml/libc-alpha/2013-09/msg00217.html
+    URL: http://sourceware.org/ml/libc-alpha/2013-09/msg00240.html
+    Signed-off-by: Jia Liu <proljc@gmail.com>
+    Signed-off-by: Mike Frysinger <vapier@gentoo.org>
+
+diff --git a/sunrpc/rpc/types.h b/sunrpc/rpc/types.h
+index 3dca5c4..beded52 100644
+--- a/sunrpc/rpc/types.h
++++ b/sunrpc/rpc/types.h
+@@ -69,6 +69,11 @@ typedef unsigned long rpcport_t;
+ #include <sys/types.h>
+ #endif
+ 
++#if defined __APPLE_CC__ || defined __FreeBSD__
++# define __u_char_defined
++# define __daddr_t_defined
++#endif
++
+ #ifndef __u_char_defined
+ typedef __u_char u_char;
+ typedef __u_short u_short;

--- a/patches/glibc/2.13/300-macos-cross-rpcgen.patch
+++ b/patches/glibc/2.13/300-macos-cross-rpcgen.patch
@@ -1,0 +1,32 @@
+commit ae7080d30c68cfa0c81ce3422dca948f64a94f50
+Author: Jia Liu <proljc@gmail.com>
+Date:   Sat Sep 7 00:01:08 2013 +0800
+
+    sunrpc/rpc/types.h: fix OS X and FreeBSD build problems
+    
+    When I build arm-linux-gcc on OS X, I find glibc will get a build error
+    in sunrpc/rpc/types.h, so I add __APPLE_CC__ to make OS X build OK.
+    For FreeBSD, Add __FreeBSD__ to make it build OK, too.
+    
+    URL: http://sourceware.org/ml/libc-alpha/2013-09/msg00155.html
+    URL: http://sourceware.org/ml/libc-alpha/2013-09/msg00217.html
+    URL: http://sourceware.org/ml/libc-alpha/2013-09/msg00240.html
+    Signed-off-by: Jia Liu <proljc@gmail.com>
+    Signed-off-by: Mike Frysinger <vapier@gentoo.org>
+
+diff --git a/sunrpc/rpc/types.h b/sunrpc/rpc/types.h
+index 3dca5c4..beded52 100644
+--- a/sunrpc/rpc/types.h
++++ b/sunrpc/rpc/types.h
+@@ -69,6 +69,11 @@ typedef unsigned long rpcport_t;
+ #include <sys/types.h>
+ #endif
+ 
++#if defined __APPLE_CC__ || defined __FreeBSD__
++# define __u_char_defined
++# define __daddr_t_defined
++#endif
++
+ #ifndef __u_char_defined
+ typedef __u_char u_char;
+ typedef __u_short u_short;

--- a/patches/glibc/2.14.1/300-macos-cross-rpcgen.patch
+++ b/patches/glibc/2.14.1/300-macos-cross-rpcgen.patch
@@ -1,0 +1,32 @@
+commit ae7080d30c68cfa0c81ce3422dca948f64a94f50
+Author: Jia Liu <proljc@gmail.com>
+Date:   Sat Sep 7 00:01:08 2013 +0800
+
+    sunrpc/rpc/types.h: fix OS X and FreeBSD build problems
+    
+    When I build arm-linux-gcc on OS X, I find glibc will get a build error
+    in sunrpc/rpc/types.h, so I add __APPLE_CC__ to make OS X build OK.
+    For FreeBSD, Add __FreeBSD__ to make it build OK, too.
+    
+    URL: http://sourceware.org/ml/libc-alpha/2013-09/msg00155.html
+    URL: http://sourceware.org/ml/libc-alpha/2013-09/msg00217.html
+    URL: http://sourceware.org/ml/libc-alpha/2013-09/msg00240.html
+    Signed-off-by: Jia Liu <proljc@gmail.com>
+    Signed-off-by: Mike Frysinger <vapier@gentoo.org>
+
+diff --git a/sunrpc/rpc/types.h b/sunrpc/rpc/types.h
+index 3dca5c4..beded52 100644
+--- a/sunrpc/rpc/types.h
++++ b/sunrpc/rpc/types.h
+@@ -69,6 +69,11 @@ typedef unsigned long rpcport_t;
+ #include <sys/types.h>
+ #endif
+ 
++#if defined __APPLE_CC__ || defined __FreeBSD__
++# define __u_char_defined
++# define __daddr_t_defined
++#endif
++
+ #ifndef __u_char_defined
+ typedef __u_char u_char;
+ typedef __u_short u_short;

--- a/patches/glibc/2.14/300-macos-cross-rpcgen.patch
+++ b/patches/glibc/2.14/300-macos-cross-rpcgen.patch
@@ -1,0 +1,32 @@
+commit ae7080d30c68cfa0c81ce3422dca948f64a94f50
+Author: Jia Liu <proljc@gmail.com>
+Date:   Sat Sep 7 00:01:08 2013 +0800
+
+    sunrpc/rpc/types.h: fix OS X and FreeBSD build problems
+    
+    When I build arm-linux-gcc on OS X, I find glibc will get a build error
+    in sunrpc/rpc/types.h, so I add __APPLE_CC__ to make OS X build OK.
+    For FreeBSD, Add __FreeBSD__ to make it build OK, too.
+    
+    URL: http://sourceware.org/ml/libc-alpha/2013-09/msg00155.html
+    URL: http://sourceware.org/ml/libc-alpha/2013-09/msg00217.html
+    URL: http://sourceware.org/ml/libc-alpha/2013-09/msg00240.html
+    Signed-off-by: Jia Liu <proljc@gmail.com>
+    Signed-off-by: Mike Frysinger <vapier@gentoo.org>
+
+diff --git a/sunrpc/rpc/types.h b/sunrpc/rpc/types.h
+index 3dca5c4..beded52 100644
+--- a/sunrpc/rpc/types.h
++++ b/sunrpc/rpc/types.h
+@@ -69,6 +69,11 @@ typedef unsigned long rpcport_t;
+ #include <sys/types.h>
+ #endif
+ 
++#if defined __APPLE_CC__ || defined __FreeBSD__
++# define __u_char_defined
++# define __daddr_t_defined
++#endif
++
+ #ifndef __u_char_defined
+ typedef __u_char u_char;
+ typedef __u_short u_short;

--- a/patches/glibc/2.15/300-macos-cross-rpcgen.patch
+++ b/patches/glibc/2.15/300-macos-cross-rpcgen.patch
@@ -1,0 +1,32 @@
+commit ae7080d30c68cfa0c81ce3422dca948f64a94f50
+Author: Jia Liu <proljc@gmail.com>
+Date:   Sat Sep 7 00:01:08 2013 +0800
+
+    sunrpc/rpc/types.h: fix OS X and FreeBSD build problems
+    
+    When I build arm-linux-gcc on OS X, I find glibc will get a build error
+    in sunrpc/rpc/types.h, so I add __APPLE_CC__ to make OS X build OK.
+    For FreeBSD, Add __FreeBSD__ to make it build OK, too.
+    
+    URL: http://sourceware.org/ml/libc-alpha/2013-09/msg00155.html
+    URL: http://sourceware.org/ml/libc-alpha/2013-09/msg00217.html
+    URL: http://sourceware.org/ml/libc-alpha/2013-09/msg00240.html
+    Signed-off-by: Jia Liu <proljc@gmail.com>
+    Signed-off-by: Mike Frysinger <vapier@gentoo.org>
+
+diff --git a/sunrpc/rpc/types.h b/sunrpc/rpc/types.h
+index 3dca5c4..beded52 100644
+--- a/sunrpc/rpc/types.h
++++ b/sunrpc/rpc/types.h
+@@ -69,6 +69,11 @@ typedef unsigned long rpcport_t;
+ #include <sys/types.h>
+ #endif
+ 
++#if defined __APPLE_CC__ || defined __FreeBSD__
++# define __u_char_defined
++# define __daddr_t_defined
++#endif
++
+ #ifndef __u_char_defined
+ typedef __u_char u_char;
+ typedef __u_short u_short;

--- a/patches/glibc/2.16.0/300-macos-cross-rpcgen.patch
+++ b/patches/glibc/2.16.0/300-macos-cross-rpcgen.patch
@@ -1,0 +1,32 @@
+commit ae7080d30c68cfa0c81ce3422dca948f64a94f50
+Author: Jia Liu <proljc@gmail.com>
+Date:   Sat Sep 7 00:01:08 2013 +0800
+
+    sunrpc/rpc/types.h: fix OS X and FreeBSD build problems
+    
+    When I build arm-linux-gcc on OS X, I find glibc will get a build error
+    in sunrpc/rpc/types.h, so I add __APPLE_CC__ to make OS X build OK.
+    For FreeBSD, Add __FreeBSD__ to make it build OK, too.
+    
+    URL: http://sourceware.org/ml/libc-alpha/2013-09/msg00155.html
+    URL: http://sourceware.org/ml/libc-alpha/2013-09/msg00217.html
+    URL: http://sourceware.org/ml/libc-alpha/2013-09/msg00240.html
+    Signed-off-by: Jia Liu <proljc@gmail.com>
+    Signed-off-by: Mike Frysinger <vapier@gentoo.org>
+
+diff --git a/sunrpc/rpc/types.h b/sunrpc/rpc/types.h
+index 3dca5c4..beded52 100644
+--- a/sunrpc/rpc/types.h
++++ b/sunrpc/rpc/types.h
+@@ -69,6 +69,11 @@ typedef unsigned long rpcport_t;
+ #include <sys/types.h>
+ #endif
+ 
++#if defined __APPLE_CC__ || defined __FreeBSD__
++# define __u_char_defined
++# define __daddr_t_defined
++#endif
++
+ #ifndef __u_char_defined
+ typedef __u_char u_char;
+ typedef __u_short u_short;

--- a/patches/glibc/2.17/300-macos-cross-rpcgen.patch
+++ b/patches/glibc/2.17/300-macos-cross-rpcgen.patch
@@ -1,0 +1,32 @@
+commit ae7080d30c68cfa0c81ce3422dca948f64a94f50
+Author: Jia Liu <proljc@gmail.com>
+Date:   Sat Sep 7 00:01:08 2013 +0800
+
+    sunrpc/rpc/types.h: fix OS X and FreeBSD build problems
+    
+    When I build arm-linux-gcc on OS X, I find glibc will get a build error
+    in sunrpc/rpc/types.h, so I add __APPLE_CC__ to make OS X build OK.
+    For FreeBSD, Add __FreeBSD__ to make it build OK, too.
+    
+    URL: http://sourceware.org/ml/libc-alpha/2013-09/msg00155.html
+    URL: http://sourceware.org/ml/libc-alpha/2013-09/msg00217.html
+    URL: http://sourceware.org/ml/libc-alpha/2013-09/msg00240.html
+    Signed-off-by: Jia Liu <proljc@gmail.com>
+    Signed-off-by: Mike Frysinger <vapier@gentoo.org>
+
+diff --git a/sunrpc/rpc/types.h b/sunrpc/rpc/types.h
+index 3dca5c4..beded52 100644
+--- a/sunrpc/rpc/types.h
++++ b/sunrpc/rpc/types.h
+@@ -69,6 +69,11 @@ typedef unsigned long rpcport_t;
+ #include <sys/types.h>
+ #endif
+ 
++#if defined __APPLE_CC__ || defined __FreeBSD__
++# define __u_char_defined
++# define __daddr_t_defined
++#endif
++
+ #ifndef __u_char_defined
+ typedef __u_char u_char;
+ typedef __u_short u_short;

--- a/patches/glibc/2.18/300-macos-cross-rpcgen.patch
+++ b/patches/glibc/2.18/300-macos-cross-rpcgen.patch
@@ -1,0 +1,32 @@
+commit ae7080d30c68cfa0c81ce3422dca948f64a94f50
+Author: Jia Liu <proljc@gmail.com>
+Date:   Sat Sep 7 00:01:08 2013 +0800
+
+    sunrpc/rpc/types.h: fix OS X and FreeBSD build problems
+    
+    When I build arm-linux-gcc on OS X, I find glibc will get a build error
+    in sunrpc/rpc/types.h, so I add __APPLE_CC__ to make OS X build OK.
+    For FreeBSD, Add __FreeBSD__ to make it build OK, too.
+    
+    URL: http://sourceware.org/ml/libc-alpha/2013-09/msg00155.html
+    URL: http://sourceware.org/ml/libc-alpha/2013-09/msg00217.html
+    URL: http://sourceware.org/ml/libc-alpha/2013-09/msg00240.html
+    Signed-off-by: Jia Liu <proljc@gmail.com>
+    Signed-off-by: Mike Frysinger <vapier@gentoo.org>
+
+diff --git a/sunrpc/rpc/types.h b/sunrpc/rpc/types.h
+index 3dca5c4..beded52 100644
+--- a/sunrpc/rpc/types.h
++++ b/sunrpc/rpc/types.h
+@@ -69,6 +69,11 @@ typedef unsigned long rpcport_t;
+ #include <sys/types.h>
+ #endif
+ 
++#if defined __APPLE_CC__ || defined __FreeBSD__
++# define __u_char_defined
++# define __daddr_t_defined
++#endif
++
+ #ifndef __u_char_defined
+ typedef __u_char u_char;
+ typedef __u_short u_short;


### PR DESCRIPTION
Signed-off-by: Alexey Neyman <stilor@att.net>