### PR TITLE
gcc: xtensa: backport fix for incorrect code generation

### DIFF
--- a/patches/gcc/4.8.5/874-gcc-xtensa-fix-fprintf-format-specifiers.patch
+++ b/patches/gcc/4.8.5/874-gcc-xtensa-fix-fprintf-format-specifiers.patch
@@ -1,0 +1,73 @@
+From 0343a584d6b5128908eabf1db43c70bed7114989 Mon Sep 17 00:00:00 2001
+From: Max Filippov <jcmvbkbc@gmail.com>
+Date: Sun, 28 May 2017 19:56:56 -0700
+Subject: [PATCH] gcc: xtensa: fix fprintf format specifiers
+
+HOST_WIDE_INT may not be long as assumed in print_operand and
+xtensa_emit_call. Use HOST_WIDE_INT_PRINT_DEC/HOST_WIDE_INT_PRINT_HEX
+format strings instead of %ld/0x%lx. This fixes incorrect assembly code
+generation by the compiler running on armhf host.
+
+2017-05-28  Max Filippov  <jcmvbkbc@gmail.com>
+gcc/
+	* config/xtensa/xtensa.c (xtensa_emit_call): Use
+	HOST_WIDE_INT_PRINT_HEX instead of 0x%lx format string.
+	(print_operand): Use HOST_WIDE_INT_PRINT_DEC instead of %ld
+	format string.
+
+Signed-off-by: Max Filippov <jcmvbkbc@gmail.com>
+---
+ gcc/config/xtensa/xtensa.c | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/gcc/config/xtensa/xtensa.c b/gcc/config/xtensa/xtensa.c
+index dbc5bd3..466adb5 100644
+--- a/gcc/config/xtensa/xtensa.c
++++ b/gcc/config/xtensa/xtensa.c
+@@ -1772,7 +1772,7 @@ xtensa_emit_call (int callop, rtx *operands)
+   rtx tgt = operands[callop];
+ 
+   if (GET_CODE (tgt) == CONST_INT)
+-    sprintf (result, "call8\t0x%lx", INTVAL (tgt));
++    sprintf (result, "call8\t" HOST_WIDE_INT_PRINT_HEX, INTVAL (tgt));
+   else if (register_operand (tgt, VOIDmode))
+     sprintf (result, "callx8\t%%%d", callop);
+   else
+@@ -2347,14 +2347,14 @@ print_operand (FILE *file, rtx x, int letter)
+ 
+     case 'L':
+       if (GET_CODE (x) == CONST_INT)
+-	fprintf (file, "%ld", (32 - INTVAL (x)) & 0x1f);
++	fprintf (file, HOST_WIDE_INT_PRINT_DEC, (32 - INTVAL (x)) & 0x1f);
+       else
+ 	output_operand_lossage ("invalid %%L value");
+       break;
+ 
+     case 'R':
+       if (GET_CODE (x) == CONST_INT)
+-	fprintf (file, "%ld", INTVAL (x) & 0x1f);
++	fprintf (file, HOST_WIDE_INT_PRINT_DEC, INTVAL (x) & 0x1f);
+       else
+ 	output_operand_lossage ("invalid %%R value");
+       break;
+@@ -2368,7 +2368,7 @@ print_operand (FILE *file, rtx x, int letter)
+ 
+     case 'd':
+       if (GET_CODE (x) == CONST_INT)
+-	fprintf (file, "%ld", INTVAL (x));
++	fprintf (file, HOST_WIDE_INT_PRINT_DEC, INTVAL (x));
+       else
+ 	output_operand_lossage ("invalid %%d value");
+       break;
+@@ -2437,7 +2437,7 @@ print_operand (FILE *file, rtx x, int letter)
+       else if (GET_CODE (x) == MEM)
+ 	output_address (XEXP (x, 0));
+       else if (GET_CODE (x) == CONST_INT)
+-	fprintf (file, "%ld", INTVAL (x));
++	fprintf (file, HOST_WIDE_INT_PRINT_DEC, INTVAL (x));
+       else
+ 	output_addr_const (file, x);
+     }
+-- 
+2.1.4
+

