### PR TITLE
Allow for reproducible builds

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -177,7 +177,7 @@ build-doc:
 build-man: docs/$(PROG_NAME).1.gz
 
 docs/$(PROG_NAME).1.gz: docs/$(PROG_NAME).1
-	$(call __silent,GZIP)gzip -c9 $< >$@
+	$(call __silent,GZIP)gzip -c9n $< >$@
 
 define sed_it
 	$(call __silent,SED,$@)$(sed) -r                    \

--- a/configure.ac
+++ b/configure.ac
@@ -424,9 +424,13 @@ AC_SEARCH_LIBS(
 # Lastly, take care of crosstool-NG internal values
 #--------------------------------------------------------------------
 # Hey! We need the date! :-)
-AC_SUBST(
-    [DATE],
-    [$(date +%Y%m%d)])
+DATE_FMT="%Y%m%d"
+if test "x$SOURCE_DATE_EPOCH" = "x"; then
+    DATE=$(date "+$DATE_FMT")
+else
+    DATE="$(date -u -d "@$SOURCE_DATE_EPOCH" "+$DATE_FMT" 2>/dev/null || date -u -r "$SOURCE_DATE_EPOCH" "+$DATE_FMT" 2>/dev/null || date -u "+$DATE_FMT")"
+fi
+AC_SUBST([DATE])
 
 # Decorate the version string if needed
 AS_IF(


### PR DESCRIPTION
Allow to override build date
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

This date call is designed to work with both GNU date and BSD date.

Note: is not properly tested yet