### PR TITLE
MinGW: add --enable-secure-api config option

### DIFF
--- a/config/libc/mingw.in
+++ b/config/libc/mingw.in
@@ -128,6 +128,10 @@ config WINAPI_VERSION
     help
       Enter the version number of the Windows API files to use
 
+config MINGW_SECURE_API
+    bool "Expose secure API prototypes"
+    default y
+
 config MINGW_DIRECTX
     bool "Include DirectX development files"
 

--- a/scripts/build/libc/mingw.sh
+++ b/scripts/build/libc/mingw.sh
@@ -40,6 +40,11 @@ do_libc_start_files() {
         :)      ;;
     esac
 
+    case "${CT_MINGW_SECURE_API}" in
+        :y)     sdk_opts+=( "--enable-secure-api"  );;
+        :)      ;;
+    esac
+
     CT_mkdir_pushd "${CT_BUILD_DIR}/build-mingw-w64-headers"
 
     CT_DoLog EXTRA "Configuring Headers"


### PR DESCRIPTION
Without this flag, MinGW does not expose secure variants of functions
such as strcpy_s.

See https://sourceforge.net/p/mingw-w64/mingw-w64/ci/master/tree/mingw-w64-headers/crt/sec_api/string_s.h#l11.