### PR TITLE
Sort out newlib patches

### DIFF
--- a/patches/newlib/1.17.0/110-fix-eabihf.patch
+++ b/patches/newlib/1.17.0/110-fix-eabihf.patch
@@ -1,0 +1,24 @@
+diff -urpN newlib-1.17.0.orig/libgloss/arm/configure newlib-1.17.0/libgloss/arm/configure
+--- newlib-1.17.0.orig/libgloss/arm/configure	2017-04-11 00:41:23.720866007 -0700
++++ newlib-1.17.0/libgloss/arm/configure	2017-04-11 00:43:12.265788484 -0700
+@@ -2540,7 +2540,7 @@ test "${CCASFLAGS+set}" = set || CCASFLA
+ 
+ 
+ case "${target}" in
+-  *-*-elf | *-*-eabi)
++  *-*-elf | *-*-eabi*)
+ 	objtype=elf-
+ 	;;
+   *-*-coff)
+diff -urpN newlib-1.17.0.orig/libgloss/arm/configure.in newlib-1.17.0/libgloss/arm/configure.in
+--- newlib-1.17.0.orig/libgloss/arm/configure.in	2017-04-11 00:41:23.720866007 -0700
++++ newlib-1.17.0/libgloss/arm/configure.in	2017-04-11 00:43:12.265788484 -0700
+@@ -49,7 +49,7 @@ AC_PROG_RANLIB
+ LIB_AM_PROG_AS
+ 
+ case "${target}" in
+-  *-*-elf | *-*-eabi)
++  *-*-elf | *-*-eabi*)
+ 	objtype=elf-
+ 	;;
+   *-*-coff)

--- a/patches/newlib/1.17.0/200-fix-mt-cflags.patch
+++ b/patches/newlib/1.17.0/200-fix-mt-cflags.patch
@@ -1,0 +1,26 @@
+diff -urpN newlib-1.17.0.orig/config/mt-d30v newlib-1.17.0/config/mt-d30v
+--- newlib-1.17.0.orig/config/mt-d30v	2017-04-11 00:51:26.572757941 -0700
++++ newlib-1.17.0/config/mt-d30v	2017-04-11 00:55:51.110626527 -0700
+@@ -1,4 +1,4 @@
+ # Build libraries optimizing for space, not speed.
+ # Turn off warnings about symbols named the same as registers
+- CFLAGS_FOR_TARGET = -g -Os -Wa,-C
+- CXXFLAGS_FOR_TARGET = -g -Os -Wa,-C
++ CFLAGS_FOR_TARGET += -g -Os -Wa,-C
++ CXXFLAGS_FOR_TARGET += -g -Os -Wa,-C
+diff -urpN newlib-1.17.0.orig/config/mt-gnu newlib-1.17.0/config/mt-gnu
+--- newlib-1.17.0.orig/config/mt-gnu	2017-04-11 00:51:26.572757941 -0700
++++ newlib-1.17.0/config/mt-gnu	2017-04-11 00:55:51.110626527 -0700
+@@ -1,2 +1,2 @@
+-CXXFLAGS_FOR_TARGET = $(CXXFLAGS) $(SYSROOT_CFLAGS_FOR_TARGET) \
++CXXFLAGS_FOR_TARGET += $(CXXFLAGS) $(SYSROOT_CFLAGS_FOR_TARGET) \
+ 	$(DEBUG_PREFIX_CFLAGS_FOR_TARGET) -D_GNU_SOURCE
+diff -urpN newlib-1.17.0.orig/config/mt-ospace newlib-1.17.0/config/mt-ospace
+--- newlib-1.17.0.orig/config/mt-ospace	2017-04-11 00:51:26.572757941 -0700
++++ newlib-1.17.0/config/mt-ospace	2017-04-11 00:55:51.110626527 -0700
+@@ -1,3 +1,3 @@
+ # Build libraries optimizing for space, not speed.
+- CFLAGS_FOR_TARGET = -g -Os
+- CXXFLAGS_FOR_TARGET = -g -Os
++ CFLAGS_FOR_TARGET += -g -Os
++ CXXFLAGS_FOR_TARGET += -g -Os

