### PR TITLE
DO NOT MERGE .travis.yml: add support for OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@
 dist: trusty
 sudo: false
 
+os:
+    - linux
+    - osx
+
 # 'bash' will define a generic environment without interfering environment
 # settings like "CC=gcc"
 language: bash
@@ -29,8 +33,26 @@ addons:
             - help2man
             - g++
 
+before_install:
+    - if test "$TRAVIS_OS_NAME" = "osx"; then brew update; fi
+    - if test "$TRAVIS_OS_NAME" = "osx"; then brew install autoconf || true; fi
+    - if test "$TRAVIS_OS_NAME" = "osx"; then brew install binutils || true; fi
+    - if test "$TRAVIS_OS_NAME" = "osx"; then brew install gawk || true; fi
+    - if test "$TRAVIS_OS_NAME" = "osx"; then brew install gmp || true; fi
+    - if test "$TRAVIS_OS_NAME" = "osx"; then brew install gnu-sed || true; fi
+    - if test "$TRAVIS_OS_NAME" = "osx"; then brew install grep || true; fi
+    - if test "$TRAVIS_OS_NAME" = "osx"; then brew install help2man || true; fi
+    - if test "$TRAVIS_OS_NAME" = "osx"; then brew install mpfr || true; fi
+    - if test "$TRAVIS_OS_NAME" = "osx"; then brew install openssl || true; fi
+    - if test "$TRAVIS_OS_NAME" = "osx"; then brew install pcre || true; fi
+    - if test "$TRAVIS_OS_NAME" = "osx"; then brew install readline || true; fi
+    - if test "$TRAVIS_OS_NAME" = "osx"; then brew install wget || true; fi
+    - if test "$TRAVIS_OS_NAME" = "osx"; then brew install xz || true; fi
+
+
 # Building crosstool-NG core
 install:
+    - if test "$TRAVIS_OS_NAME" = "osx"; then export SED=gsed; fi
     - ./bootstrap
     - ./configure --enable-local
     - make


### PR DESCRIPTION
I've been playing a bit with enabling osx support in the ct-ng travis configuration. It's not working yet but I figured I'd get this out there so that someone who knows more about osx and/or travis can tell me where I'm going wrong.

Outstanding issues:
* The configure step can't detect the sed version. It correctly picks up gsed but when it checks for the version being >= 4.0 it fails. The output from gsed --version looks like something that should match the ````'GNU sed[^0-9]* [4-9]\.'```` regex but ````ACX_PROG_VERSION_REQ_STRICT```` still fails. I tried switching to GNU grep but still no lock.
* I've had to add || true to all the brew invocations because it's considered an error if you try to install something that has a newer version. I don't know if brew upgrade will work any better for things that don't have a newer version or aren't currently installed.