### PR TITLE
Make creation of ld.so.conf optional

### DIFF
--- a/config/libc.in
+++ b/config/libc.in
@@ -87,6 +87,26 @@ config THREADS_NONE
 
 endchoice
 
+config CREATE_LDSO_CONF
+    bool "Create /etc/ld.so.conf file"
+    depends on SHARED_LIBS
+    default y if MULTILIB
+    help
+      Create /etc/ld.so.conf file in the sysroot directory for the
+      target.
+
+      Note that Buildroot errors out if it sees /etc/ld.so.conf.
+
+config LDSO_CONF_EXTRA_DIRS_ARRAY
+    string "Extra directories to add to /etc/ld.so.conf
+    depends on CREATE_LDSO_CONF
+    help
+      Extra directories to include in /etc/ld.so.conf. The directories
+      will be augmented per compiler's multilib specification,
+      if applicable. For example, if the compiler's multilibs include
+      /lib and /lib64, and you specify /usr/local/lib here, ld.so.conf
+      will have both /usr/local/lib and /usr/local/lib64.
+
 config LIBC_XLDD
     bool
     prompt "Install a cross ldd-like helper"

--- a/scripts/build/internals.sh
+++ b/scripts/build/internals.sh
@@ -10,7 +10,7 @@ create_ldso_conf()
     done
 
     CT_DoExecLog ALL mkdir -p "${multi_root}/etc"
-    for b in /lib /usr/lib /usr/local/lib; do
+    for b in /lib /usr/lib "${CT_LDSO_CONF_EXTRA_DIRS_ARRAY[@]}"; do
         d="${b}/${multi_os_dir}"
         CT_SanitizeVarDir d
         echo "${d}" >> "${multi_root}/etc/ld.so.conf"
@@ -34,7 +34,7 @@ do_finish() {
 
     CT_DoStep INFO "Finalizing the toolchain's directory"
 
-    if [ "${CT_SHARED_LIBS}" = "y" ]; then
+    if [ "${CT_CREATE_LDSO_CONF}" = "y" ]; then
         # Create /etc/ld.so.conf
         CT_mkdir_pushd "${CT_BUILD_DIR}/build-create-ldso"
         CT_IterateMultilibs create_ldso_conf create-ldso


### PR DESCRIPTION
... enabled by default for multilib and disabled otherwise. Buildroot
has been complaining about /etc/ld.so.conf presence for almost a year
now and I missed that.

After the release, xldd will be modified to query the compiler for
the list of multilibs to search. This would be too invasive change
before 1.23, though.

Note that it may lead to configurations where xldd currently does not
find the libraries (if both DEMULTILIB and CREATE_LDSO_CONF are turned
off). This is not the default setting in Kconfig, though.

Signed-off-by: Alexey Neyman <stilor@att.net>