--- a/patches/newlib/1.17.0/999-fix-arm-build.patch
+++ b/patches/newlib/1.17.0/999-fix-arm-build.patch
@@ -1,0 +1,62 @@
+diff -urpN newlib-1.17.0.orig/libgloss/arm/linux-syscalls0.S newlib-1.17.0/libgloss/arm/linux-syscalls0.S
+--- newlib-1.17.0.orig/libgloss/arm/linux-syscalls0.S	2017-04-10 23:18:30.559142019 -0700
++++ newlib-1.17.0/libgloss/arm/linux-syscalls0.S	2017-04-10 23:35:06.422568832 -0700
+@@ -19,47 +19,6 @@
+ #define GLOBAL(name) .global name; FUNC(name)
+ #define SIZE(name) .size name, .-name
+ 
+-#if __thumb__
+-
+-# define SYSCALL0(name) \
+-	GLOBAL(_ ## name); \
+-	mov r12, r7; \
+-	mov r7, #SYS_ ## name; \
+-	swi; \
+-	mov r7, r12; \
+-	b _set_errno; \
+-	SIZE(_ ## name)
+-
+-/* static int _syscall3(int a, int b, int c, int number); */
+-FUNC(_syscall3)
+-	push { r7 }
+-	mov r7, r3
+-	swi
+-	pop { r7 }
+-	b _set_errno
+-	SIZE(_syscall3)
+-
+-# define SYSCALL3(name) \
+-	GLOBAL(_ ## name); \
+-	mov r3, #SYS_ ## name; \
+-	b _syscall3; \
+-	SIZE(_ ## name)
+-
+-# define SYSCALL6(name) \
+-	GLOBAL(_ ## name); \
+-	push { r4 - r5, r7 }; \
+-	ldr r4, [sp, #12]; \
+-	ldr r5, [sp, #16]; \
+-	mov r7, #SYS_ ## name; \
+-	swi; \
+-	pop { r4 - r5, r7 }; \
+-	b _set_errno; \
+-	SIZE(_ ## name)
+-
+-# define SYSCALL4(name) SYSCALL6(name)
+-
+-#else /* __thumb__ */
+-
+ # define SYSCALL4(name) \
+ 	GLOBAL(_ ## name); \
+ 	swi #SYS_ ## name; \
+@@ -78,9 +37,6 @@ FUNC(_syscall3)
+ 
+ #define SYSCALL0(name) SYSCALL3(name)
+ #define SYSCALL3(name) SYSCALL4(name)
+-
+-#endif /* __thumb__ */
+-
+ #define SYSCALL1(name) SYSCALL3(name)
+ #define SYSCALL2(name) SYSCALL3(name)
+ #define SYSCALL5(name) SYSCALL6(name)
+Binary files newlib-1.17.0.orig/libgloss/arm/.linux-syscalls0.S.swp and newlib-1.17.0/libgloss/arm/.linux-syscalls0.S.swp differ

--- a/patches/newlib/1.18.0/110-fix-eabihf.patch
+++ b/patches/newlib/1.18.0/110-fix-eabihf.patch
@@ -1,0 +1,24 @@
+diff -urpN newlib-1.18.0.orig/libgloss/arm/configure newlib-1.18.0/libgloss/arm/configure
+--- newlib-1.18.0.orig/libgloss/arm/configure	2017-04-11 00:41:23.864867229 -0700
++++ newlib-1.18.0/libgloss/arm/configure	2017-04-11 00:43:12.273788551 -0700
+@@ -2540,7 +2540,7 @@ test "${CCASFLAGS+set}" = set || CCASFLA
+ 
+ 
+ case "${target}" in
+-  *-*-elf | *-*-eabi)
++  *-*-elf | *-*-eabi*)
+ 	objtype=elf-
+ 	;;
+   *-*-coff)
+diff -urpN newlib-1.18.0.orig/libgloss/arm/configure.in newlib-1.18.0/libgloss/arm/configure.in
+--- newlib-1.18.0.orig/libgloss/arm/configure.in	2017-04-11 00:41:23.864867229 -0700
++++ newlib-1.18.0/libgloss/arm/configure.in	2017-04-11 00:43:12.273788551 -0700
+@@ -49,7 +49,7 @@ AC_PROG_RANLIB
+ LIB_AM_PROG_AS
+ 
+ case "${target}" in
+-  *-*-elf | *-*-eabi)
++  *-*-elf | *-*-eabi*)
+ 	objtype=elf-
+ 	;;
+   *-*-coff)

--- a/patches/newlib/1.18.0/200-fix-mt-cflags.patch
+++ b/patches/newlib/1.18.0/200-fix-mt-cflags.patch
@@ -1,0 +1,25 @@
+diff -urpN newlib-1.18.0.orig/config/mt-d30v newlib-1.18.0/config/mt-d30v
+--- newlib-1.18.0.orig/config/mt-d30v	2017-04-11 00:51:26.740759083 -0700
++++ newlib-1.18.0/config/mt-d30v	2017-04-11 00:55:51.114626557 -0700
+@@ -1,4 +1,4 @@
+ # Build libraries optimizing for space, not speed.
+ # Turn off warnings about symbols named the same as registers
+- CFLAGS_FOR_TARGET = -g -Os -Wa,-C
+- CXXFLAGS_FOR_TARGET = -g -Os -Wa,-C
++ CFLAGS_FOR_TARGET += -g -Os -Wa,-C
++ CXXFLAGS_FOR_TARGET += -g -Os -Wa,-C
+diff -urpN newlib-1.18.0.orig/config/mt-gnu newlib-1.18.0/config/mt-gnu
+--- newlib-1.18.0.orig/config/mt-gnu	2017-04-11 00:51:26.740759083 -0700
++++ newlib-1.18.0/config/mt-gnu	2017-04-11 00:55:51.114626557 -0700
+@@ -1 +1 @@
+-CXXFLAGS_FOR_TARGET = $(CXXFLAGS) -D_GNU_SOURCE
++CXXFLAGS_FOR_TARGET += $(CXXFLAGS) -D_GNU_SOURCE
+diff -urpN newlib-1.18.0.orig/config/mt-ospace newlib-1.18.0/config/mt-ospace
+--- newlib-1.18.0.orig/config/mt-ospace	2017-04-11 00:51:26.740759083 -0700
++++ newlib-1.18.0/config/mt-ospace	2017-04-11 00:55:51.114626557 -0700
+@@ -1,3 +1,3 @@
+ # Build libraries optimizing for space, not speed.
+- CFLAGS_FOR_TARGET = -g -Os
+- CXXFLAGS_FOR_TARGET = -g -Os
++ CFLAGS_FOR_TARGET += -g -Os
++ CXXFLAGS_FOR_TARGET += -g -Os

--- a/patches/newlib/1.19.0/110-fix-eabihf.patch
+++ b/patches/newlib/1.19.0/110-fix-eabihf.patch
@@ -1,0 +1,24 @@
+diff -urpN newlib-1.19.0.orig/libgloss/arm/configure newlib-1.19.0/libgloss/arm/configure
+--- newlib-1.19.0.orig/libgloss/arm/configure	2017-04-11 00:41:24.072868994 -0700
++++ newlib-1.19.0/libgloss/arm/configure	2017-04-11 00:43:12.281788619 -0700
+@@ -2540,7 +2540,7 @@ test "${CCASFLAGS+set}" = set || CCASFLA
+ 
+ 
+ case "${target}" in
+-  *-*-elf | *-*-eabi)
++  *-*-elf | *-*-eabi*)
+ 	objtype=elf-
+ 	;;
+   *-*-coff)
+diff -urpN newlib-1.19.0.orig/libgloss/arm/configure.in newlib-1.19.0/libgloss/arm/configure.in
+--- newlib-1.19.0.orig/libgloss/arm/configure.in	2017-04-11 00:41:24.072868994 -0700
++++ newlib-1.19.0/libgloss/arm/configure.in	2017-04-11 00:43:12.281788619 -0700
+@@ -49,7 +49,7 @@ AC_PROG_RANLIB
+ LIB_AM_PROG_AS
+ 
+ case "${target}" in
+-  *-*-elf | *-*-eabi)
++  *-*-elf | *-*-eabi*)
+ 	objtype=elf-
+ 	;;
+   *-*-coff)

--- a/patches/newlib/1.19.0/200-fix-mt-cflags.patch
+++ b/patches/newlib/1.19.0/200-fix-mt-cflags.patch
@@ -1,0 +1,25 @@
+diff -urpN newlib-1.19.0.orig/config/mt-d30v newlib-1.19.0/config/mt-d30v
+--- newlib-1.19.0.orig/config/mt-d30v	2017-04-11 00:51:26.912760252 -0700
++++ newlib-1.19.0/config/mt-d30v	2017-04-11 00:55:51.118626585 -0700
+@@ -1,4 +1,4 @@
+ # Build libraries optimizing for space, not speed.
+ # Turn off warnings about symbols named the same as registers
+- CFLAGS_FOR_TARGET = -g -Os -Wa,-C
+- CXXFLAGS_FOR_TARGET = -g -Os -Wa,-C
++ CFLAGS_FOR_TARGET += -g -Os -Wa,-C
++ CXXFLAGS_FOR_TARGET += -g -Os -Wa,-C
+diff -urpN newlib-1.19.0.orig/config/mt-gnu newlib-1.19.0/config/mt-gnu
+--- newlib-1.19.0.orig/config/mt-gnu	2017-04-11 00:51:26.912760252 -0700
++++ newlib-1.19.0/config/mt-gnu	2017-04-11 00:55:51.118626585 -0700
+@@ -1 +1 @@
+-CXXFLAGS_FOR_TARGET = $(CXXFLAGS) -D_GNU_SOURCE
++CXXFLAGS_FOR_TARGET += $(CXXFLAGS) -D_GNU_SOURCE
+diff -urpN newlib-1.19.0.orig/config/mt-ospace newlib-1.19.0/config/mt-ospace
+--- newlib-1.19.0.orig/config/mt-ospace	2017-04-11 00:51:26.912760252 -0700
++++ newlib-1.19.0/config/mt-ospace	2017-04-11 00:55:51.118626585 -0700
+@@ -1,3 +1,3 @@
+ # Build libraries optimizing for space, not speed.
+- CFLAGS_FOR_TARGET = -g -Os
+- CXXFLAGS_FOR_TARGET = -g -Os
++ CFLAGS_FOR_TARGET += -g -Os
++ CXXFLAGS_FOR_TARGET += -g -Os

--- a/patches/newlib/1.20.0/110-fix-eabihf.patch
+++ b/patches/newlib/1.20.0/110-fix-eabihf.patch
@@ -1,12 +1,24 @@
-diff -ur newlib-1.20.0.orig/libgloss/arm/configure.in newlib-1.20.0/libgloss/arm/configure.in
---- newlib-1.20.0.orig/libgloss/arm/configure.in    2006-05-10 22:51:40.000000000 +0200
-+++ newlib-1.20.0/libgloss/arm/configure.in 2015-01-04 15:27:41.471549917 +0100
-@@ -49,7 +49,7 @@
- LIB_AM_PROG_AS
-
+diff -urpN newlib-1.20.0.orig/libgloss/arm/configure newlib-1.20.0/libgloss/arm/configure
+--- newlib-1.20.0.orig/libgloss/arm/configure	2017-04-11 00:41:24.120869401 -0700
++++ newlib-1.20.0/libgloss/arm/configure	2017-04-11 00:43:12.289788688 -0700
+@@ -2540,7 +2540,7 @@ test "${CCASFLAGS+set}" = set || CCASFLA
+ 
+ 
  case "${target}" in
 -  *-*-elf | *-*-eabi)
 +  *-*-elf | *-*-eabi*)
