### PR TITLE
Add option to build gdbserver for target that does not require libstdc++.so

### DIFF
--- a/config/debug/gdb.in.gdbserver
+++ b/config/debug/gdb.in.gdbserver
@@ -40,6 +40,15 @@ config GDB_GDBSERVER_STATIC
       https://sourceware.org/bugzilla/show_bug.cgi?id=19617
       https://sourceware.org/bugzilla/show_bug.cgi?id=21086
 
+config GDB_GDBSERVER_STATIC_LIBSTDCXX
+    bool
+    prompt "Link against static libstdc+++"
+    depends on !GDB_GDBSERVER_STATIC
+    default n
+    help
+      Say 'y' if you do not want gdbserver to require libstdc++.so on the
+      target.
+
 config GDB_GDBSERVER_BUILD_IPA_LIB
     bool
     prompt "Build the IPA library"

--- a/scripts/build/debug/300-gdb.sh
+++ b/scripts/build/debug/300-gdb.sh
@@ -319,6 +319,10 @@ do_debug_gdb_build() {
             gdbserver_LDFLAGS=-static
         fi
 
+        if [ "${CT_GDB_GDBSERVER_STATIC_LIBSTDCXX}" = "y" ]; then
+            gdbserver_LDFLAGS+=" -static-libstdc++"
+        fi
+
         gdbserver_extra_config=("${extra_config[@]}")
 
         # We may not have C++ language configured for target


### PR DESCRIPTION
Workaround for issue #753

Before:
```
# ldd /usr/bin/gdbserver 
        libdl.so.2 => /lib/libdl.so.2 (0x400dc000)
        libstdc++.so.6 => /lib/libstdc++.so.6 (0x400ef000)
        libm.so.6 => /lib/libm.so.6 (0x4027c000)
        libgcc_s.so.1 => /lib/libgcc_s.so.1 (0x4007b000)
        libc.so.6 => /lib/libc.so.6 (0x40341000)
        /lib/ld-linux.so.3 (0x4004a000)
```
After:
```
# ldd /usr/bin/gdbserver
        libdl.so.2 => /lib/libdl.so.2 (0x401e0000)
        libm.so.6 => /lib/libm.so.6 (0x400f7000)
        libgcc_s.so.1 => /lib/libgcc_s.so.1 (0x401f3000)
        libc.so.6 => /lib/libc.so.6 (0x40223000)
        /lib/ld-linux.so.3 (0x400c4000)
```