### PR TITLE
cross-gdb: account for canadian/crossnative toolchains

### DIFF
--- a/config/cc/gcc.in.2
+++ b/config/cc/gcc.in.2
@@ -66,8 +66,9 @@ config CC_GCC_STATIC_LIBSTDCXX
     bool
     prompt "Link libstdc++ statically into the gcc binary"
     default y
-    depends on CONFIGURE_has_static_link
-    select WANTS_STATIC_LINK
+    depends on CONFIGURE_has_static_link || CANADIAN || CROSS_NATIVE
+    select WANTS_STATIC_LINK if CROSS || NATIVE
+    select WANTS_STATIC_LINK_CXX if CROSS || NATIVE
     help
       Newer gcc versions require some c++ libraries. So statically
       linking libstdc++ increases the likeliness that the gcc binary will

--- a/config/debug/gdb.in.cross
+++ b/config/debug/gdb.in.cross
@@ -17,8 +17,8 @@ if GDB_CROSS
 config GDB_CROSS_STATIC
     bool
     prompt "Build a static cross gdb"
-    depends on CONFIGURE_has_static_link
-    select WANTS_STATIC_LINK
+    depends on CONFIGURE_has_static_link || CROSS_NATIVE || CANADIAN
+    select WANTS_STATIC_LINK if NATIVE || CROSS
     help
       A static cross gdb can be useful if you debug on a machine that is
       not the one that is used to compile the toolchain.
@@ -38,8 +38,8 @@ config GDB_CROSS_PYTHON
     bool
     prompt "Enable python scripting"
     depends on GDB_HAS_PYTHON
-    depends on ! GDB_CROSS_STATIC
-    default y
+    depends on !GDB_CROSS_STATIC
+    default y if !CROSS_NATIVE && !CANADIAN
     help
       Say 'y' if you want to use Python scripting inside gdb.
       Say 'n' if you do not want to.

--- a/config/toolchain.in
+++ b/config/toolchain.in
@@ -47,14 +47,18 @@ config SYSROOT_DIR_PREFIX
       In fact, the sysroot path is constructed as:
         ${CT_PREFIX_DIR}/${CT_TARGET}/${CT_SYSROOT_DIR_PREFIX}/${CT_SYSROOT_NAME}
 
+# FIXME: the name is misleading, it is only checking if we want the build machine
+# to support static linking.
 config WANTS_STATIC_LINK
+    bool
+config WANTS_STATIC_LINK_CXX
     bool
 
 config STATIC_TOOLCHAIN
     bool
     prompt "Build Static Toolchain"
     depends on CONFIGURE_has_static_link
-    select WANTS_STATIC_LINK
+    select WANTS_STATIC_LINK if NATIVE || CROSS
     help
       Build static host binaries.
       

--- a/scripts/crosstool-NG.sh.in
+++ b/scripts/crosstool-NG.sh.in
@@ -563,18 +563,18 @@ if [ -z "${CT_RESTART}" ]; then
     rm -f "${gccout}"
     CT_EndStep
 
+    # These tests are only enabled if we need static linking on the *build*
     if [ "${CT_WANTS_STATIC_LINK}" = "y" ]; then
         CT_DoStep DEBUG "Checking that gcc can compile a trivial statically linked program (CT_WANTS_STATIC_LINK)"
         CT_DoLog DEBUG "You may need to ensure that static libraries such as libc.a are installed on your system"
-        CT_DoExecLog DEBUG "${CT_HOST}-gcc" ${CT_CFLAGS_FOR_HOST} ${CT_LDFLAGS_FOR_HOST} "${testc}" -static -o "${gccout}"
+        CT_DoExecLog DEBUG "${CT_HOST}-gcc" ${CT_CFLAGS_FOR_BUILD} ${CT_LDFLAGS_FOR_BUILD} "${testc}" -static -o "${gccout}"
         rm -f "${gccout}"
         CT_EndStep
     fi
-
-    if [ "${CT_CC_GCC_STATIC_LIBSTDCXX}" = "y" ]; then
-        CT_DoStep DEBUG "Checking that gcc can statically link libstdc++ (CT_CC_GCC_STATIC_LIBSTDCXX)"
+    if [ "${CT_WANTS_STATIC_LINK_CXX}" = "y" ]; then
+        CT_DoStep DEBUG "Checking that gcc can statically link libstdc++ (CT_WANTS_STATIC_LINK_CXX)"
         CT_DoLog DEBUG "You may need to ensure that libstdc++.a is installed on your system"
-        CT_DoExecLog DEBUG "${CT_HOST}-gcc" ${CT_CFLAGS_FOR_HOST} ${CT_LDFLAGS_FOR_HOST} "${testc}" -static -lstdc++ -o "${gccout}"
+        CT_DoExecLog DEBUG "${CT_HOST}-gcc" ${CT_CFLAGS_FOR_BUILD} ${CT_LDFLAGS_FOR_BUILD} "${testc}" -static -lstdc++ -o "${gccout}"
         rm -f "${gccout}"
         CT_EndStep
     fi


### PR DESCRIPTION
... when determining if it can be linked statically, and if Python
scripting should default to y.

Prompted by a failure of i686-w64-mingw32,nios2-spico-elf sample
on a system where configure didn't report static linking support.

A similar issue was then found in gcc configuration, fixed as well.

Signed-off-by: Alexey Neyman <stilor@att.net>