### PR TITLE
nios2: fix architecture features

### DIFF
--- a/config/arch/nios2.in
+++ b/config/arch/nios2.in
@@ -3,7 +3,7 @@
 ## select ARCH_SUPPORTS_32
 ## select ARCH_DEFAULT_32
 ## select ARCH_DEFAULT_LE
-## select ARCH_SUPPORTS_WITH_CPU
+## select ARCH_SUPPORTS_WITH_ARCH
 ##
 ## help The NIOS2 architecture, as defined by:
 ## help     http://www.altera.com


### PR DESCRIPTION
Gcc for Nios II does not support -mcpu option, and --with-cpu=XXX flag
breaks gcc compilation. Use --with-arch instead.

Signed-off-by: Kirill Smirnov <kirill.k.smirnov@gmail.com>