-    objtype=elf-
-    ;;
+ 	objtype=elf-
+ 	;;
+   *-*-coff)
+diff -urpN newlib-1.20.0.orig/libgloss/arm/configure.in newlib-1.20.0/libgloss/arm/configure.in
+--- newlib-1.20.0.orig/libgloss/arm/configure.in	2017-04-11 00:41:24.120869401 -0700
++++ newlib-1.20.0/libgloss/arm/configure.in	2017-04-11 00:43:12.289788688 -0700
+@@ -49,7 +49,7 @@ AC_PROG_RANLIB
+ LIB_AM_PROG_AS
+ 
+ case "${target}" in
+-  *-*-elf | *-*-eabi)
++  *-*-elf | *-*-eabi*)
+ 	objtype=elf-
+ 	;;
    *-*-coff)

--- a/patches/newlib/1.20.0/200-fix-mt-cflags.patch
+++ b/patches/newlib/1.20.0/200-fix-mt-cflags.patch
@@ -1,0 +1,25 @@
+diff -urpN newlib-1.20.0.orig/config/mt-d30v newlib-1.20.0/config/mt-d30v
+--- newlib-1.20.0.orig/config/mt-d30v	2017-04-11 00:51:27.080761393 -0700
++++ newlib-1.20.0/config/mt-d30v	2017-04-11 00:55:51.122626615 -0700
+@@ -1,4 +1,4 @@
+ # Build libraries optimizing for space, not speed.
+ # Turn off warnings about symbols named the same as registers
+- CFLAGS_FOR_TARGET = -g -Os -Wa,-C
+- CXXFLAGS_FOR_TARGET = -g -Os -Wa,-C
++ CFLAGS_FOR_TARGET += -g -Os -Wa,-C
++ CXXFLAGS_FOR_TARGET += -g -Os -Wa,-C
+diff -urpN newlib-1.20.0.orig/config/mt-gnu newlib-1.20.0/config/mt-gnu
+--- newlib-1.20.0.orig/config/mt-gnu	2017-04-11 00:51:27.080761393 -0700
++++ newlib-1.20.0/config/mt-gnu	2017-04-11 00:55:51.122626615 -0700
+@@ -1 +1 @@
+-CXXFLAGS_FOR_TARGET = $(CXXFLAGS) -D_GNU_SOURCE
++CXXFLAGS_FOR_TARGET += $(CXXFLAGS) -D_GNU_SOURCE
+diff -urpN newlib-1.20.0.orig/config/mt-ospace newlib-1.20.0/config/mt-ospace
+--- newlib-1.20.0.orig/config/mt-ospace	2017-04-11 00:51:27.080761393 -0700
++++ newlib-1.20.0/config/mt-ospace	2017-04-11 00:55:51.122626615 -0700
+@@ -1,3 +1,3 @@
+ # Build libraries optimizing for space, not speed.
+- CFLAGS_FOR_TARGET = -g -Os
+- CXXFLAGS_FOR_TARGET = -g -Os
++ CFLAGS_FOR_TARGET += -g -Os
++ CXXFLAGS_FOR_TARGET += -g -Os

--- a/patches/newlib/2.0.0/100-fix-optimising-for-space.patch
+++ b/patches/newlib/2.0.0/100-fix-optimising-for-space.patch
@@ -1,8 +1,0 @@
---- newlib-2.0.0/config/mt-ospace-orig	2014-11-13 12:02:45.463578281 +0000
-+++ newlib-2.0.0/config/mt-ospace	2014-11-13 12:03:01.409592374 +0000
-@@ -1,3 +1,3 @@
- # Build libraries optimizing for space, not speed.
-- CFLAGS_FOR_TARGET = -g -Os
-- CXXFLAGS_FOR_TARGET = -g -Os
-+ CFLAGS_FOR_TARGET += -g -Os
-+ CXXFLAGS_FOR_TARGET += -g -Os

--- a/patches/newlib/2.0.0/100-fix-unaligned-access-memcpy-m68k.patch
+++ b/patches/newlib/2.0.0/100-fix-unaligned-access-memcpy-m68k.patch
@@ -1,0 +1,27 @@
+The m68k mcpu processor does not like unaligned access
+
+Disable at least mcpu32, m68010 and m68020. These processors certainly
+do not like unaligned accesses.
+
+Signed-off-by: Remy Bohmer <linux@bohmer.net>
+[yann.morin.1998@anciens.enib.fr: update for 1.19.0 from 1.18.0]
+Signed-off-by: "Yann E. MORIN" <yann.morin.1998@anciens.enib.fr>
+[austinpmorton@gmail.com: update for 1.20.0 from 1.19.0]
+Signed-off-by: Austin Morton <austinpmorton@gmail.com>
+---
+ newlib/libc/machine/m68k/memcpy.S |    2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+Index: newlib-1.20.0/newlib/libc/machine/m68k/memcpy.S
+===================================================================
+--- newlib-1.20.0.orig/newlib/libc/machine/m68k/memcpy.S
++++ newlib-1.20.0/newlib/libc/machine/m68k/memcpy.S
+@@ -15,7 +15,7 @@
+ 
+ #include "m68kasm.h"
+ 
+-#if defined (__mcoldfire__) || defined (__mc68010__) || defined (__mc68020__) || defined (__mc68030__) || defined (__mc68040__) || defined (__mc68060__)
++#if defined (__mcoldfire__) || defined (__mc68030__) || defined (__mc68040__) || defined (__mc68060__)
+ # define MISALIGNED_OK 1
+ #else
+ # define MISALIGNED_OK 0

--- a/patches/newlib/2.0.0/110-fix-eabihf.patch
+++ b/patches/newlib/2.0.0/110-fix-eabihf.patch
@@ -1,0 +1,24 @@
+diff -urpN newlib-2.0.0.orig/libgloss/arm/configure newlib-2.0.0/libgloss/arm/configure
+--- newlib-2.0.0.orig/libgloss/arm/configure	2017-04-11 00:41:24.304870963 -0700
++++ newlib-2.0.0/libgloss/arm/configure	2017-04-11 00:43:12.297788756 -0700
+@@ -2540,7 +2540,7 @@ test "${CCASFLAGS+set}" = set || CCASFLA
+ 
+ 
+ case "${target}" in
+-  *-*-elf | *-*-eabi)
++  *-*-elf | *-*-eabi*)
+ 	objtype=elf-
+ 	;;
+   *-*-coff)
+diff -urpN newlib-2.0.0.orig/libgloss/arm/configure.in newlib-2.0.0/libgloss/arm/configure.in
+--- newlib-2.0.0.orig/libgloss/arm/configure.in	2017-04-11 00:41:24.304870963 -0700
++++ newlib-2.0.0/libgloss/arm/configure.in	2017-04-11 00:43:12.297788756 -0700
+@@ -49,7 +49,7 @@ AC_PROG_RANLIB
+ LIB_AM_PROG_AS
+ 
+ case "${target}" in
+-  *-*-elf | *-*-eabi)
++  *-*-elf | *-*-eabi*)
+ 	objtype=elf-
+ 	;;
+   *-*-coff)

--- a/patches/newlib/2.0.0/200-fix-mt-cflags.patch
+++ b/patches/newlib/2.0.0/200-fix-mt-cflags.patch
@@ -1,0 +1,25 @@
+diff -urpN newlib-2.0.0.orig/config/mt-d30v newlib-2.0.0/config/mt-d30v
+--- newlib-2.0.0.orig/config/mt-d30v	2017-04-11 00:51:27.256762590 -0700
++++ newlib-2.0.0/config/mt-d30v	2017-04-11 00:55:51.126626644 -0700
+@@ -1,4 +1,4 @@
+ # Build libraries optimizing for space, not speed.
+ # Turn off warnings about symbols named the same as registers
+- CFLAGS_FOR_TARGET = -g -Os -Wa,-C
+- CXXFLAGS_FOR_TARGET = -g -Os -Wa,-C
++ CFLAGS_FOR_TARGET += -g -Os -Wa,-C
++ CXXFLAGS_FOR_TARGET += -g -Os -Wa,-C
+diff -urpN newlib-2.0.0.orig/config/mt-gnu newlib-2.0.0/config/mt-gnu
+--- newlib-2.0.0.orig/config/mt-gnu	2017-04-11 00:51:27.256762590 -0700
++++ newlib-2.0.0/config/mt-gnu	2017-04-11 00:55:51.126626644 -0700
+@@ -1 +1 @@
+-CXXFLAGS_FOR_TARGET = $(CXXFLAGS) -D_GNU_SOURCE
++CXXFLAGS_FOR_TARGET += $(CXXFLAGS) -D_GNU_SOURCE
+diff -urpN newlib-2.0.0.orig/config/mt-ospace newlib-2.0.0/config/mt-ospace
+--- newlib-2.0.0.orig/config/mt-ospace	2017-04-11 00:51:27.256762590 -0700
++++ newlib-2.0.0/config/mt-ospace	2017-04-11 00:55:51.126626644 -0700
+@@ -1,3 +1,3 @@
+ # Build libraries optimizing for space, not speed.
+- CFLAGS_FOR_TARGET = -g -Os
+- CXXFLAGS_FOR_TARGET = -g -Os
++ CFLAGS_FOR_TARGET += -g -Os
++ CXXFLAGS_FOR_TARGET += -g -Os

