### PR TITLE
Disable Guile in make if building for host in canadian

### DIFF
--- a/scripts/build/companion_tools/050-make.sh
+++ b/scripts/build/companion_tools/050-make.sh
@@ -46,10 +46,15 @@ do_make_backend() {
     local prefix
     local cflags
     local ldflags
+    local -a extra_config
 
     for arg in "$@"; do
         eval "${arg// /\\ }"
     done
+
+    if [ "${host}" != "${CT_BUILD}" ]; then
+        extra_config+=( --without-guile )
+    fi
 
     CT_DoLog EXTRA "Configuring make"
     CT_DoExecLog CFG \
@@ -58,7 +63,8 @@ do_make_backend() {
                      ${CONFIG_SHELL} \
                      "${CT_SRC_DIR}/make-${CT_MAKE_VERSION}/configure" \
                      --host="${host}" \
-                     --prefix="${prefix}"
+                     --prefix="${prefix}" \
+		     "${extra_config[@]}"
 
     CT_DoLog EXTRA "Building make"
     CT_DoExecLog ALL make


### PR DESCRIPTION
make's configure uses pkg-config to detect if Guile should be enabled;
on ArchLinux, this picks up Guile from build machine's pkg-config and then
it fails to compile.

A better solution might be to create a ${CT_HOST}-pkg-config in
buildtools/bin that would report "unsupported" for all packages.
However a quick grep only showed pkg-config being used by GCJ
(not sure if it will build in canadian cross - we don't have any
samples with GCJ) and Blackfin simulator in GDB (Blackfin is not
currently supported by crosstool-ng). Hence, leave such pkg-config
implementation and testing for another day.

Signed-off-by: Alexey Neyman <stilor@att.net>