### PR TITLE
Bump expat version to 2.2.1 for security fixes

### DIFF
--- a/config/companion_libs/expat.in
+++ b/config/companion_libs/expat.in
@@ -6,9 +6,9 @@ choice
 # Don't remove next line
 # CT_INSERT_VERSION_BELOW
 
-config EXPAT_V_2_2_0
+config EXPAT_V_2_2_1
     bool
-    prompt "2.2.0"
+    prompt "2.2.1"
 
 config EXPAT_V_2_1_1
     bool
@@ -21,5 +21,5 @@ config EXPAT_VERSION
     string
 # Don't remove next line
 # CT_INSERT_VERSION_STRING_BELOW
-    default "2.2.0" if EXPAT_V_2_2_0
+    default "2.2.1" if EXPAT_V_2_2_1
     default "2.1.1" if EXPAT_V_2_1_1


### PR DESCRIPTION
Expat 2.2.0 and earlier were affected by CVE-2017-923. Expat 2.2.1
provides the corresponding security fixes.