--- a/patches/newlib/2.1.0/100-fix-optimising-for-space.patch
+++ b/patches/newlib/2.1.0/100-fix-optimising-for-space.patch
@@ -1,8 +1,0 @@
---- newlib-2.1.0/config/mt-ospace-orig	2014-11-13 12:02:45.463578281 +0000
-+++ newlib-2.1.0/config/mt-ospace	2014-11-13 12:03:01.409592374 +0000
-@@ -1,3 +1,3 @@
- # Build libraries optimizing for space, not speed.
-- CFLAGS_FOR_TARGET = -g -Os
-- CXXFLAGS_FOR_TARGET = -g -Os
-+ CFLAGS_FOR_TARGET += -g -Os
-+ CXXFLAGS_FOR_TARGET += -g -Os

--- a/patches/newlib/2.1.0/100-fix-unaligned-access-memcpy-m68k.patch
+++ b/patches/newlib/2.1.0/100-fix-unaligned-access-memcpy-m68k.patch
@@ -1,0 +1,27 @@
+The m68k mcpu processor does not like unaligned access
+
+Disable at least mcpu32, m68010 and m68020. These processors certainly
+do not like unaligned accesses.
+
+Signed-off-by: Remy Bohmer <linux@bohmer.net>
+[yann.morin.1998@anciens.enib.fr: update for 1.19.0 from 1.18.0]
+Signed-off-by: "Yann E. MORIN" <yann.morin.1998@anciens.enib.fr>
+[austinpmorton@gmail.com: update for 1.20.0 from 1.19.0]
+Signed-off-by: Austin Morton <austinpmorton@gmail.com>
+---
+ newlib/libc/machine/m68k/memcpy.S |    2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+Index: newlib-1.20.0/newlib/libc/machine/m68k/memcpy.S
+===================================================================
+--- newlib-1.20.0.orig/newlib/libc/machine/m68k/memcpy.S
++++ newlib-1.20.0/newlib/libc/machine/m68k/memcpy.S
+@@ -15,7 +15,7 @@
+ 
+ #include "m68kasm.h"
+ 
+-#if defined (__mcoldfire__) || defined (__mc68010__) || defined (__mc68020__) || defined (__mc68030__) || defined (__mc68040__) || defined (__mc68060__)
++#if defined (__mcoldfire__) || defined (__mc68030__) || defined (__mc68040__) || defined (__mc68060__)
+ # define MISALIGNED_OK 1
+ #else
+ # define MISALIGNED_OK 0

--- a/patches/newlib/2.1.0/110-fix-eabihf.patch
+++ b/patches/newlib/2.1.0/110-fix-eabihf.patch
@@ -1,0 +1,24 @@
+diff -urpN newlib-2.1.0.orig/libgloss/arm/configure newlib-2.1.0/libgloss/arm/configure
+--- newlib-2.1.0.orig/libgloss/arm/configure	2017-04-11 00:41:24.592873407 -0700
++++ newlib-2.1.0/libgloss/arm/configure	2017-04-11 00:43:12.305788823 -0700
+@@ -2541,7 +2541,7 @@ test "${CCASFLAGS+set}" = set || CCASFLA
+ 
+ 
+ case "${target}" in
+-  *-*-elf | *-*-eabi)
++  *-*-elf | *-*-eabi*)
+ 	objtype=elf-
+ 	;;
+   *-*-coff)
+diff -urpN newlib-2.1.0.orig/libgloss/arm/configure.in newlib-2.1.0/libgloss/arm/configure.in
+--- newlib-2.1.0.orig/libgloss/arm/configure.in	2017-04-11 00:41:24.592873407 -0700
++++ newlib-2.1.0/libgloss/arm/configure.in	2017-04-11 00:43:12.305788823 -0700
+@@ -49,7 +49,7 @@ AC_PROG_RANLIB
+ LIB_AM_PROG_AS
+ 
+ case "${target}" in
+-  *-*-elf | *-*-eabi)
++  *-*-elf | *-*-eabi*)
+ 	objtype=elf-
+ 	;;
+   *-*-coff)

--- a/patches/newlib/2.1.0/200-fix-mt-cflags.patch
+++ b/patches/newlib/2.1.0/200-fix-mt-cflags.patch
@@ -1,0 +1,25 @@
+diff -urpN newlib-2.1.0.orig/config/mt-d30v newlib-2.1.0/config/mt-d30v
+--- newlib-2.1.0.orig/config/mt-d30v	2017-04-11 00:51:27.380763434 -0700
++++ newlib-2.1.0/config/mt-d30v	2017-04-11 00:55:51.130626674 -0700
+@@ -1,4 +1,4 @@
+ # Build libraries optimizing for space, not speed.
+ # Turn off warnings about symbols named the same as registers
+- CFLAGS_FOR_TARGET = -g -Os -Wa,-C
+- CXXFLAGS_FOR_TARGET = -g -Os -Wa,-C
++ CFLAGS_FOR_TARGET += -g -Os -Wa,-C
++ CXXFLAGS_FOR_TARGET += -g -Os -Wa,-C
+diff -urpN newlib-2.1.0.orig/config/mt-gnu newlib-2.1.0/config/mt-gnu
+--- newlib-2.1.0.orig/config/mt-gnu	2017-04-11 00:51:27.380763434 -0700
++++ newlib-2.1.0/config/mt-gnu	2017-04-11 00:55:51.130626674 -0700
+@@ -1 +1 @@
+-CXXFLAGS_FOR_TARGET = $(CXXFLAGS) -D_GNU_SOURCE
++CXXFLAGS_FOR_TARGET += $(CXXFLAGS) -D_GNU_SOURCE
+diff -urpN newlib-2.1.0.orig/config/mt-ospace newlib-2.1.0/config/mt-ospace
+--- newlib-2.1.0.orig/config/mt-ospace	2017-04-11 00:51:27.380763434 -0700
++++ newlib-2.1.0/config/mt-ospace	2017-04-11 00:55:51.130626674 -0700
+@@ -1,3 +1,3 @@
+ # Build libraries optimizing for space, not speed.
+- CFLAGS_FOR_TARGET = -g -Os
+- CXXFLAGS_FOR_TARGET = -g -Os
++ CFLAGS_FOR_TARGET += -g -Os
++ CXXFLAGS_FOR_TARGET += -g -Os

--- a/patches/newlib/2.2.0.20151023/100-fix-unaligned-access-memcpy-m68k.patch
+++ b/patches/newlib/2.2.0.20151023/100-fix-unaligned-access-memcpy-m68k.patch
@@ -1,0 +1,27 @@
+The m68k mcpu processor does not like unaligned access
+
+Disable at least mcpu32, m68010 and m68020. These processors certainly
+do not like unaligned accesses.
+
+Signed-off-by: Remy Bohmer <linux@bohmer.net>
+[yann.morin.1998@anciens.enib.fr: update for 1.19.0 from 1.18.0]
+Signed-off-by: "Yann E. MORIN" <yann.morin.1998@anciens.enib.fr>
+[austinpmorton@gmail.com: update for 1.20.0 from 1.19.0]
+Signed-off-by: Austin Morton <austinpmorton@gmail.com>
+---
+ newlib/libc/machine/m68k/memcpy.S |    2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+Index: newlib-1.20.0/newlib/libc/machine/m68k/memcpy.S
+===================================================================
+--- newlib-1.20.0.orig/newlib/libc/machine/m68k/memcpy.S
++++ newlib-1.20.0/newlib/libc/machine/m68k/memcpy.S
+@@ -15,7 +15,7 @@
+ 
+ #include "m68kasm.h"
+ 
+-#if defined (__mcoldfire__) || defined (__mc68010__) || defined (__mc68020__) || defined (__mc68030__) || defined (__mc68040__) || defined (__mc68060__)
++#if defined (__mcoldfire__) || defined (__mc68030__) || defined (__mc68040__) || defined (__mc68060__)
+ # define MISALIGNED_OK 1
+ #else
+ # define MISALIGNED_OK 0

