### PR TITLE
Added MSP430 architecture support

### DIFF
--- a/config/arch/msp430.in
+++ b/config/arch/msp430.in
@@ -1,0 +1,8 @@
+# MSP430 specific config options
+
+## select ARCH_SUPPORTS_16
+## select ARCH_DEFAULT_16
+## select ARCH_REQUIRES_MULTILIB
+##
+## help The 16-bit MSP430 architecture, as defined by:
+## help     http://www.ti.com/lsds/ti/microcontrollers-16-bit-32-bit/msp/overview.page?HQS=msp430

--- a/config/target.in
+++ b/config/target.in
@@ -132,6 +132,9 @@ config ARCH_ENDIAN
 config ARCH_SUPPORTS_8
     bool
 
+config ARCH_SUPPORTS_16
+    bool
+
 config ARCH_SUPPORTS_32
     bool
 
@@ -164,6 +167,11 @@ config ARCH_8
     bool
     prompt "8-bit"
     depends on ARCH_SUPPORTS_8
+
+config ARCH_16
+    bool
+    prompt "16-bit"
+    depends on ARCH_SUPPORTS_16
 
 config ARCH_32
     bool

--- a/samples/msp430-unknown-elf/crosstool.config
+++ b/samples/msp430-unknown-elf/crosstool.config
@@ -1,0 +1,2 @@
+CT_ARCH_msp430=y
+CT_DEBUG_gdb=y

--- a/samples/msp430-unknown-elf/reported.by
+++ b/samples/msp430-unknown-elf/reported.by
@@ -1,0 +1,3 @@
+reporter_name="Andrew Wygle"
+reporter_url="https://github.com/awygle"
+reporter_comment="MSP430 16-bit toolchain"

--- a/scripts/build/arch/msp430.sh
+++ b/scripts/build/arch/msp430.sh
@@ -2,5 +2,4 @@
 
 CT_DoArchTupleValues() {
     CT_TARGET_ARCH="${CT_ARCH}"
-    CT_TARGET_SKIP_CONFIG_SUB="y"
 }

--- a/scripts/build/arch/msp430.sh
+++ b/scripts/build/arch/msp430.sh
@@ -1,0 +1,6 @@
+# Compute MSP430-specific values
+
+CT_DoArchTupleValues() {
+    CT_TARGET_ARCH="${CT_ARCH}"
+    CT_TARGET_SKIP_CONFIG_SUB="y"
+}


### PR DESCRIPTION
Added support for the MSP430 architecture. 

First patch to crosstool-ng, fully anticipating some feedback. In particular the hack added to set `CT_TARGET_SKIP_CONFIG_SUB="y"` in `CT_DoArchTupleValues ` seems likely to produce pushback, but it annoyed me that I couldn't use msp430-elf as my target (the canonicalizer in config.sub overrides the empty `CT_TARGET_VENDOR`).

Signed-off-by: Andrew Wygle <awygle@gmail.com>