### PR TITLE
scripts/config.sub: recognize three additional ARM cores

### DIFF
--- a/scripts/config.sub
+++ b/scripts/config.sub
@@ -253,6 +253,7 @@ case $basic_machine in
 	| am33_2.0 \
 	| arc | arceb \
 	| arm | arm[bl]e | arme[lb] | armv[2-8] | armv[3-8][lb] | armv7[arm] \
+	| armv6m | armv7em | armv8a \
 	| avr | avr32 \
 	| ba \
 	| be32 | be64 \


### PR DESCRIPTION
ARMv6-M (armv6m), ARMv7E-M (armv7em), ARMv8-A (armv8a), so for a bare-metal
toolchain we get the following result:

    armv7em-eabi -> armv7em-unknown-eabi

Test with the following defconfig:

    CT_ARCH_arm=y
    CT_ARCH_SUFFIX="v7em"
    CT_LIBC_none=y

Signed-off-by: Carlos Santos <casantos@datacom.ind.br>