--- a/patches/newlib/2.2.0.20151023/110-fix-eabihf.patch
+++ b/patches/newlib/2.2.0.20151023/110-fix-eabihf.patch
@@ -1,0 +1,24 @@
+diff -urpN newlib-2.2.0.20151023.orig/libgloss/arm/configure newlib-2.2.0.20151023/libgloss/arm/configure
+--- newlib-2.2.0.20151023.orig/libgloss/arm/configure	2017-04-11 00:41:24.816875309 -0700
++++ newlib-2.2.0.20151023/libgloss/arm/configure	2017-04-11 00:43:12.313788892 -0700
+@@ -2531,7 +2531,7 @@ test "${CCASFLAGS+set}" = set || CCASFLA
+ 
+ 
+ case "${target}" in
+-  *-*-elf | *-*-eabi | *-*-tirtos*)
++  *-*-elf | *-*-eabi* | *-*-tirtos*)
+ 	objtype=elf-
+ 	;;
+   *-*-coff)
+diff -urpN newlib-2.2.0.20151023.orig/libgloss/arm/configure.in newlib-2.2.0.20151023/libgloss/arm/configure.in
+--- newlib-2.2.0.20151023.orig/libgloss/arm/configure.in	2017-04-11 00:41:24.816875309 -0700
++++ newlib-2.2.0.20151023/libgloss/arm/configure.in	2017-04-11 00:43:12.313788892 -0700
+@@ -49,7 +49,7 @@ AC_PROG_RANLIB
+ LIB_AM_PROG_AS
+ 
+ case "${target}" in
+-  *-*-elf | *-*-eabi | *-*-tirtos*)
++  *-*-elf | *-*-eabi* | *-*-tirtos*)
+ 	objtype=elf-
+ 	;;
+   *-*-coff)

--- a/patches/newlib/2.2.0.20151023/200-fix-mt-cflags.patch
+++ b/patches/newlib/2.2.0.20151023/200-fix-mt-cflags.patch
@@ -1,0 +1,25 @@
+diff -urpN newlib-2.2.0.20151023.orig/config/mt-d30v newlib-2.2.0.20151023/config/mt-d30v
+--- newlib-2.2.0.20151023.orig/config/mt-d30v	2017-04-11 00:51:27.580764794 -0700
++++ newlib-2.2.0.20151023/config/mt-d30v	2017-04-11 00:55:51.130626674 -0700
+@@ -1,4 +1,4 @@
+ # Build libraries optimizing for space, not speed.
+ # Turn off warnings about symbols named the same as registers
+- CFLAGS_FOR_TARGET = -g -Os -Wa,-C
+- CXXFLAGS_FOR_TARGET = -g -Os -Wa,-C
++ CFLAGS_FOR_TARGET += -g -Os -Wa,-C
++ CXXFLAGS_FOR_TARGET += -g -Os -Wa,-C
+diff -urpN newlib-2.2.0.20151023.orig/config/mt-gnu newlib-2.2.0.20151023/config/mt-gnu
+--- newlib-2.2.0.20151023.orig/config/mt-gnu	2017-04-11 00:51:27.576764766 -0700
++++ newlib-2.2.0.20151023/config/mt-gnu	2017-04-11 00:55:51.130626674 -0700
+@@ -1 +1 @@
+-CXXFLAGS_FOR_TARGET = $(CXXFLAGS) -D_GNU_SOURCE
++CXXFLAGS_FOR_TARGET += $(CXXFLAGS) -D_GNU_SOURCE
+diff -urpN newlib-2.2.0.20151023.orig/config/mt-ospace newlib-2.2.0.20151023/config/mt-ospace
+--- newlib-2.2.0.20151023.orig/config/mt-ospace	2017-04-11 00:51:27.576764766 -0700
++++ newlib-2.2.0.20151023/config/mt-ospace	2017-04-11 00:55:51.130626674 -0700
+@@ -1,3 +1,3 @@
+ # Build libraries optimizing for space, not speed.
+- CFLAGS_FOR_TARGET = -g -Os
+- CXXFLAGS_FOR_TARGET = -g -Os
++ CFLAGS_FOR_TARGET += -g -Os
++ CXXFLAGS_FOR_TARGET += -g -Os

--- a/patches/newlib/2.3.0.20160226/100-fix-unaligned-access-memcpy-m68k.patch
+++ b/patches/newlib/2.3.0.20160226/100-fix-unaligned-access-memcpy-m68k.patch
@@ -1,0 +1,27 @@
+The m68k mcpu processor does not like unaligned access
+
+Disable at least mcpu32, m68010 and m68020. These processors certainly
+do not like unaligned accesses.
+
+Signed-off-by: Remy Bohmer <linux@bohmer.net>
+[yann.morin.1998@anciens.enib.fr: update for 1.19.0 from 1.18.0]
+Signed-off-by: "Yann E. MORIN" <yann.morin.1998@anciens.enib.fr>
+[austinpmorton@gmail.com: update for 1.20.0 from 1.19.0]
+Signed-off-by: Austin Morton <austinpmorton@gmail.com>
+---
+ newlib/libc/machine/m68k/memcpy.S |    2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+Index: newlib-1.20.0/newlib/libc/machine/m68k/memcpy.S
+===================================================================
+--- newlib-1.20.0.orig/newlib/libc/machine/m68k/memcpy.S
++++ newlib-1.20.0/newlib/libc/machine/m68k/memcpy.S
+@@ -15,7 +15,7 @@
+ 
+ #include "m68kasm.h"
+ 
+-#if defined (__mcoldfire__) || defined (__mc68010__) || defined (__mc68020__) || defined (__mc68030__) || defined (__mc68040__) || defined (__mc68060__)
++#if defined (__mcoldfire__) || defined (__mc68030__) || defined (__mc68040__) || defined (__mc68060__)
+ # define MISALIGNED_OK 1
+ #else
+ # define MISALIGNED_OK 0

--- a/patches/newlib/2.3.0.20160226/110-fix-eabihf.patch
+++ b/patches/newlib/2.3.0.20160226/110-fix-eabihf.patch
@@ -1,0 +1,24 @@
+diff -urpN newlib-2.3.0.20160226.orig/libgloss/arm/configure newlib-2.3.0.20160226/libgloss/arm/configure
+--- newlib-2.3.0.20160226.orig/libgloss/arm/configure	2017-04-11 00:41:25.064877413 -0700
++++ newlib-2.3.0.20160226/libgloss/arm/configure	2017-04-11 00:43:12.321788960 -0700
+@@ -2531,7 +2531,7 @@ test "${CCASFLAGS+set}" = set || CCASFLA
+ 
+ 
+ case "${target}" in
+-  *-*-elf | *-*-eabi | *-*-tirtos*)
++  *-*-elf | *-*-eabi* | *-*-tirtos*)
+ 	objtype=elf-
+ 	;;
+   *-*-coff)
+diff -urpN newlib-2.3.0.20160226.orig/libgloss/arm/configure.in newlib-2.3.0.20160226/libgloss/arm/configure.in
+--- newlib-2.3.0.20160226.orig/libgloss/arm/configure.in	2017-04-11 00:41:25.064877413 -0700
++++ newlib-2.3.0.20160226/libgloss/arm/configure.in	2017-04-11 00:43:12.321788960 -0700
+@@ -49,7 +49,7 @@ AC_PROG_RANLIB
+ LIB_AM_PROG_AS
+ 
+ case "${target}" in
+-  *-*-elf | *-*-eabi | *-*-tirtos*)
++  *-*-elf | *-*-eabi* | *-*-tirtos*)
+ 	objtype=elf-
+ 	;;
+   *-*-coff)

