### PR TITLE
Set CT_BUILD_DIR prior to using it

### DIFF
--- a/scripts/crosstool-NG.sh.in
+++ b/scripts/crosstool-NG.sh.in
@@ -90,6 +90,7 @@ done
 
 # Where will we work?
 CT_WORK_DIR="${CT_WORK_DIR:-${CT_TOP_DIR}/.build}"
+CT_BUILD_DIR="${CT_BUILD_TOP_DIR}/build"
 CT_DoExecLog ALL mkdir -p "${CT_WORK_DIR}"
 CT_DoExecLog DEBUG rm -f "${CT_WORK_DIR}/backtrace"
 
@@ -166,7 +167,6 @@ CT_PKGVERSION="crosstool-NG ${CT_VERSION}${CT_TOOLCHAIN_PKGVERSION:+ - ${CT_TOOL
 # Compute the working directories names
 CT_TARBALLS_DIR="${CT_WORK_DIR}/tarballs"
 CT_SRC_DIR="${CT_WORK_DIR}/src"
-CT_BUILD_DIR="${CT_BUILD_TOP_DIR}/build"
 CT_BUILDTOOLS_PREFIX_DIR="${CT_BUILD_TOP_DIR}/buildtools"
 CT_STATE_DIR="${CT_WORK_DIR}/${CT_TARGET}/state"
 # Note about HOST_COMPLIBS_DIR: it's always gonna be in the buildtools dir, or a


### PR DESCRIPTION
Fixes #731

CT_BUILD_DIR is used in CT_DoExecLog. We need to ensure that it is
set before the first call to CT_DoExecLog.

Signed-off-by: Chris Packham <judge.packham@gmail.com>