### PR TITLE
Obey CONFIG_SHELL when configuring ltrace.

### DIFF
--- a/scripts/build/debug/400-ltrace.sh
+++ b/scripts/build/debug/400-ltrace.sh
@@ -46,11 +46,13 @@ do_debug_ltrace_build() {
         ${CONFIG_SHELL}                 \
         ./configure --prefix=/usr
     else
-        CT_DoExecLog CFG        \
-        ${CONFIG_SHELL}         \
-        ./configure             \
-            --build=${CT_BUILD} \
-            --host=${CT_TARGET} \
+        CT_DoExecLog CFG               \
+        CONFIG_SHELL=${CONFIG_SHELL}   \
+        ${CONFIG_SHELL}                \
+        ./configure                    \
+            CONFIG_SHELL=${CONFIG_SHELL}\
+            --build=${CT_BUILD}        \
+            --host=${CT_TARGET}        \
             --prefix=/usr
     fi
 


### PR DESCRIPTION
According to the INSTALL readme:

 Unfortunately, this technique does not work for `CONFIG_SHELL' due to
 an Autoconf bug.  Until the bug is fixed you can use this workaround:

     CONFIG_SHELL=/bin/bash /bin/bash ./configure CONFIG_SHELL=/bin/bash