--- a/patches/newlib/2.3.0.20160226/200-fix-mt-cflags.patch
+++ b/patches/newlib/2.3.0.20160226/200-fix-mt-cflags.patch
@@ -1,0 +1,25 @@
+diff -urpN newlib-2.3.0.20160226.orig/config/mt-d30v newlib-2.3.0.20160226/config/mt-d30v
+--- newlib-2.3.0.20160226.orig/config/mt-d30v	2017-04-11 00:51:27.736765855 -0700
++++ newlib-2.3.0.20160226/config/mt-d30v	2017-04-11 00:55:51.134626702 -0700
+@@ -1,4 +1,4 @@
+ # Build libraries optimizing for space, not speed.
+ # Turn off warnings about symbols named the same as registers
+- CFLAGS_FOR_TARGET = -g -Os -Wa,-C
+- CXXFLAGS_FOR_TARGET = -g -Os -Wa,-C
++ CFLAGS_FOR_TARGET += -g -Os -Wa,-C
++ CXXFLAGS_FOR_TARGET += -g -Os -Wa,-C
+diff -urpN newlib-2.3.0.20160226.orig/config/mt-gnu newlib-2.3.0.20160226/config/mt-gnu
+--- newlib-2.3.0.20160226.orig/config/mt-gnu	2017-04-11 00:51:27.736765855 -0700
++++ newlib-2.3.0.20160226/config/mt-gnu	2017-04-11 00:55:51.134626702 -0700
+@@ -1 +1 @@
+-CXXFLAGS_FOR_TARGET = $(CXXFLAGS) -D_GNU_SOURCE
++CXXFLAGS_FOR_TARGET += $(CXXFLAGS) -D_GNU_SOURCE
+diff -urpN newlib-2.3.0.20160226.orig/config/mt-ospace newlib-2.3.0.20160226/config/mt-ospace
+--- newlib-2.3.0.20160226.orig/config/mt-ospace	2017-04-11 00:51:27.736765855 -0700
++++ newlib-2.3.0.20160226/config/mt-ospace	2017-04-11 00:55:51.134626702 -0700
+@@ -1,3 +1,3 @@
+ # Build libraries optimizing for space, not speed.
+- CFLAGS_FOR_TARGET = -g -Os
+- CXXFLAGS_FOR_TARGET = -g -Os
++ CFLAGS_FOR_TARGET += -g -Os
++ CXXFLAGS_FOR_TARGET += -g -Os

--- a/patches/newlib/2.4.0.20161025/100-fix-unaligned-access-memcpy-m68k.patch
+++ b/patches/newlib/2.4.0.20161025/100-fix-unaligned-access-memcpy-m68k.patch
@@ -1,0 +1,27 @@
+The m68k mcpu processor does not like unaligned access
+
+Disable at least mcpu32, m68010 and m68020. These processors certainly
+do not like unaligned accesses.
+
+Signed-off-by: Remy Bohmer <linux@bohmer.net>
+[yann.morin.1998@anciens.enib.fr: update for 1.19.0 from 1.18.0]
+Signed-off-by: "Yann E. MORIN" <yann.morin.1998@anciens.enib.fr>
+[austinpmorton@gmail.com: update for 1.20.0 from 1.19.0]
+Signed-off-by: Austin Morton <austinpmorton@gmail.com>
+---
+ newlib/libc/machine/m68k/memcpy.S |    2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+Index: newlib-1.20.0/newlib/libc/machine/m68k/memcpy.S
+===================================================================
+--- newlib-1.20.0.orig/newlib/libc/machine/m68k/memcpy.S
++++ newlib-1.20.0/newlib/libc/machine/m68k/memcpy.S
+@@ -15,7 +15,7 @@
+ 
+ #include "m68kasm.h"
+ 
+-#if defined (__mcoldfire__) || defined (__mc68010__) || defined (__mc68020__) || defined (__mc68030__) || defined (__mc68040__) || defined (__mc68060__)
++#if defined (__mcoldfire__) || defined (__mc68030__) || defined (__mc68040__) || defined (__mc68060__)
+ # define MISALIGNED_OK 1
+ #else
+ # define MISALIGNED_OK 0

--- a/patches/newlib/2.4.0.20161025/110-fix-eabihf.patch
+++ b/patches/newlib/2.4.0.20161025/110-fix-eabihf.patch
@@ -1,0 +1,24 @@
+diff -urpN newlib-2.4.0.20161025.orig/libgloss/arm/configure newlib-2.4.0.20161025/libgloss/arm/configure
+--- newlib-2.4.0.20161025.orig/libgloss/arm/configure	2017-04-11 00:41:25.240878908 -0700
++++ newlib-2.4.0.20161025/libgloss/arm/configure	2017-04-11 00:43:12.325788994 -0700
+@@ -2531,7 +2531,7 @@ test "${CCASFLAGS+set}" = set || CCASFLA
+ 
+ 
+ case "${target}" in
+-  *-*-elf | *-*-eabi | *-*-tirtos*)
++  *-*-elf | *-*-eabi* | *-*-tirtos*)
+ 	objtype=elf-
+ 	;;
+   *-*-coff)
+diff -urpN newlib-2.4.0.20161025.orig/libgloss/arm/configure.in newlib-2.4.0.20161025/libgloss/arm/configure.in
+--- newlib-2.4.0.20161025.orig/libgloss/arm/configure.in	2017-04-11 00:41:25.236878874 -0700
++++ newlib-2.4.0.20161025/libgloss/arm/configure.in	2017-04-11 00:43:12.325788994 -0700
+@@ -49,7 +49,7 @@ AC_PROG_RANLIB
+ LIB_AM_PROG_AS
+ 
+ case "${target}" in
+-  *-*-elf | *-*-eabi | *-*-tirtos*)
++  *-*-elf | *-*-eabi* | *-*-tirtos*)
+ 	objtype=elf-
+ 	;;
+   *-*-coff)

--- a/patches/newlib/2.4.0.20161025/200-fix-mt-cflags.patch
+++ b/patches/newlib/2.4.0.20161025/200-fix-mt-cflags.patch
@@ -1,0 +1,10 @@
+diff -urpN newlib-2.4.0.20161025.orig/config/mt-d30v newlib-2.4.0.20161025/config/mt-d30v
+--- newlib-2.4.0.20161025.orig/config/mt-d30v	2017-04-11 00:51:27.980767513 -0700
++++ newlib-2.4.0.20161025/config/mt-d30v	2017-04-11 00:55:51.138626731 -0700
+@@ -1,4 +1,4 @@
+ # Build libraries optimizing for space, not speed.
+ # Turn off warnings about symbols named the same as registers
+- CFLAGS_FOR_TARGET = -g -Os -Wa,-C
+- CXXFLAGS_FOR_TARGET = -g -Os -Wa,-C
++ CFLAGS_FOR_TARGET += -g -Os -Wa,-C
++ CXXFLAGS_FOR_TARGET += -g -Os -Wa,-C

--- a/patches/newlib/2.5.0.20170323/100-fix-unaligned-access-memcpy-m68k.patch
+++ b/patches/newlib/2.5.0.20170323/100-fix-unaligned-access-memcpy-m68k.patch
@@ -1,0 +1,27 @@
+The m68k mcpu processor does not like unaligned access
+
+Disable at least mcpu32, m68010 and m68020. These processors certainly
+do not like unaligned accesses.
+
+Signed-off-by: Remy Bohmer <linux@bohmer.net>
+[yann.morin.1998@anciens.enib.fr: update for 1.19.0 from 1.18.0]
+Signed-off-by: "Yann E. MORIN" <yann.morin.1998@anciens.enib.fr>
+[austinpmorton@gmail.com: update for 1.20.0 from 1.19.0]
+Signed-off-by: Austin Morton <austinpmorton@gmail.com>
+---
+ newlib/libc/machine/m68k/memcpy.S |    2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+Index: newlib-1.20.0/newlib/libc/machine/m68k/memcpy.S
+===================================================================
+--- newlib-1.20.0.orig/newlib/libc/machine/m68k/memcpy.S
++++ newlib-1.20.0/newlib/libc/machine/m68k/memcpy.S
+@@ -15,7 +15,7 @@
+ 
+ #include "m68kasm.h"
+ 
+-#if defined (__mcoldfire__) || defined (__mc68010__) || defined (__mc68020__) || defined (__mc68030__) || defined (__mc68040__) || defined (__mc68060__)
++#if defined (__mcoldfire__) || defined (__mc68030__) || defined (__mc68040__) || defined (__mc68060__)
+ # define MISALIGNED_OK 1
+ #else
+ # define MISALIGNED_OK 0