--- a/patches/gcc/4.9.4/875-gcc-xtensa-fix-fprintf-format-specifiers.patch
+++ b/patches/gcc/4.9.4/875-gcc-xtensa-fix-fprintf-format-specifiers.patch
@@ -1,0 +1,73 @@
+From 0f32ae7bc51725cd500e2877b571fd914d77852e Mon Sep 17 00:00:00 2001
+From: Max Filippov <jcmvbkbc@gmail.com>
+Date: Sun, 28 May 2017 19:56:56 -0700
+Subject: [PATCH] gcc: xtensa: fix fprintf format specifiers
+
+HOST_WIDE_INT may not be long as assumed in print_operand and
+xtensa_emit_call. Use HOST_WIDE_INT_PRINT_DEC/HOST_WIDE_INT_PRINT_HEX
+format strings instead of %ld/0x%lx. This fixes incorrect assembly code
+generation by the compiler running on armhf host.
+
+2017-05-28  Max Filippov  <jcmvbkbc@gmail.com>
+gcc/
+	* config/xtensa/xtensa.c (xtensa_emit_call): Use
+	HOST_WIDE_INT_PRINT_HEX instead of 0x%lx format string.
+	(print_operand): Use HOST_WIDE_INT_PRINT_DEC instead of %ld
+	format string.
+
+Signed-off-by: Max Filippov <jcmvbkbc@gmail.com>
+---
+ gcc/config/xtensa/xtensa.c | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/gcc/config/xtensa/xtensa.c b/gcc/config/xtensa/xtensa.c
+index d8c8298..3c00961 100644
+--- a/gcc/config/xtensa/xtensa.c
++++ b/gcc/config/xtensa/xtensa.c
+@@ -1785,7 +1785,7 @@ xtensa_emit_call (int callop, rtx *operands)
+   rtx tgt = operands[callop];
+ 
+   if (GET_CODE (tgt) == CONST_INT)
+-    sprintf (result, "call8\t0x%lx", INTVAL (tgt));
++    sprintf (result, "call8\t" HOST_WIDE_INT_PRINT_HEX, INTVAL (tgt));
+   else if (register_operand (tgt, VOIDmode))
+     sprintf (result, "callx8\t%%%d", callop);
+   else
+@@ -2360,14 +2360,14 @@ print_operand (FILE *file, rtx x, int letter)
+ 
+     case 'L':
+       if (GET_CODE (x) == CONST_INT)
+-	fprintf (file, "%ld", (32 - INTVAL (x)) & 0x1f);
++	fprintf (file, HOST_WIDE_INT_PRINT_DEC, (32 - INTVAL (x)) & 0x1f);
+       else
+ 	output_operand_lossage ("invalid %%L value");
+       break;
+ 
+     case 'R':
+       if (GET_CODE (x) == CONST_INT)
+-	fprintf (file, "%ld", INTVAL (x) & 0x1f);
++	fprintf (file, HOST_WIDE_INT_PRINT_DEC, INTVAL (x) & 0x1f);
+       else
+ 	output_operand_lossage ("invalid %%R value");
+       break;
+@@ -2381,7 +2381,7 @@ print_operand (FILE *file, rtx x, int letter)
+ 
+     case 'd':
+       if (GET_CODE (x) == CONST_INT)
+-	fprintf (file, "%ld", INTVAL (x));
++	fprintf (file, HOST_WIDE_INT_PRINT_DEC, INTVAL (x));
+       else
+ 	output_operand_lossage ("invalid %%d value");
+       break;
+@@ -2450,7 +2450,7 @@ print_operand (FILE *file, rtx x, int letter)
+       else if (GET_CODE (x) == MEM)
+ 	output_address (XEXP (x, 0));
+       else if (GET_CODE (x) == CONST_INT)
+-	fprintf (file, "%ld", INTVAL (x));
++	fprintf (file, HOST_WIDE_INT_PRINT_DEC, INTVAL (x));
+       else
+ 	output_addr_const (file, x);
+     }
+-- 
+2.1.4
+

