### PR TITLE
Make ARM32 option appear only if 32-bit is selected

### DIFF
--- a/config/arch/arm.in.2
+++ b/config/arch/arm.in.2
@@ -1,5 +1,6 @@
 # ARM specific configuration file
 
+if ARCH_32
 config ARCH_ARM_MODE
     string
     default "arm"   if ARCH_ARM_MODE_ARM
@@ -91,3 +92,5 @@ config ARCH_ARM_TUPLE_USE_EABIHF
 
       Say 'n', unless you are trying to fix gcc to properly recognise
       the *eabihf tuples.
+
+endif

--- a/config/target.in
+++ b/config/target.in
@@ -144,6 +144,9 @@ config ARCH_SUPPORTS_64
 config ARCH_DEFAULT_8
     bool
 
+config ARCH_DEFAULT_16
+    bool
+
 config ARCH_DEFAULT_32
     bool
 
@@ -153,6 +156,7 @@ config ARCH_DEFAULT_64
 config ARCH_BITNESS
     int
     default "8"     if ARCH_8
+    default "16"    if ARCH_16
     default "32"    if ARCH_32
     default "64"    if ARCH_64
 
@@ -160,6 +164,7 @@ choice
     bool
     prompt "Bitness:"
     default ARCH_8  if ARCH_DEFAULT_8
+    default ARCH_16 if ARCH_DEFAULT_16
     default ARCH_32 if ARCH_DEFAULT_32
     default ARCH_64 if ARCH_DEFAULT_64
 


### PR DESCRIPTION
Fixes #745

Signed-off-by: Alexey Neyman <stilor@att.net>