--- a/patches/newlib/2.5.0.20170323/110-fix-eabihf.patch
+++ b/patches/newlib/2.5.0.20170323/110-fix-eabihf.patch
@@ -1,0 +1,24 @@
+diff -urpN newlib-2.5.0.20170323.orig/libgloss/arm/configure newlib-2.5.0.20170323/libgloss/arm/configure
+--- newlib-2.5.0.20170323.orig/libgloss/arm/configure	2017-04-11 00:41:25.464880809 -0700
++++ newlib-2.5.0.20170323/libgloss/arm/configure	2017-04-11 00:43:12.333789062 -0700
+@@ -2531,7 +2531,7 @@ test "${CCASFLAGS+set}" = set || CCASFLA
+ 
+ 
+ case "${target}" in
+-  *-*-elf | *-*-eabi | *-*-tirtos*)
++  *-*-elf | *-*-eabi* | *-*-tirtos*)
+ 	objtype=elf-
+ 	;;
+   *-*-coff)
+diff -urpN newlib-2.5.0.20170323.orig/libgloss/arm/configure.in newlib-2.5.0.20170323/libgloss/arm/configure.in
+--- newlib-2.5.0.20170323.orig/libgloss/arm/configure.in	2017-04-11 00:41:25.464880809 -0700
++++ newlib-2.5.0.20170323/libgloss/arm/configure.in	2017-04-11 00:43:12.333789062 -0700
+@@ -49,7 +49,7 @@ AC_PROG_RANLIB
+ LIB_AM_PROG_AS
+ 
+ case "${target}" in
+-  *-*-elf | *-*-eabi | *-*-tirtos*)
++  *-*-elf | *-*-eabi* | *-*-tirtos*)
+ 	objtype=elf-
+ 	;;
+   *-*-coff)

--- a/patches/newlib/2.5.0.20170323/200-fix-mt-cflags.patch
+++ b/patches/newlib/2.5.0.20170323/200-fix-mt-cflags.patch
@@ -1,0 +1,10 @@
+diff -urpN newlib-2.5.0.20170323.orig/config/mt-d30v newlib-2.5.0.20170323/config/mt-d30v
+--- newlib-2.5.0.20170323.orig/config/mt-d30v	2017-04-11 00:51:28.180768874 -0700
++++ newlib-2.5.0.20170323/config/mt-d30v	2017-04-11 00:55:51.138626731 -0700
+@@ -1,4 +1,4 @@
+ # Build libraries optimizing for space, not speed.
+ # Turn off warnings about symbols named the same as registers
+- CFLAGS_FOR_TARGET = -g -Os -Wa,-C
+- CXXFLAGS_FOR_TARGET = -g -Os -Wa,-C
++ CFLAGS_FOR_TARGET += -g -Os -Wa,-C
++ CXXFLAGS_FOR_TARGET += -g -Os -Wa,-C

--- a/patches/newlib/linaro-2.1.0-2014.09/100-fix-unaligned-access-memcpy-m68k.patch
+++ b/patches/newlib/linaro-2.1.0-2014.09/100-fix-unaligned-access-memcpy-m68k.patch
@@ -1,0 +1,27 @@
+The m68k mcpu processor does not like unaligned access
+
+Disable at least mcpu32, m68010 and m68020. These processors certainly
+do not like unaligned accesses.
+
+Signed-off-by: Remy Bohmer <linux@bohmer.net>
+[yann.morin.1998@anciens.enib.fr: update for 1.19.0 from 1.18.0]
+Signed-off-by: "Yann E. MORIN" <yann.morin.1998@anciens.enib.fr>
+[austinpmorton@gmail.com: update for 1.20.0 from 1.19.0]
+Signed-off-by: Austin Morton <austinpmorton@gmail.com>
+---
+ newlib/libc/machine/m68k/memcpy.S |    2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+Index: newlib-1.20.0/newlib/libc/machine/m68k/memcpy.S
+===================================================================
+--- newlib-1.20.0.orig/newlib/libc/machine/m68k/memcpy.S
++++ newlib-1.20.0/newlib/libc/machine/m68k/memcpy.S
+@@ -15,7 +15,7 @@
+ 
+ #include "m68kasm.h"
+ 
+-#if defined (__mcoldfire__) || defined (__mc68010__) || defined (__mc68020__) || defined (__mc68030__) || defined (__mc68040__) || defined (__mc68060__)
++#if defined (__mcoldfire__) || defined (__mc68030__) || defined (__mc68040__) || defined (__mc68060__)
+ # define MISALIGNED_OK 1
+ #else
+ # define MISALIGNED_OK 0

--- a/patches/newlib/linaro-2.1.0-2014.09/110-fix-eabihf.patch
+++ b/patches/newlib/linaro-2.1.0-2014.09/110-fix-eabihf.patch
@@ -1,0 +1,24 @@
+diff -urpN newlib-linaro-2.1.0-2014.09.orig/libgloss/arm/configure newlib-linaro-2.1.0-2014.09/libgloss/arm/configure
+--- newlib-linaro-2.1.0-2014.09.orig/libgloss/arm/configure	2017-04-11 00:41:25.484880978 -0700
++++ newlib-linaro-2.1.0-2014.09/libgloss/arm/configure	2017-04-11 00:43:12.341789130 -0700
+@@ -2531,7 +2531,7 @@ test "${CCASFLAGS+set}" = set || CCASFLA
+ 
+ 
+ case "${target}" in
+-  *-*-elf | *-*-eabi | *-*-tirtos*)
++  *-*-elf | *-*-eabi* | *-*-tirtos*)
+ 	objtype=elf-
+ 	;;
+   *-*-coff)
+diff -urpN newlib-linaro-2.1.0-2014.09.orig/libgloss/arm/configure.in newlib-linaro-2.1.0-2014.09/libgloss/arm/configure.in
+--- newlib-linaro-2.1.0-2014.09.orig/libgloss/arm/configure.in	2017-04-11 00:41:25.484880978 -0700
++++ newlib-linaro-2.1.0-2014.09/libgloss/arm/configure.in	2017-04-11 00:43:12.341789130 -0700
+@@ -49,7 +49,7 @@ AC_PROG_RANLIB
+ LIB_AM_PROG_AS
+ 
+ case "${target}" in
+-  *-*-elf | *-*-eabi | *-*-tirtos*)
++  *-*-elf | *-*-eabi* | *-*-tirtos*)
+ 	objtype=elf-
+ 	;;
+   *-*-coff)

