### PR TITLE
Declare msp430 experimental

### DIFF
--- a/config/arch/msp430.in
+++ b/config/arch/msp430.in
@@ -3,6 +3,7 @@
 ## select ARCH_SUPPORTS_16
 ## select ARCH_DEFAULT_16
 ## select ARCH_REQUIRES_MULTILIB
+## depends on EXPERIMENTAL
 ##
 ## help The 16-bit MSP430 architecture, as defined by:
 ## help     http://www.ti.com/lsds/ti/microcontrollers-16-bit-32-bit/msp/overview.page?HQS=msp430

--- a/samples/msp430-unknown-elf/crosstool.config
+++ b/samples/msp430-unknown-elf/crosstool.config
@@ -1,2 +1,4 @@
+CT_EXPERIMENTAL=y
 CT_ARCH_msp430=y
+CT_CC_GCC_V_4_9_4=y
 CT_DEBUG_gdb=y

--- a/samples/msp430-unknown-elf/reported.by
+++ b/samples/msp430-unknown-elf/reported.by
@@ -1,3 +1,4 @@
 reporter_name="Andrew Wygle"
 reporter_url="https://github.com/awygle"
-reporter_comment="MSP430 16-bit toolchain"
+reporter_comment="MSP430 with GCC5 and later suffers from a pretty nasty bug:
+https://gcc.gnu.org/bugzilla/show_bug.cgi?id=79242"


### PR DESCRIPTION
... as GCC5 and later ICEs over inocuous code.
See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=79242

Signed-off-by: Alexey Neyman <stilor@att.net>