### PR TITLE
Fix unifdef in Linux 2.6.32 on macos

### DIFF
--- a/patches/linux/2.6.32.27/100-unifdef-strclpy.patch
+++ b/patches/linux/2.6.32.27/100-unifdef-strclpy.patch
@@ -1,0 +1,11 @@
+--- linux-2.6.32.27/scripts/unifdef.c.orig	2017-03-08 21:42:27.000000000 -0800
++++ linux-2.6.32.27/scripts/unifdef.c	2017-03-08 21:42:44.000000000 -0800
+@@ -72,8 +72,6 @@
+ #include <string.h>
+ #include <unistd.h>
+ 
+-size_t strlcpy(char *dst, const char *src, size_t siz);
+-
+ /* types of input lines: */
+ typedef enum {
+ 	LT_TRUEI,		/* a true #if with ignore flag */


### PR DESCRIPTION
... which fails to compile due to incompatible prototype for strlcpy()
which isn't even used.

2.6.33 dropped the prototype, so the patch is n/a for newer kernels.

Signed-off-by: Alexey Neyman <stilor@att.net>