### PR TITLE
Force wide char support in uClibc if GDB8 is enabled

### DIFF
--- a/config/debug/gdb.in.gdbserver
+++ b/config/debug/gdb.in.gdbserver
@@ -5,6 +5,7 @@ config GDB_GDBSERVER
     prompt "gdbserver"
     default y
     depends on ! BARE_METAL
+    select LIBC_UCLIBC_WCHAR if LIBC_uClibc && GDB_8_0_or_later
     help
       Build and install a gdbserver for the target, to run on the target.
 

--- a/config/debug/gdb.in.native
+++ b/config/debug/gdb.in.native
@@ -6,6 +6,7 @@ config GDB_NATIVE
     depends on ! BARE_METAL
     depends on ! LIBC_bionic
     depends on CC_LANG_CXX || !GDB_8_0_or_later
+    select LIBC_UCLIBC_WCHAR if LIBC_uClibc && GDB_8_0_or_later
     select EXPAT_TARGET
     select NCURSES_TARGET
     help


### PR DESCRIPTION
GDB8 (or rather gnulib that is a part of it) provides a fallback mbstate_t
definition - but GCC's C++ headers (which are used via stdint.h since GDB8
uses C++) provide another mbstate_t if libc does not have wide char support.
These two definitions conflict with each other.

Signed-off-by: Alexey Neyman <stilor@att.net>