--- a/patches/gcc/5.4.0/879-gcc-xtensa-fix-fprintf-format-specifiers.patch
+++ b/patches/gcc/5.4.0/879-gcc-xtensa-fix-fprintf-format-specifiers.patch
@@ -1,0 +1,74 @@
+From 1117c8be9e712f778739d751aa61038794437d7d Mon Sep 17 00:00:00 2001
+From: Max Filippov <jcmvbkbc@gmail.com>
+Date: Sun, 28 May 2017 19:56:56 -0700
+Subject: [PATCH] gcc: xtensa: fix fprintf format specifiers
+
+HOST_WIDE_INT may not be long as assumed in print_operand and
+xtensa_emit_call. Use HOST_WIDE_INT_PRINT_DEC/HOST_WIDE_INT_PRINT_HEX
+format strings instead of %ld/0x%lx. This fixes incorrect assembly code
+generation by the compiler running on armhf host.
+
+2017-05-28  Max Filippov  <jcmvbkbc@gmail.com>
+gcc/
+	* config/xtensa/xtensa.c (xtensa_emit_call): Use
+	HOST_WIDE_INT_PRINT_HEX instead of 0x%lx format string.
+	(print_operand): Use HOST_WIDE_INT_PRINT_DEC instead of %ld
+	format string.
+
+Signed-off-by: Max Filippov <jcmvbkbc@gmail.com>
+---
+ gcc/config/xtensa/xtensa.c | 11 ++++++-----
+ 1 file changed, 6 insertions(+), 5 deletions(-)
+
+diff --git a/gcc/config/xtensa/xtensa.c b/gcc/config/xtensa/xtensa.c
+index 36ab1e3..8e62d63 100644
+--- a/gcc/config/xtensa/xtensa.c
++++ b/gcc/config/xtensa/xtensa.c
+@@ -1811,7 +1811,8 @@ xtensa_emit_call (int callop, rtx *operands)
+   rtx tgt = operands[callop];
+ 
+   if (GET_CODE (tgt) == CONST_INT)
+-    sprintf (result, "call%d\t0x%lx", WINDOW_SIZE, INTVAL (tgt));
++    sprintf (result, "call%d\t" HOST_WIDE_INT_PRINT_HEX,
++	     WINDOW_SIZE, INTVAL (tgt));
+   else if (register_operand (tgt, VOIDmode))
+     sprintf (result, "callx%d\t%%%d", WINDOW_SIZE, callop);
+   else
+@@ -2382,14 +2383,14 @@ print_operand (FILE *file, rtx x, int letter)
+ 
+     case 'L':
+       if (GET_CODE (x) == CONST_INT)
+-	fprintf (file, "%ld", (32 - INTVAL (x)) & 0x1f);
++	fprintf (file, HOST_WIDE_INT_PRINT_DEC, (32 - INTVAL (x)) & 0x1f);
+       else
+ 	output_operand_lossage ("invalid %%L value");
+       break;
+ 
+     case 'R':
+       if (GET_CODE (x) == CONST_INT)
+-	fprintf (file, "%ld", INTVAL (x) & 0x1f);
++	fprintf (file, HOST_WIDE_INT_PRINT_DEC, INTVAL (x) & 0x1f);
+       else
+ 	output_operand_lossage ("invalid %%R value");
+       break;
+@@ -2403,7 +2404,7 @@ print_operand (FILE *file, rtx x, int letter)
+ 
+     case 'd':
+       if (GET_CODE (x) == CONST_INT)
+-	fprintf (file, "%ld", INTVAL (x));
++	fprintf (file, HOST_WIDE_INT_PRINT_DEC, INTVAL (x));
+       else
+ 	output_operand_lossage ("invalid %%d value");
+       break;
+@@ -2472,7 +2473,7 @@ print_operand (FILE *file, rtx x, int letter)
+       else if (GET_CODE (x) == MEM)
+ 	output_address (XEXP (x, 0));
+       else if (GET_CODE (x) == CONST_INT)
+-	fprintf (file, "%ld", INTVAL (x));
++	fprintf (file, HOST_WIDE_INT_PRINT_DEC, INTVAL (x));
+       else
+ 	output_addr_const (file, x);
+     }
+-- 
+2.1.4
+

