### PR TITLE
Fix symlinking to multiarch tools on Cygwin

### DIFF
--- a/scripts/build/binutils/binutils.sh
+++ b/scripts/build/binutils/binutils.sh
@@ -82,7 +82,6 @@ do_binutils_for_build() {
 
 # Build binutils for host -> target
 do_binutils_for_host() {
-    local -a binutils_tools
     local -a binutils_opts
 
     CT_DoStep INFO "Installing binutils for host"
@@ -118,26 +117,13 @@ do_binutils_for_host() {
     # are not executable on the build machine.
     case "${CT_TOOLCHAIN_TYPE}" in
         cross|native)
-            binutils_tools=( ar as ld ranlib strip )
-            if [ -n "${CT_ARCH_BINFMT_FLAT}" ]; then
-                binutils_tools+=( elf2flt flthdr )
-            fi
-            case "${CT_BINUTILS_LINKERS_LIST}" in
-                ld)         binutils_tools+=( ld.bfd ) ;;
-                gold)       binutils_tools+=( ld.gold ) ;;
-                ld,gold)    binutils_tools+=( ld.bfd ld.gold ) ;;
-                gold,ld)    binutils_tools+=( ld.bfd ld.gold ) ;;
-            esac
-            mkdir -p "${CT_BUILDTOOLS_PREFIX_DIR}/${CT_TARGET}/bin"
             mkdir -p "${CT_BUILDTOOLS_PREFIX_DIR}/bin"
-            for t in "${binutils_tools[@]}"; do
-                CT_DoExecLog ALL ln -sv                                         \
-                                    "${CT_PREFIX_DIR}/${CT_TARGET}/bin/${t}"    \
-                                    "${CT_BUILDTOOLS_PREFIX_DIR}/${CT_TARGET}/bin/${t}"
-                CT_DoExecLog ALL ln -sv                                         \
-                                    "${CT_PREFIX_DIR}/bin/${CT_TARGET}-${t}"    \
-                                    "${CT_BUILDTOOLS_PREFIX_DIR}/bin/${CT_TARGET}-${t}"
-            done
+            CT_SymlinkTools "${CT_BUILDTOOLS_PREFIX_DIR}/bin" \
+                "${CT_PREFIX_DIR}/bin" \
+                "${CT_TARGET}"
+            CT_DoExecLog ALL mkdir -p "${CT_BUILDTOOLS_PREFIX_DIR}/${CT_TARGET}"
+            CT_DoExecLog ALL ln -sv "${CT_PREFIX_DIR}/${CT_TARGET}/bin" \
+                "${CT_BUILDTOOLS_PREFIX_DIR}/${CT_TARGET}/bin"
             ;;
         *)  ;;
     esac

--- a/scripts/functions
+++ b/scripts/functions
@@ -1784,7 +1784,11 @@ CT_SymlinkTools()
 
     CT_Pushd "${srcdir}"
     for t in "${CT_TARGET}-"*; do
-        if [ -n "${newpfx}" -a "${newpfx}" != "${CT_TARGET}" ]; then
+        if [ "${t}" = "${CT_TARGET}-*" ]; then
+            # No matching files
+            break
+        fi
+        if [ "${newpfx}" != "${CT_TARGET}" -o "${bindir}" != "${srcdir}" ]; then
             _t="${newpfx}-${t#${CT_TARGET}-}"
             CT_DoExecLog ALL ln -sfv "${dirpfx}${t}" "${bindir}/${_t}"
         fi


### PR DESCRIPTION
On cygwin, creating both "foo.exe" and "foo" results in 'ln -sf'
returning an error ("File exists"). However, ln silently removes
the "foo.exe" in this case, so an attempt to re-run the same command
manually then succeeds.

Hence, make binutils.sh also create symlinks with .exe prefix,
using the new & shiny routine.

Signed-off-by: Alexey Neyman <stilor@att.net>