### PR TITLE
scripts: remove superfluous dot

### DIFF
--- a/scripts/functions
+++ b/scripts/functions
@@ -658,8 +658,8 @@ CT_GetFileBasename()
     local ext
 
     for ext in $(CT_DoListTarballExt); do
-        if [ "${bn%.${ext}}" != "${bn}" ]; then
-            echo "${bn%.${ext}}"
+        if [ "${bn%${ext}}" != "${bn}" ]; then
+            echo "${bn%${ext}}"
             exit 0
         fi
     done


### PR DESCRIPTION
Tarball extensions list already contains leading dot,
do not add another one.

Signed-off-by: Kirill Smirnov <kirill.k.smirnov@gmail.com>