### PR TITLE
Remove explicit core passes selection for multilib

### DIFF
--- a/config/target.in
+++ b/config/target.in
@@ -36,7 +36,6 @@ config ARCH_REQUIRES_MULTILIB
 config MULTILIB
     bool
     prompt "Build a multilib toolchain (READ HELP!!!)"
-    select CC_CORE_PASS_1_NEEDED
     help
       If you say 'y' here, then the toolchain will also contain the C library
       optimised for some variants of the selected architecture, besides the


### PR DESCRIPTION
It is only used if this libc flavor uses a multilib iterator (and not
determines the multilibs itself). This class currently includes glibc,
uClibc, musl - but they explicitly select CC_CORE_PASSES_NEEDED anyway.

Signed-off-by: Alexey Neyman <stilor@att.net>