--- a/patches/gcc/6.3.0/873-gcc-xtensa-fix-fprintf-format-specifiers.patch
+++ b/patches/gcc/6.3.0/873-gcc-xtensa-fix-fprintf-format-specifiers.patch
@@ -1,0 +1,74 @@
+From a3d07c8a2a9564b57ebcae8463c1541a37c97c34 Mon Sep 17 00:00:00 2001
+From: Max Filippov <jcmvbkbc@gmail.com>
+Date: Sun, 28 May 2017 19:56:56 -0700
+Subject: [PATCH] gcc: xtensa: fix fprintf format specifiers
+
+HOST_WIDE_INT may not be long as assumed in print_operand and
+xtensa_emit_call. Use HOST_WIDE_INT_PRINT_DEC/HOST_WIDE_INT_PRINT_HEX
+format strings instead of %ld/0x%lx. This fixes incorrect assembly code
+generation by the compiler running on armhf host.
+
+2017-05-28  Max Filippov  <jcmvbkbc@gmail.com>
+gcc/
+	* config/xtensa/xtensa.c (xtensa_emit_call): Use
+	HOST_WIDE_INT_PRINT_HEX instead of 0x%lx format string.
+	(print_operand): Use HOST_WIDE_INT_PRINT_DEC instead of %ld
+	format string.
+
+Signed-off-by: Max Filippov <jcmvbkbc@gmail.com>
+---
+ gcc/config/xtensa/xtensa.c | 11 ++++++-----
+ 1 file changed, 6 insertions(+), 5 deletions(-)
+
+diff --git a/gcc/config/xtensa/xtensa.c b/gcc/config/xtensa/xtensa.c
+index 70f698a..2bdf5cc 100644
+--- a/gcc/config/xtensa/xtensa.c
++++ b/gcc/config/xtensa/xtensa.c
+@@ -1776,7 +1776,8 @@ xtensa_emit_call (int callop, rtx *operands)
+   rtx tgt = operands[callop];
+ 
+   if (GET_CODE (tgt) == CONST_INT)
+-    sprintf (result, "call%d\t0x%lx", WINDOW_SIZE, INTVAL (tgt));
++    sprintf (result, "call%d\t" HOST_WIDE_INT_PRINT_HEX,
++	     WINDOW_SIZE, INTVAL (tgt));
+   else if (register_operand (tgt, VOIDmode))
+     sprintf (result, "callx%d\t%%%d", WINDOW_SIZE, callop);
+   else
+@@ -2347,14 +2348,14 @@ print_operand (FILE *file, rtx x, int letter)
+ 
+     case 'L':
+       if (GET_CODE (x) == CONST_INT)
+-	fprintf (file, "%ld", (32 - INTVAL (x)) & 0x1f);
++	fprintf (file, HOST_WIDE_INT_PRINT_DEC, (32 - INTVAL (x)) & 0x1f);
+       else
+ 	output_operand_lossage ("invalid %%L value");
+       break;
+ 
+     case 'R':
+       if (GET_CODE (x) == CONST_INT)
+-	fprintf (file, "%ld", INTVAL (x) & 0x1f);
++	fprintf (file, HOST_WIDE_INT_PRINT_DEC, INTVAL (x) & 0x1f);
+       else
+ 	output_operand_lossage ("invalid %%R value");
+       break;
+@@ -2368,7 +2369,7 @@ print_operand (FILE *file, rtx x, int letter)
+ 
+     case 'd':
+       if (GET_CODE (x) == CONST_INT)
+-	fprintf (file, "%ld", INTVAL (x));
++	fprintf (file, HOST_WIDE_INT_PRINT_DEC, INTVAL (x));
+       else
+ 	output_operand_lossage ("invalid %%d value");
+       break;
+@@ -2433,7 +2434,7 @@ print_operand (FILE *file, rtx x, int letter)
+       else if (GET_CODE (x) == MEM)
+ 	output_address (GET_MODE (x), XEXP (x, 0));
+       else if (GET_CODE (x) == CONST_INT)
+-	fprintf (file, "%ld", INTVAL (x));
++	fprintf (file, HOST_WIDE_INT_PRINT_DEC, INTVAL (x));
+       else
+ 	output_addr_const (file, x);
+     }
+-- 
+2.1.4
+