--- a/patches/newlib/linaro-2.1.0-2014.09/200-fix-mt-cflags.patch
+++ b/patches/newlib/linaro-2.1.0-2014.09/200-fix-mt-cflags.patch
@@ -1,0 +1,25 @@
+diff -urpN newlib-linaro-2.1.0-2014.09.orig/config/mt-d30v newlib-linaro-2.1.0-2014.09/config/mt-d30v
+--- newlib-linaro-2.1.0-2014.09.orig/config/mt-d30v	2017-04-11 00:51:28.188768929 -0700
++++ newlib-linaro-2.1.0-2014.09/config/mt-d30v	2017-04-11 00:55:51.142626761 -0700
+@@ -1,4 +1,4 @@
+ # Build libraries optimizing for space, not speed.
+ # Turn off warnings about symbols named the same as registers
+- CFLAGS_FOR_TARGET = -g -Os -Wa,-C
+- CXXFLAGS_FOR_TARGET = -g -Os -Wa,-C
++ CFLAGS_FOR_TARGET += -g -Os -Wa,-C
++ CXXFLAGS_FOR_TARGET += -g -Os -Wa,-C
+diff -urpN newlib-linaro-2.1.0-2014.09.orig/config/mt-gnu newlib-linaro-2.1.0-2014.09/config/mt-gnu
+--- newlib-linaro-2.1.0-2014.09.orig/config/mt-gnu	2017-04-11 00:51:28.188768929 -0700
++++ newlib-linaro-2.1.0-2014.09/config/mt-gnu	2017-04-11 00:55:51.142626761 -0700
+@@ -1 +1 @@
+-CXXFLAGS_FOR_TARGET = $(CXXFLAGS) -D_GNU_SOURCE
++CXXFLAGS_FOR_TARGET += $(CXXFLAGS) -D_GNU_SOURCE
+diff -urpN newlib-linaro-2.1.0-2014.09.orig/config/mt-ospace newlib-linaro-2.1.0-2014.09/config/mt-ospace
+--- newlib-linaro-2.1.0-2014.09.orig/config/mt-ospace	2017-04-11 00:51:28.188768929 -0700
++++ newlib-linaro-2.1.0-2014.09/config/mt-ospace	2017-04-11 00:55:51.142626761 -0700
+@@ -1,3 +1,3 @@
+ # Build libraries optimizing for space, not speed.
+- CFLAGS_FOR_TARGET = -g -Os
+- CXXFLAGS_FOR_TARGET = -g -Os
++ CFLAGS_FOR_TARGET += -g -Os
++ CXXFLAGS_FOR_TARGET += -g -Os

--- a/patches/newlib/linaro-2.2.0-2015.01/100-fix-unaligned-access-memcpy-m68k.patch
+++ b/patches/newlib/linaro-2.2.0-2015.01/100-fix-unaligned-access-memcpy-m68k.patch
@@ -1,0 +1,27 @@
+The m68k mcpu processor does not like unaligned access
+
+Disable at least mcpu32, m68010 and m68020. These processors certainly
+do not like unaligned accesses.
+
+Signed-off-by: Remy Bohmer <linux@bohmer.net>
+[yann.morin.1998@anciens.enib.fr: update for 1.19.0 from 1.18.0]
+Signed-off-by: "Yann E. MORIN" <yann.morin.1998@anciens.enib.fr>
+[austinpmorton@gmail.com: update for 1.20.0 from 1.19.0]
+Signed-off-by: Austin Morton <austinpmorton@gmail.com>
+---
+ newlib/libc/machine/m68k/memcpy.S |    2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+Index: newlib-1.20.0/newlib/libc/machine/m68k/memcpy.S
+===================================================================
+--- newlib-1.20.0.orig/newlib/libc/machine/m68k/memcpy.S
++++ newlib-1.20.0/newlib/libc/machine/m68k/memcpy.S
+@@ -15,7 +15,7 @@
+ 
+ #include "m68kasm.h"
+ 
+-#if defined (__mcoldfire__) || defined (__mc68010__) || defined (__mc68020__) || defined (__mc68030__) || defined (__mc68040__) || defined (__mc68060__)
++#if defined (__mcoldfire__) || defined (__mc68030__) || defined (__mc68040__) || defined (__mc68060__)
+ # define MISALIGNED_OK 1
+ #else
+ # define MISALIGNED_OK 0

--- a/patches/newlib/linaro-2.2.0-2015.01/110-fix-eabihf.patch
+++ b/patches/newlib/linaro-2.2.0-2015.01/110-fix-eabihf.patch
@@ -1,0 +1,24 @@
+diff -urpN newlib-linaro-2.2.0-2015.01.orig/libgloss/arm/configure newlib-linaro-2.2.0-2015.01/libgloss/arm/configure
+--- newlib-linaro-2.2.0-2015.01.orig/libgloss/arm/configure	2017-04-11 00:41:25.672882574 -0700
++++ newlib-linaro-2.2.0-2015.01/libgloss/arm/configure	2017-04-11 00:43:12.349789198 -0700
+@@ -2531,7 +2531,7 @@ test "${CCASFLAGS+set}" = set || CCASFLA
+ 
+ 
+ case "${target}" in
+-  *-*-elf | *-*-eabi | *-*-tirtos*)
++  *-*-elf | *-*-eabi* | *-*-tirtos*)
+ 	objtype=elf-
+ 	;;
+   *-*-coff)
+diff -urpN newlib-linaro-2.2.0-2015.01.orig/libgloss/arm/configure.in newlib-linaro-2.2.0-2015.01/libgloss/arm/configure.in
+--- newlib-linaro-2.2.0-2015.01.orig/libgloss/arm/configure.in	2017-04-11 00:41:25.672882574 -0700
++++ newlib-linaro-2.2.0-2015.01/libgloss/arm/configure.in	2017-04-11 00:43:12.349789198 -0700
+@@ -49,7 +49,7 @@ AC_PROG_RANLIB
+ LIB_AM_PROG_AS
+ 
+ case "${target}" in
+-  *-*-elf | *-*-eabi | *-*-tirtos*)
++  *-*-elf | *-*-eabi* | *-*-tirtos*)
+ 	objtype=elf-
+ 	;;
+   *-*-coff)

--- a/patches/newlib/linaro-2.2.0-2015.01/200-fix-mt-cflags.patch
+++ b/patches/newlib/linaro-2.2.0-2015.01/200-fix-mt-cflags.patch
@@ -1,0 +1,25 @@
+diff -urpN newlib-linaro-2.2.0-2015.01.orig/config/mt-d30v newlib-linaro-2.2.0-2015.01/config/mt-d30v
+--- newlib-linaro-2.2.0-2015.01.orig/config/mt-d30v	2017-04-11 00:51:28.364770125 -0700
++++ newlib-linaro-2.2.0-2015.01/config/mt-d30v	2017-04-11 00:55:51.142626761 -0700
+@@ -1,4 +1,4 @@
+ # Build libraries optimizing for space, not speed.
+ # Turn off warnings about symbols named the same as registers
+- CFLAGS_FOR_TARGET = -g -Os -Wa,-C
+- CXXFLAGS_FOR_TARGET = -g -Os -Wa,-C
++ CFLAGS_FOR_TARGET += -g -Os -Wa,-C
++ CXXFLAGS_FOR_TARGET += -g -Os -Wa,-C
+diff -urpN newlib-linaro-2.2.0-2015.01.orig/config/mt-gnu newlib-linaro-2.2.0-2015.01/config/mt-gnu
+--- newlib-linaro-2.2.0-2015.01.orig/config/mt-gnu	2017-04-11 00:51:28.364770125 -0700
++++ newlib-linaro-2.2.0-2015.01/config/mt-gnu	2017-04-11 00:55:51.142626761 -0700
+@@ -1 +1 @@
+-CXXFLAGS_FOR_TARGET = $(CXXFLAGS) -D_GNU_SOURCE
++CXXFLAGS_FOR_TARGET += $(CXXFLAGS) -D_GNU_SOURCE
+diff -urpN newlib-linaro-2.2.0-2015.01.orig/config/mt-ospace newlib-linaro-2.2.0-2015.01/config/mt-ospace
+--- newlib-linaro-2.2.0-2015.01.orig/config/mt-ospace	2017-04-11 00:51:28.368770153 -0700
++++ newlib-linaro-2.2.0-2015.01/config/mt-ospace	2017-04-11 00:55:51.142626761 -0700
+@@ -1,3 +1,3 @@
+ # Build libraries optimizing for space, not speed.
+- CFLAGS_FOR_TARGET = -g -Os
+- CXXFLAGS_FOR_TARGET = -g -Os
++ CFLAGS_FOR_TARGET += -g -Os
++ CXXFLAGS_FOR_TARGET += -g -Os


### PR DESCRIPTION
- Existing 110-fix-eabihf.patch did not apply to 1.20.0 and earlier
- This patch is also applicable to 2.x versions
- The patch needs to be applied to both configure.in/configure
- Existing 200-optimising-for-space.patch also applies to all versions
  before 2.4.0
- Similar issues exist in other config/mt-* files
- m68k patch is applicable to 2.* versions

Signed-off-by: Alexey Neyman <stilor@att.net>