### PR TITLE
Avoid creating symlinks with empty prefix

### DIFF
--- a/scripts/functions
+++ b/scripts/functions
@@ -1795,7 +1795,7 @@ CT_SymlinkTools()
             # No matching files
             break
         fi
-        if [ "${newpfx}" != "${CT_TARGET}" -o "${bindir}" != "${srcdir}" ]; then
+        if [ -n "${newpfx}" -a \( "${newpfx}" != "${CT_TARGET}" -o "${bindir}" != "${srcdir}" \) ]; then
             _t="${newpfx}-${t#${CT_TARGET}-}"
             CT_DoExecLog ALL ln -sfv "${dirpfx}${t}" "${bindir}/${_t}"
         fi


### PR DESCRIPTION
(regression after Cygwin fix)

Signed-off-by: Alexey Neyman <stilor@att.net>