--- a/patches/gcc/7.1.0/870-gcc-xtensa-fix-fprintf-format-specifiers.patch
+++ b/patches/gcc/7.1.0/870-gcc-xtensa-fix-fprintf-format-specifiers.patch
@@ -1,0 +1,74 @@
+From 06689e5973647f5c65d1984b164f2531f5418d7a Mon Sep 17 00:00:00 2001
+From: Max Filippov <jcmvbkbc@gmail.com>
+Date: Sun, 28 May 2017 19:56:56 -0700
+Subject: [PATCH] gcc: xtensa: fix fprintf format specifiers
+
+HOST_WIDE_INT may not be long as assumed in print_operand and
+xtensa_emit_call. Use HOST_WIDE_INT_PRINT_DEC/HOST_WIDE_INT_PRINT_HEX
+format strings instead of %ld/0x%lx. This fixes incorrect assembly code
+generation by the compiler running on armhf host.
+
+2017-05-28  Max Filippov  <jcmvbkbc@gmail.com>
+gcc/
+	* config/xtensa/xtensa.c (xtensa_emit_call): Use
+	HOST_WIDE_INT_PRINT_HEX instead of 0x%lx format string.
+	(print_operand): Use HOST_WIDE_INT_PRINT_DEC instead of %ld
+	format string.
+
+Signed-off-by: Max Filippov <jcmvbkbc@gmail.com>
+---
+ gcc/config/xtensa/xtensa.c | 11 ++++++-----
+ 1 file changed, 6 insertions(+), 5 deletions(-)
+
+diff --git a/gcc/config/xtensa/xtensa.c b/gcc/config/xtensa/xtensa.c
+index 0181dde..25e4a28 100644
+--- a/gcc/config/xtensa/xtensa.c
++++ b/gcc/config/xtensa/xtensa.c
+@@ -1780,7 +1780,8 @@ xtensa_emit_call (int callop, rtx *operands)
+   rtx tgt = operands[callop];
+ 
+   if (GET_CODE (tgt) == CONST_INT)
+-    sprintf (result, "call%d\t0x%lx", WINDOW_SIZE, INTVAL (tgt));
++    sprintf (result, "call%d\t" HOST_WIDE_INT_PRINT_HEX,
++	     WINDOW_SIZE, INTVAL (tgt));
+   else if (register_operand (tgt, VOIDmode))
+     sprintf (result, "callx%d\t%%%d", WINDOW_SIZE, callop);
+   else
+@@ -2351,14 +2352,14 @@ print_operand (FILE *file, rtx x, int letter)
+ 
+     case 'L':
+       if (GET_CODE (x) == CONST_INT)
+-	fprintf (file, "%ld", (32 - INTVAL (x)) & 0x1f);
++	fprintf (file, HOST_WIDE_INT_PRINT_DEC, (32 - INTVAL (x)) & 0x1f);
+       else
+ 	output_operand_lossage ("invalid %%L value");
+       break;
+ 
+     case 'R':
+       if (GET_CODE (x) == CONST_INT)
+-	fprintf (file, "%ld", INTVAL (x) & 0x1f);
++	fprintf (file, HOST_WIDE_INT_PRINT_DEC, INTVAL (x) & 0x1f);
+       else
+ 	output_operand_lossage ("invalid %%R value");
+       break;
+@@ -2372,7 +2373,7 @@ print_operand (FILE *file, rtx x, int letter)
+ 
+     case 'd':
+       if (GET_CODE (x) == CONST_INT)
+-	fprintf (file, "%ld", INTVAL (x));
++	fprintf (file, HOST_WIDE_INT_PRINT_DEC, INTVAL (x));
+       else
+ 	output_operand_lossage ("invalid %%d value");
+       break;
+@@ -2437,7 +2438,7 @@ print_operand (FILE *file, rtx x, int letter)
+       else if (GET_CODE (x) == MEM)
+ 	output_address (GET_MODE (x), XEXP (x, 0));
+       else if (GET_CODE (x) == CONST_INT)
+-	fprintf (file, "%ld", INTVAL (x));
++	fprintf (file, HOST_WIDE_INT_PRINT_DEC, INTVAL (x));
+       else
+ 	output_addr_const (file, x);
+     }
+-- 
+2.1.4
+


### PR DESCRIPTION
Hi Alexey,

please pull the following fix for xtensa gcc:

xtensa GCC incorrectly uses %ld/0x%lx format specifiers to output
HOST_WIDE_INT values, which results in incorrect code generation by the
compiler built for armhf host.

The original issue:
  https://github.com/qca/open-ath9k-htc-firmware/issues/130

Thanks.
-- Max