### PR TITLE
Fix regressions after binutils 2.29

### DIFF
--- a/packages/glibc/2.12.1/998-obstack-common.patch
+++ b/packages/glibc/2.12.1/998-obstack-common.patch
@@ -1,0 +1,30 @@
+commit 39b1f6172a2f9ddc74a8f82d6e84dd13b22dbaf2
+Author: Peter Collingbourne <pcc@google.com>
+Date:   Wed May 15 20:28:08 2013 +0200
+
+    Move _obstack_compat out of common
+    
+    it is impossible to create an alias of a common symbol (as
+    compat_symbol does), because common symbols do not have a section or
+    an offset until linked.  GNU as tolerates aliases of common symbols by
+    simply creating another common symbol, but other assemblers (notably
+    LLVM's integrated assembler) are less tolerant.
+    
+    2013-05-15  Peter Collingbourne  <pcc@google.com>
+    
+            * malloc/obstack.c (_obstack_compat): Add initializer.
+    -
+
+diff --git a/malloc/obstack.c b/malloc/obstack.c
+index 25a90514f7..c3c7db4a96 100644
+--- a/malloc/obstack.c
++++ b/malloc/obstack.c
+@@ -115,7 +115,7 @@ int obstack_exit_failure = EXIT_FAILURE;
+ /* A looong time ago (before 1994, anyway; we're not sure) this global variable
+    was used by non-GNU-C macros to avoid multiple evaluation.  The GNU C
+    library still exports it because somebody might use it.  */
+-struct obstack *_obstack_compat;
++struct obstack *_obstack_compat = 0;
+ compat_symbol (libc, _obstack_compat, _obstack, GLIBC_2_0);
+ #  endif
+ # endif

--- a/packages/glibc/2.12.2/998-obstack-common.patch
+++ b/packages/glibc/2.12.2/998-obstack-common.patch
@@ -1,0 +1,30 @@
+commit 39b1f6172a2f9ddc74a8f82d6e84dd13b22dbaf2
+Author: Peter Collingbourne <pcc@google.com>
+Date:   Wed May 15 20:28:08 2013 +0200
+
+    Move _obstack_compat out of common
+    
+    it is impossible to create an alias of a common symbol (as
+    compat_symbol does), because common symbols do not have a section or
+    an offset until linked.  GNU as tolerates aliases of common symbols by
+    simply creating another common symbol, but other assemblers (notably
+    LLVM's integrated assembler) are less tolerant.
+    
+    2013-05-15  Peter Collingbourne  <pcc@google.com>
+    
+            * malloc/obstack.c (_obstack_compat): Add initializer.
+    -
+
+diff --git a/malloc/obstack.c b/malloc/obstack.c
+index 25a90514f7..c3c7db4a96 100644
+--- a/malloc/obstack.c
++++ b/malloc/obstack.c
+@@ -115,7 +115,7 @@ int obstack_exit_failure = EXIT_FAILURE;
+ /* A looong time ago (before 1994, anyway; we're not sure) this global variable
+    was used by non-GNU-C macros to avoid multiple evaluation.  The GNU C
+    library still exports it because somebody might use it.  */
+-struct obstack *_obstack_compat;
++struct obstack *_obstack_compat = 0;
+ compat_symbol (libc, _obstack_compat, _obstack, GLIBC_2_0);
+ #  endif
+ # endif

--- a/packages/glibc/2.13/998-obstack-common.patch
+++ b/packages/glibc/2.13/998-obstack-common.patch
@@ -1,0 +1,30 @@
+commit 39b1f6172a2f9ddc74a8f82d6e84dd13b22dbaf2
+Author: Peter Collingbourne <pcc@google.com>
+Date:   Wed May 15 20:28:08 2013 +0200
+
+    Move _obstack_compat out of common
+    
+    it is impossible to create an alias of a common symbol (as
+    compat_symbol does), because common symbols do not have a section or
+    an offset until linked.  GNU as tolerates aliases of common symbols by
+    simply creating another common symbol, but other assemblers (notably
+    LLVM's integrated assembler) are less tolerant.
+    
+    2013-05-15  Peter Collingbourne  <pcc@google.com>
+    
+            * malloc/obstack.c (_obstack_compat): Add initializer.
+    -
+
+diff --git a/malloc/obstack.c b/malloc/obstack.c
+index 25a90514f7..c3c7db4a96 100644
+--- a/malloc/obstack.c
++++ b/malloc/obstack.c
+@@ -115,7 +115,7 @@ int obstack_exit_failure = EXIT_FAILURE;
+ /* A looong time ago (before 1994, anyway; we're not sure) this global variable
+    was used by non-GNU-C macros to avoid multiple evaluation.  The GNU C
+    library still exports it because somebody might use it.  */
+-struct obstack *_obstack_compat;
++struct obstack *_obstack_compat = 0;
+ compat_symbol (libc, _obstack_compat, _obstack, GLIBC_2_0);
+ #  endif
+ # endif

--- a/packages/glibc/2.14.1/998-obstack-common.patch
+++ b/packages/glibc/2.14.1/998-obstack-common.patch
@@ -1,0 +1,30 @@
+commit 39b1f6172a2f9ddc74a8f82d6e84dd13b22dbaf2
+Author: Peter Collingbourne <pcc@google.com>
+Date:   Wed May 15 20:28:08 2013 +0200
+
+    Move _obstack_compat out of common
+    
+    it is impossible to create an alias of a common symbol (as
+    compat_symbol does), because common symbols do not have a section or
+    an offset until linked.  GNU as tolerates aliases of common symbols by
+    simply creating another common symbol, but other assemblers (notably
+    LLVM's integrated assembler) are less tolerant.
+    
+    2013-05-15  Peter Collingbourne  <pcc@google.com>
+    
+            * malloc/obstack.c (_obstack_compat): Add initializer.
+    -
+
+diff --git a/malloc/obstack.c b/malloc/obstack.c
+index 25a90514f7..c3c7db4a96 100644
+--- a/malloc/obstack.c
++++ b/malloc/obstack.c
+@@ -115,7 +115,7 @@ int obstack_exit_failure = EXIT_FAILURE;
+ /* A looong time ago (before 1994, anyway; we're not sure) this global variable
+    was used by non-GNU-C macros to avoid multiple evaluation.  The GNU C
+    library still exports it because somebody might use it.  */
+-struct obstack *_obstack_compat;
++struct obstack *_obstack_compat = 0;
+ compat_symbol (libc, _obstack_compat, _obstack, GLIBC_2_0);
+ #  endif
+ # endif

--- a/packages/glibc/2.14/998-obstack-common.patch
+++ b/packages/glibc/2.14/998-obstack-common.patch
@@ -1,0 +1,30 @@
+commit 39b1f6172a2f9ddc74a8f82d6e84dd13b22dbaf2
+Author: Peter Collingbourne <pcc@google.com>
+Date:   Wed May 15 20:28:08 2013 +0200
+
+    Move _obstack_compat out of common
+    
+    it is impossible to create an alias of a common symbol (as
+    compat_symbol does), because common symbols do not have a section or
+    an offset until linked.  GNU as tolerates aliases of common symbols by
+    simply creating another common symbol, but other assemblers (notably
+    LLVM's integrated assembler) are less tolerant.
+    
+    2013-05-15  Peter Collingbourne  <pcc@google.com>
+    
+            * malloc/obstack.c (_obstack_compat): Add initializer.
+    -
+
+diff --git a/malloc/obstack.c b/malloc/obstack.c
+index 25a90514f7..c3c7db4a96 100644
+--- a/malloc/obstack.c
++++ b/malloc/obstack.c
+@@ -115,7 +115,7 @@ int obstack_exit_failure = EXIT_FAILURE;
+ /* A looong time ago (before 1994, anyway; we're not sure) this global variable
+    was used by non-GNU-C macros to avoid multiple evaluation.  The GNU C
+    library still exports it because somebody might use it.  */
+-struct obstack *_obstack_compat;
++struct obstack *_obstack_compat = 0;
+ compat_symbol (libc, _obstack_compat, _obstack, GLIBC_2_0);
+ #  endif
+ # endif

--- a/packages/glibc/2.15/998-obstack-common.patch
+++ b/packages/glibc/2.15/998-obstack-common.patch
@@ -1,0 +1,30 @@
+commit 39b1f6172a2f9ddc74a8f82d6e84dd13b22dbaf2
+Author: Peter Collingbourne <pcc@google.com>
+Date:   Wed May 15 20:28:08 2013 +0200
+
+    Move _obstack_compat out of common
+    
+    it is impossible to create an alias of a common symbol (as
+    compat_symbol does), because common symbols do not have a section or
+    an offset until linked.  GNU as tolerates aliases of common symbols by
+    simply creating another common symbol, but other assemblers (notably
+    LLVM's integrated assembler) are less tolerant.
+    
+    2013-05-15  Peter Collingbourne  <pcc@google.com>
+    
+            * malloc/obstack.c (_obstack_compat): Add initializer.
+    -
+
+diff --git a/malloc/obstack.c b/malloc/obstack.c
+index 25a90514f7..c3c7db4a96 100644
+--- a/malloc/obstack.c
++++ b/malloc/obstack.c
+@@ -115,7 +115,7 @@ int obstack_exit_failure = EXIT_FAILURE;
+ /* A looong time ago (before 1994, anyway; we're not sure) this global variable
+    was used by non-GNU-C macros to avoid multiple evaluation.  The GNU C
+    library still exports it because somebody might use it.  */
+-struct obstack *_obstack_compat;
++struct obstack *_obstack_compat = 0;
+ compat_symbol (libc, _obstack_compat, _obstack, GLIBC_2_0);
+ #  endif
+ # endif

--- a/packages/glibc/2.16.0/998-obstack-common.patch
+++ b/packages/glibc/2.16.0/998-obstack-common.patch
@@ -1,0 +1,30 @@
+commit 39b1f6172a2f9ddc74a8f82d6e84dd13b22dbaf2
+Author: Peter Collingbourne <pcc@google.com>
+Date:   Wed May 15 20:28:08 2013 +0200
+
+    Move _obstack_compat out of common
+    
+    it is impossible to create an alias of a common symbol (as
+    compat_symbol does), because common symbols do not have a section or
+    an offset until linked.  GNU as tolerates aliases of common symbols by
+    simply creating another common symbol, but other assemblers (notably
+    LLVM's integrated assembler) are less tolerant.
+    
+    2013-05-15  Peter Collingbourne  <pcc@google.com>
+    
+            * malloc/obstack.c (_obstack_compat): Add initializer.
+    -
+
+diff --git a/malloc/obstack.c b/malloc/obstack.c
+index 25a90514f7..c3c7db4a96 100644
+--- a/malloc/obstack.c
++++ b/malloc/obstack.c
+@@ -115,7 +115,7 @@ int obstack_exit_failure = EXIT_FAILURE;
+ /* A looong time ago (before 1994, anyway; we're not sure) this global variable
+    was used by non-GNU-C macros to avoid multiple evaluation.  The GNU C
+    library still exports it because somebody might use it.  */
+-struct obstack *_obstack_compat;
++struct obstack *_obstack_compat = 0;
+ compat_symbol (libc, _obstack_compat, _obstack, GLIBC_2_0);
+ #  endif
+ # endif

--- a/packages/glibc/2.17/998-obstack-common.patch
+++ b/packages/glibc/2.17/998-obstack-common.patch
@@ -1,0 +1,30 @@
+commit 39b1f6172a2f9ddc74a8f82d6e84dd13b22dbaf2
+Author: Peter Collingbourne <pcc@google.com>
+Date:   Wed May 15 20:28:08 2013 +0200
+
+    Move _obstack_compat out of common
+    
+    it is impossible to create an alias of a common symbol (as
+    compat_symbol does), because common symbols do not have a section or
+    an offset until linked.  GNU as tolerates aliases of common symbols by
+    simply creating another common symbol, but other assemblers (notably
+    LLVM's integrated assembler) are less tolerant.
+    
+    2013-05-15  Peter Collingbourne  <pcc@google.com>
+    
+            * malloc/obstack.c (_obstack_compat): Add initializer.
+    -
+
+diff --git a/malloc/obstack.c b/malloc/obstack.c
+index 25a90514f7..c3c7db4a96 100644
+--- a/malloc/obstack.c
++++ b/malloc/obstack.c
+@@ -115,7 +115,7 @@ int obstack_exit_failure = EXIT_FAILURE;
+ /* A looong time ago (before 1994, anyway; we're not sure) this global variable
+    was used by non-GNU-C macros to avoid multiple evaluation.  The GNU C
+    library still exports it because somebody might use it.  */
+-struct obstack *_obstack_compat;
++struct obstack *_obstack_compat = 0;
+ compat_symbol (libc, _obstack_compat, _obstack, GLIBC_2_0);
+ #  endif
+ # endif

--- a/packages/glibc/2.23/997-regexp-common.patch
+++ b/packages/glibc/2.23/997-regexp-common.patch
@@ -1,0 +1,58 @@
+commit 388b4f1a02f3a801965028bbfcd48d905638b797
+Author: H.J. Lu <hjl.tools@gmail.com>
+Date:   Fri Jun 23 14:38:46 2017 -0700
+
+    Avoid .symver on common symbols [BZ #21666]
+    
+    The .symver directive on common symbol just creates a new common symbol,
+    not an alias and the newer assembler with the bug fix for
+    
+    https://sourceware.org/bugzilla/show_bug.cgi?id=21661
+    
+    will issue an error.  Before the fix, we got
+    
+    $ readelf -sW libc.so | grep "loc[12s]"
+      5109: 00000000003a0608     8 OBJECT  LOCAL  DEFAULT   36 loc1
+      5188: 00000000003a0610     8 OBJECT  LOCAL  DEFAULT   36 loc2
+      5455: 00000000003a0618     8 OBJECT  LOCAL  DEFAULT   36 locs
+      6575: 00000000003a05f0     8 OBJECT  GLOBAL DEFAULT   36 locs@GLIBC_2.2.5
+      7156: 00000000003a05f8     8 OBJECT  GLOBAL DEFAULT   36 loc1@GLIBC_2.2.5
+      7312: 00000000003a0600     8 OBJECT  GLOBAL DEFAULT   36 loc2@GLIBC_2.2.5
+    
+    in libc.so.  The versioned loc1, loc2 and locs have the wrong addresses.
+    After the fix, we got
+    
+    $ readelf -sW libc.so | grep "loc[12s]"
+      6570: 000000000039e3b8     8 OBJECT  GLOBAL DEFAULT   34 locs@GLIBC_2.2.5
+      7151: 000000000039e3c8     8 OBJECT  GLOBAL DEFAULT   34 loc1@GLIBC_2.2.5
+      7307: 000000000039e3c0     8 OBJECT  GLOBAL DEFAULT   34 loc2@GLIBC_2.2.5
+    
+            [BZ #21666]
+            * misc/regexp.c (loc1): Add __attribute__ ((nocommon));
+            (loc2): Likewise.
+            (locs): Likewise.
+
+diff --git a/misc/regexp.c b/misc/regexp.c
+index 19d76c0c37..eaea7c3b89 100644
+--- a/misc/regexp.c
++++ b/misc/regexp.c
+@@ -29,14 +29,15 @@
+ 
+ #if SHLIB_COMPAT (libc, GLIBC_2_0, GLIBC_2_23)
+ 
+-/* Define the variables used for the interface.  */
+-char *loc1;
+-char *loc2;
++/* Define the variables used for the interface.  Avoid .symver on common
++   symbol, which just creates a new common symbol, not an alias.  */
++char *loc1 __attribute__ ((nocommon));
++char *loc2 __attribute__ ((nocommon));
+ compat_symbol (libc, loc1, loc1, GLIBC_2_0);
+ compat_symbol (libc, loc2, loc2, GLIBC_2_0);
+ 
+ /* Although we do not support the use we define this variable as well.  */
+-char *locs;
++char *locs __attribute__ ((nocommon));
+ compat_symbol (libc, locs, locs, GLIBC_2_0);
+ 
+ 

--- a/packages/glibc/2.24/997-regexp-common.patch
+++ b/packages/glibc/2.24/997-regexp-common.patch
@@ -1,0 +1,58 @@
+commit 388b4f1a02f3a801965028bbfcd48d905638b797
+Author: H.J. Lu <hjl.tools@gmail.com>
+Date:   Fri Jun 23 14:38:46 2017 -0700
+
+    Avoid .symver on common symbols [BZ #21666]
+    
+    The .symver directive on common symbol just creates a new common symbol,
+    not an alias and the newer assembler with the bug fix for
+    
+    https://sourceware.org/bugzilla/show_bug.cgi?id=21661
+    
+    will issue an error.  Before the fix, we got
+    
+    $ readelf -sW libc.so | grep "loc[12s]"
+      5109: 00000000003a0608     8 OBJECT  LOCAL  DEFAULT   36 loc1
+      5188: 00000000003a0610     8 OBJECT  LOCAL  DEFAULT   36 loc2
+      5455: 00000000003a0618     8 OBJECT  LOCAL  DEFAULT   36 locs
+      6575: 00000000003a05f0     8 OBJECT  GLOBAL DEFAULT   36 locs@GLIBC_2.2.5
+      7156: 00000000003a05f8     8 OBJECT  GLOBAL DEFAULT   36 loc1@GLIBC_2.2.5
+      7312: 00000000003a0600     8 OBJECT  GLOBAL DEFAULT   36 loc2@GLIBC_2.2.5
+    
+    in libc.so.  The versioned loc1, loc2 and locs have the wrong addresses.
+    After the fix, we got
+    
+    $ readelf -sW libc.so | grep "loc[12s]"
+      6570: 000000000039e3b8     8 OBJECT  GLOBAL DEFAULT   34 locs@GLIBC_2.2.5
+      7151: 000000000039e3c8     8 OBJECT  GLOBAL DEFAULT   34 loc1@GLIBC_2.2.5
+      7307: 000000000039e3c0     8 OBJECT  GLOBAL DEFAULT   34 loc2@GLIBC_2.2.5
+    
+            [BZ #21666]
+            * misc/regexp.c (loc1): Add __attribute__ ((nocommon));
+            (loc2): Likewise.
+            (locs): Likewise.
+
+diff --git a/misc/regexp.c b/misc/regexp.c
+index 19d76c0c37..eaea7c3b89 100644
+--- a/misc/regexp.c
++++ b/misc/regexp.c
+@@ -29,14 +29,15 @@
+ 
+ #if SHLIB_COMPAT (libc, GLIBC_2_0, GLIBC_2_23)
+ 
+-/* Define the variables used for the interface.  */
+-char *loc1;
+-char *loc2;
++/* Define the variables used for the interface.  Avoid .symver on common
++   symbol, which just creates a new common symbol, not an alias.  */
++char *loc1 __attribute__ ((nocommon));
++char *loc2 __attribute__ ((nocommon));
+ compat_symbol (libc, loc1, loc1, GLIBC_2_0);
+ compat_symbol (libc, loc2, loc2, GLIBC_2_0);
+ 
+ /* Although we do not support the use we define this variable as well.  */
+-char *locs;
++char *locs __attribute__ ((nocommon));
+ compat_symbol (libc, locs, locs, GLIBC_2_0);
+ 
+ 

--- a/packages/glibc/2.25/997-regexp-common.patch
+++ b/packages/glibc/2.25/997-regexp-common.patch
@@ -1,0 +1,58 @@
+commit 388b4f1a02f3a801965028bbfcd48d905638b797
+Author: H.J. Lu <hjl.tools@gmail.com>
+Date:   Fri Jun 23 14:38:46 2017 -0700
+
+    Avoid .symver on common symbols [BZ #21666]
+    
+    The .symver directive on common symbol just creates a new common symbol,
+    not an alias and the newer assembler with the bug fix for
+    
+    https://sourceware.org/bugzilla/show_bug.cgi?id=21661
+    
+    will issue an error.  Before the fix, we got
+    
+    $ readelf -sW libc.so | grep "loc[12s]"
+      5109: 00000000003a0608     8 OBJECT  LOCAL  DEFAULT   36 loc1
+      5188: 00000000003a0610     8 OBJECT  LOCAL  DEFAULT   36 loc2
+      5455: 00000000003a0618     8 OBJECT  LOCAL  DEFAULT   36 locs
+      6575: 00000000003a05f0     8 OBJECT  GLOBAL DEFAULT   36 locs@GLIBC_2.2.5
+      7156: 00000000003a05f8     8 OBJECT  GLOBAL DEFAULT   36 loc1@GLIBC_2.2.5
+      7312: 00000000003a0600     8 OBJECT  GLOBAL DEFAULT   36 loc2@GLIBC_2.2.5
+    
+    in libc.so.  The versioned loc1, loc2 and locs have the wrong addresses.
+    After the fix, we got
+    
+    $ readelf -sW libc.so | grep "loc[12s]"
+      6570: 000000000039e3b8     8 OBJECT  GLOBAL DEFAULT   34 locs@GLIBC_2.2.5
+      7151: 000000000039e3c8     8 OBJECT  GLOBAL DEFAULT   34 loc1@GLIBC_2.2.5
+      7307: 000000000039e3c0     8 OBJECT  GLOBAL DEFAULT   34 loc2@GLIBC_2.2.5
+    
+            [BZ #21666]
+            * misc/regexp.c (loc1): Add __attribute__ ((nocommon));
+            (loc2): Likewise.
+            (locs): Likewise.
+
+diff --git a/misc/regexp.c b/misc/regexp.c
+index 19d76c0c37..eaea7c3b89 100644
+--- a/misc/regexp.c
++++ b/misc/regexp.c
+@@ -29,14 +29,15 @@
+ 
+ #if SHLIB_COMPAT (libc, GLIBC_2_0, GLIBC_2_23)
+ 
+-/* Define the variables used for the interface.  */
+-char *loc1;
+-char *loc2;
++/* Define the variables used for the interface.  Avoid .symver on common
++   symbol, which just creates a new common symbol, not an alias.  */
++char *loc1 __attribute__ ((nocommon));
++char *loc2 __attribute__ ((nocommon));
+ compat_symbol (libc, loc1, loc1, GLIBC_2_0);
+ compat_symbol (libc, loc2, loc2, GLIBC_2_0);
+ 
+ /* Although we do not support the use we define this variable as well.  */
+-char *locs;
++char *locs __attribute__ ((nocommon));
+ compat_symbol (libc, locs, locs, GLIBC_2_0);
+ 
+ 


### PR DESCRIPTION
Binutils 2.29 are more picky about versioning of common symbols.
Fix two offenders in glibc versions as applicable.

Signed-off-by: Alexey Neyman <stilor@att.net>