### PR TITLE
Force C preprocessor to toolchain cpp

### DIFF
--- a/scripts/build/libc/glibc.sh
+++ b/scripts/build/libc/glibc.sh
@@ -323,6 +323,7 @@ do_libc_backend_once() {
     CT_DoExecLog CFG                                                \
     BUILD_CC=${CT_BUILD}-gcc                                        \
     CC="${CT_TARGET}-${CT_CC} ${glibc_cflags}"                      \
+    CPP="${CT_TARGET}-cpp"                                          \
     AR=${CT_TARGET}-ar                                              \
     RANLIB=${CT_TARGET}-ranlib                                      \
     "${CONFIG_SHELL}"                                               \


### PR DESCRIPTION
For multilib builds on hosts without cpp installed as cpp, only the
first glibc build completed successfully. Force the use of the
newly built target cpp for all multilib targets.

On systems with gcc installed in the way glibc expects (ie most Linux systems), it eventually falls back to /lib/cpp, and configure continues and eventually succeeds. If it isn't installed, configure fails once the real <sysroot>/usr/include/bits/stubs is installed.