### PR TITLE
patches/mingw-w64: Fix build with gcc7

### DIFF
--- a/TODO
+++ b/TODO
@@ -2,6 +2,8 @@ A (slightly) ordered set of tasks for crosstool-NG. Written in a cryptic languag
 
 -- Alexey Neyman (@stilor)
 
+[ ] mingw-w64 fails to build (with new gcc?) - the headers are installed into usr/x86_64-w64-mingw32/x86_64-w64-mingw32/include instead of usr/x86_64-w64-mingw32/include
+  [ ] fix or retire?
 [ ] test-packages.sh
   [ ] FTP URLs always succeed in verification (wget bug) - how to work around?
   [ ] new function - refresh/renumber patches

--- a/packages/mingw-w64/v2.0.10/200-gendef-explicit-fallthrough.patch
+++ b/packages/mingw-w64/v2.0.10/200-gendef-explicit-fallthrough.patch
@@ -1,0 +1,42 @@
+commit b4416f9a54ca0f27adc4a5a2d576779ec1288047
+Author: sezero <sezero@users.sourceforge.net>
+Date:   Thu Jun 15 09:50:00 2017 +0300
+
+    gendef.c (getMemonic): add /* fallthru */ comments in the switch to avoid -Wimplicit-fallthrough
+
+diff --git a/mingw-w64-tools/gendef/src/gendef.c b/mingw-w64-tools/gendef/src/gendef.c
+index a935abfe..0c5beaad 100644
+--- a/mingw-w64-tools/gendef/src/gendef.c
++++ b/mingw-w64-tools/gendef/src/gendef.c
+@@ -836,7 +836,7 @@ disassembleRetIntern (uint32_t pc, uint32_t *retpop, sAddresses *seen, sAddresse
+       if (!sz || code == c_ill)
+         {
+           PRDEBUG(" %s = 0x08%x ILL (%u) at least one==%d\n",name,
+-	 	  (unsigned int) pc, (unsigned int) sz,atleast_one[0]);
++		  (unsigned int) pc, (unsigned int) sz,atleast_one[0]);
+ #if ENABLE_DEBUG == 1
+       {
+         unsigned char *ppc = (unsigned char *) map_va (pc);
+@@ -1031,10 +1031,10 @@ redo_switch:
+     PRDEBUG(" 0x%x illegal ", (unsigned int) b);
+ #endif
+     *aCode=c_ill; return 0;
+-  case c_4: sz++;
+-  case c_3: sz++;
++  case c_4: sz++;/* fallthru */
++  case c_3: sz++;/* fallthru */
+   case c_lb:
+-  case c_2: sz++;
++  case c_2: sz++;/* fallthru */
+   case c_retn: case c_retf:
+   case c_iret: case c_int3:
+   case c_ad: case c_op:
+@@ -1061,7 +1061,7 @@ redo_switch:
+           p = (unsigned char *) map_va (pc + sz);
+           if (!p) { *aCode=c_ill; return 0; }
+ #if ENABLE_DEBUG == 1
+-    enter_save_insn(lw,p[0]);
++	  enter_save_insn(lw,p[0]);
+ #endif
+           b&=~0x7; b|=(p[0]&7);
+ 	  sz+=1;

--- a/packages/mingw-w64/v3.0.0/200-gendef-explicit-fallthrough.patch
+++ b/packages/mingw-w64/v3.0.0/200-gendef-explicit-fallthrough.patch
@@ -1,0 +1,42 @@
+commit b4416f9a54ca0f27adc4a5a2d576779ec1288047
+Author: sezero <sezero@users.sourceforge.net>
+Date:   Thu Jun 15 09:50:00 2017 +0300
+
+    gendef.c (getMemonic): add /* fallthru */ comments in the switch to avoid -Wimplicit-fallthrough
+
+diff --git a/mingw-w64-tools/gendef/src/gendef.c b/mingw-w64-tools/gendef/src/gendef.c
+index a935abfe..0c5beaad 100644
+--- a/mingw-w64-tools/gendef/src/gendef.c
++++ b/mingw-w64-tools/gendef/src/gendef.c
+@@ -836,7 +836,7 @@ disassembleRetIntern (uint32_t pc, uint32_t *retpop, sAddresses *seen, sAddresse
+       if (!sz || code == c_ill)
+         {
+           PRDEBUG(" %s = 0x08%x ILL (%u) at least one==%d\n",name,
+-	 	  (unsigned int) pc, (unsigned int) sz,atleast_one[0]);
++		  (unsigned int) pc, (unsigned int) sz,atleast_one[0]);
+ #if ENABLE_DEBUG == 1
+       {
+         unsigned char *ppc = (unsigned char *) map_va (pc);
+@@ -1031,10 +1031,10 @@ redo_switch:
+     PRDEBUG(" 0x%x illegal ", (unsigned int) b);
+ #endif
+     *aCode=c_ill; return 0;
+-  case c_4: sz++;
+-  case c_3: sz++;
++  case c_4: sz++;/* fallthru */
++  case c_3: sz++;/* fallthru */
+   case c_lb:
+-  case c_2: sz++;
++  case c_2: sz++;/* fallthru */
+   case c_retn: case c_retf:
+   case c_iret: case c_int3:
+   case c_ad: case c_op:
+@@ -1061,7 +1061,7 @@ redo_switch:
+           p = (unsigned char *) map_va (pc + sz);
+           if (!p) { *aCode=c_ill; return 0; }
+ #if ENABLE_DEBUG == 1
+-    enter_save_insn(lw,p[0]);
++	  enter_save_insn(lw,p[0]);
+ #endif
+           b&=~0x7; b|=(p[0]&7);
+ 	  sz+=1;

--- a/packages/mingw-w64/v3.0.0/300-genpeimg-explicit-fallthrough.patch
+++ b/packages/mingw-w64/v3.0.0/300-genpeimg-explicit-fallthrough.patch
@@ -1,0 +1,29 @@
+commit f9f2bd0641b89895ab42b1948f431dadf1e837a4
+Author: sezero <sezero@users.sourceforge.net>
+Date:   Thu Jun 15 09:45:52 2017 +0300
+
+    genpeimg.c (pass_args): add a /* fallthru */ comment in the switch
+     after show_usage() to avoid -Wimplicit-fallthrough
+    (show_usage): mark the function with noreturn attribute.
+
+diff --git a/mingw-w64-tools/genpeimg/src/genpeimg.c b/mingw-w64-tools/genpeimg/src/genpeimg.c
+index b2430bbc..1ebe607d 100644
+--- a/mingw-w64-tools/genpeimg/src/genpeimg.c
++++ b/mingw-w64-tools/genpeimg/src/genpeimg.c
+@@ -28,7 +28,7 @@ unsigned short mask_pe_opt_hdr_dll_chara = 0xffff;
+ int dump_information = 0;
+ static char *file_name = NULL;
+ 
+-static void
++static void __attribute__((noreturn))
+ show_usage (void)
+ {
+   fprintf (stderr, "genpeimg [options] files...\n");
+@@ -204,6 +204,7 @@ pass_args (int argc, char **argv)
+ 	case 'h':
+ 	  if (h[2] == 0)
+ 	    show_usage ();
++	  /* fallthru */
+ 	default:
+ error_point:
+ 	  fprintf (stderr, "Unknown option ,%s'\n", h);

--- a/packages/mingw-w64/v3.1.0/200-gendef-explicit-fallthrough.patch
+++ b/packages/mingw-w64/v3.1.0/200-gendef-explicit-fallthrough.patch
@@ -1,0 +1,42 @@
+commit b4416f9a54ca0f27adc4a5a2d576779ec1288047
+Author: sezero <sezero@users.sourceforge.net>
+Date:   Thu Jun 15 09:50:00 2017 +0300
+
+    gendef.c (getMemonic): add /* fallthru */ comments in the switch to avoid -Wimplicit-fallthrough
+
+diff --git a/mingw-w64-tools/gendef/src/gendef.c b/mingw-w64-tools/gendef/src/gendef.c
+index a935abfe..0c5beaad 100644
+--- a/mingw-w64-tools/gendef/src/gendef.c
++++ b/mingw-w64-tools/gendef/src/gendef.c
+@@ -836,7 +836,7 @@ disassembleRetIntern (uint32_t pc, uint32_t *retpop, sAddresses *seen, sAddresse
+       if (!sz || code == c_ill)
+         {
+           PRDEBUG(" %s = 0x08%x ILL (%u) at least one==%d\n",name,
+-	 	  (unsigned int) pc, (unsigned int) sz,atleast_one[0]);
++		  (unsigned int) pc, (unsigned int) sz,atleast_one[0]);
+ #if ENABLE_DEBUG == 1
+       {
+         unsigned char *ppc = (unsigned char *) map_va (pc);
+@@ -1031,10 +1031,10 @@ redo_switch:
+     PRDEBUG(" 0x%x illegal ", (unsigned int) b);
+ #endif
+     *aCode=c_ill; return 0;
+-  case c_4: sz++;
+-  case c_3: sz++;
++  case c_4: sz++;/* fallthru */
++  case c_3: sz++;/* fallthru */
+   case c_lb:
+-  case c_2: sz++;
++  case c_2: sz++;/* fallthru */
+   case c_retn: case c_retf:
+   case c_iret: case c_int3:
+   case c_ad: case c_op:
+@@ -1061,7 +1061,7 @@ redo_switch:
+           p = (unsigned char *) map_va (pc + sz);
+           if (!p) { *aCode=c_ill; return 0; }
+ #if ENABLE_DEBUG == 1
+-    enter_save_insn(lw,p[0]);
++	  enter_save_insn(lw,p[0]);
+ #endif
+           b&=~0x7; b|=(p[0]&7);
+ 	  sz+=1;

--- a/packages/mingw-w64/v3.1.0/300-genpeimg-explicit-fallthrough.patch
+++ b/packages/mingw-w64/v3.1.0/300-genpeimg-explicit-fallthrough.patch
@@ -1,0 +1,29 @@
+commit f9f2bd0641b89895ab42b1948f431dadf1e837a4
+Author: sezero <sezero@users.sourceforge.net>
+Date:   Thu Jun 15 09:45:52 2017 +0300
+
+    genpeimg.c (pass_args): add a /* fallthru */ comment in the switch
+     after show_usage() to avoid -Wimplicit-fallthrough
+    (show_usage): mark the function with noreturn attribute.
+
+diff --git a/mingw-w64-tools/genpeimg/src/genpeimg.c b/mingw-w64-tools/genpeimg/src/genpeimg.c
+index b2430bbc..1ebe607d 100644
+--- a/mingw-w64-tools/genpeimg/src/genpeimg.c
++++ b/mingw-w64-tools/genpeimg/src/genpeimg.c
+@@ -28,7 +28,7 @@ unsigned short mask_pe_opt_hdr_dll_chara = 0xffff;
+ int dump_information = 0;
+ static char *file_name = NULL;
+ 
+-static void
++static void __attribute__((noreturn))
+ show_usage (void)
+ {
+   fprintf (stderr, "genpeimg [options] files...\n");
+@@ -204,6 +204,7 @@ pass_args (int argc, char **argv)
+ 	case 'h':
+ 	  if (h[2] == 0)
+ 	    show_usage ();
++	  /* fallthru */
+ 	default:
+ error_point:
+ 	  fprintf (stderr, "Unknown option ,%s'\n", h);

--- a/packages/mingw-w64/v3.2.0/200-gendef-explicit-fallthrough.patch
+++ b/packages/mingw-w64/v3.2.0/200-gendef-explicit-fallthrough.patch
@@ -1,0 +1,42 @@
+commit b4416f9a54ca0f27adc4a5a2d576779ec1288047
+Author: sezero <sezero@users.sourceforge.net>
+Date:   Thu Jun 15 09:50:00 2017 +0300
+
+    gendef.c (getMemonic): add /* fallthru */ comments in the switch to avoid -Wimplicit-fallthrough
+
+diff --git a/mingw-w64-tools/gendef/src/gendef.c b/mingw-w64-tools/gendef/src/gendef.c
+index a935abfe..0c5beaad 100644
+--- a/mingw-w64-tools/gendef/src/gendef.c
++++ b/mingw-w64-tools/gendef/src/gendef.c
+@@ -836,7 +836,7 @@ disassembleRetIntern (uint32_t pc, uint32_t *retpop, sAddresses *seen, sAddresse
+       if (!sz || code == c_ill)
+         {
+           PRDEBUG(" %s = 0x08%x ILL (%u) at least one==%d\n",name,
+-	 	  (unsigned int) pc, (unsigned int) sz,atleast_one[0]);
++		  (unsigned int) pc, (unsigned int) sz,atleast_one[0]);
+ #if ENABLE_DEBUG == 1
+       {
+         unsigned char *ppc = (unsigned char *) map_va (pc);
+@@ -1031,10 +1031,10 @@ redo_switch:
+     PRDEBUG(" 0x%x illegal ", (unsigned int) b);
+ #endif
+     *aCode=c_ill; return 0;
+-  case c_4: sz++;
+-  case c_3: sz++;
++  case c_4: sz++;/* fallthru */
++  case c_3: sz++;/* fallthru */
+   case c_lb:
+-  case c_2: sz++;
++  case c_2: sz++;/* fallthru */
+   case c_retn: case c_retf:
+   case c_iret: case c_int3:
+   case c_ad: case c_op:
+@@ -1061,7 +1061,7 @@ redo_switch:
+           p = (unsigned char *) map_va (pc + sz);
+           if (!p) { *aCode=c_ill; return 0; }
+ #if ENABLE_DEBUG == 1
+-    enter_save_insn(lw,p[0]);
++	  enter_save_insn(lw,p[0]);
+ #endif
+           b&=~0x7; b|=(p[0]&7);
+ 	  sz+=1;

--- a/packages/mingw-w64/v3.2.0/300-genpeimg-explicit-fallthrough.patch
+++ b/packages/mingw-w64/v3.2.0/300-genpeimg-explicit-fallthrough.patch
@@ -1,0 +1,29 @@
+commit f9f2bd0641b89895ab42b1948f431dadf1e837a4
+Author: sezero <sezero@users.sourceforge.net>
+Date:   Thu Jun 15 09:45:52 2017 +0300
+
+    genpeimg.c (pass_args): add a /* fallthru */ comment in the switch
+     after show_usage() to avoid -Wimplicit-fallthrough
+    (show_usage): mark the function with noreturn attribute.
+
+diff --git a/mingw-w64-tools/genpeimg/src/genpeimg.c b/mingw-w64-tools/genpeimg/src/genpeimg.c
+index b2430bbc..1ebe607d 100644
+--- a/mingw-w64-tools/genpeimg/src/genpeimg.c
++++ b/mingw-w64-tools/genpeimg/src/genpeimg.c
+@@ -28,7 +28,7 @@ unsigned short mask_pe_opt_hdr_dll_chara = 0xffff;
+ int dump_information = 0;
+ static char *file_name = NULL;
+ 
+-static void
++static void __attribute__((noreturn))
+ show_usage (void)
+ {
+   fprintf (stderr, "genpeimg [options] files...\n");
+@@ -204,6 +204,7 @@ pass_args (int argc, char **argv)
+ 	case 'h':
+ 	  if (h[2] == 0)
+ 	    show_usage ();
++	  /* fallthru */
+ 	default:
+ error_point:
+ 	  fprintf (stderr, "Unknown option ,%s'\n", h);

--- a/packages/mingw-w64/v3.3.0/200-gendef-explicit-fallthrough.patch
+++ b/packages/mingw-w64/v3.3.0/200-gendef-explicit-fallthrough.patch
@@ -1,0 +1,42 @@
+commit b4416f9a54ca0f27adc4a5a2d576779ec1288047
+Author: sezero <sezero@users.sourceforge.net>
+Date:   Thu Jun 15 09:50:00 2017 +0300
+
+    gendef.c (getMemonic): add /* fallthru */ comments in the switch to avoid -Wimplicit-fallthrough
+
+diff --git a/mingw-w64-tools/gendef/src/gendef.c b/mingw-w64-tools/gendef/src/gendef.c
+index a935abfe..0c5beaad 100644
+--- a/mingw-w64-tools/gendef/src/gendef.c
++++ b/mingw-w64-tools/gendef/src/gendef.c
+@@ -836,7 +836,7 @@ disassembleRetIntern (uint32_t pc, uint32_t *retpop, sAddresses *seen, sAddresse
+       if (!sz || code == c_ill)
+         {
+           PRDEBUG(" %s = 0x08%x ILL (%u) at least one==%d\n",name,
+-	 	  (unsigned int) pc, (unsigned int) sz,atleast_one[0]);
++		  (unsigned int) pc, (unsigned int) sz,atleast_one[0]);
+ #if ENABLE_DEBUG == 1
+       {
+         unsigned char *ppc = (unsigned char *) map_va (pc);
+@@ -1031,10 +1031,10 @@ redo_switch:
+     PRDEBUG(" 0x%x illegal ", (unsigned int) b);
+ #endif
+     *aCode=c_ill; return 0;
+-  case c_4: sz++;
+-  case c_3: sz++;
++  case c_4: sz++;/* fallthru */
++  case c_3: sz++;/* fallthru */
+   case c_lb:
+-  case c_2: sz++;
++  case c_2: sz++;/* fallthru */
+   case c_retn: case c_retf:
+   case c_iret: case c_int3:
+   case c_ad: case c_op:
+@@ -1061,7 +1061,7 @@ redo_switch:
+           p = (unsigned char *) map_va (pc + sz);
+           if (!p) { *aCode=c_ill; return 0; }
+ #if ENABLE_DEBUG == 1
+-    enter_save_insn(lw,p[0]);
++	  enter_save_insn(lw,p[0]);
+ #endif
+           b&=~0x7; b|=(p[0]&7);
+ 	  sz+=1;

--- a/packages/mingw-w64/v3.3.0/300-genpeimg-explicit-fallthrough.patch
+++ b/packages/mingw-w64/v3.3.0/300-genpeimg-explicit-fallthrough.patch
@@ -1,0 +1,29 @@
+commit f9f2bd0641b89895ab42b1948f431dadf1e837a4
+Author: sezero <sezero@users.sourceforge.net>
+Date:   Thu Jun 15 09:45:52 2017 +0300
+
+    genpeimg.c (pass_args): add a /* fallthru */ comment in the switch
+     after show_usage() to avoid -Wimplicit-fallthrough
+    (show_usage): mark the function with noreturn attribute.
+
+diff --git a/mingw-w64-tools/genpeimg/src/genpeimg.c b/mingw-w64-tools/genpeimg/src/genpeimg.c
+index b2430bbc..1ebe607d 100644
+--- a/mingw-w64-tools/genpeimg/src/genpeimg.c
++++ b/mingw-w64-tools/genpeimg/src/genpeimg.c
+@@ -28,7 +28,7 @@ unsigned short mask_pe_opt_hdr_dll_chara = 0xffff;
+ int dump_information = 0;
+ static char *file_name = NULL;
+ 
+-static void
++static void __attribute__((noreturn))
+ show_usage (void)
+ {
+   fprintf (stderr, "genpeimg [options] files...\n");
+@@ -204,6 +204,7 @@ pass_args (int argc, char **argv)
+ 	case 'h':
+ 	  if (h[2] == 0)
+ 	    show_usage ();
++	  /* fallthru */
+ 	default:
+ error_point:
+ 	  fprintf (stderr, "Unknown option ,%s'\n", h);

--- a/packages/mingw-w64/v4.0.6/200-gendef-explicit-fallthrough.patch
+++ b/packages/mingw-w64/v4.0.6/200-gendef-explicit-fallthrough.patch
@@ -1,0 +1,42 @@
+commit b4416f9a54ca0f27adc4a5a2d576779ec1288047
+Author: sezero <sezero@users.sourceforge.net>
+Date:   Thu Jun 15 09:50:00 2017 +0300
+
+    gendef.c (getMemonic): add /* fallthru */ comments in the switch to avoid -Wimplicit-fallthrough
+
+diff --git a/mingw-w64-tools/gendef/src/gendef.c b/mingw-w64-tools/gendef/src/gendef.c
+index a935abfe..0c5beaad 100644
+--- a/mingw-w64-tools/gendef/src/gendef.c
++++ b/mingw-w64-tools/gendef/src/gendef.c
+@@ -836,7 +836,7 @@ disassembleRetIntern (uint32_t pc, uint32_t *retpop, sAddresses *seen, sAddresse
+       if (!sz || code == c_ill)
+         {
+           PRDEBUG(" %s = 0x08%x ILL (%u) at least one==%d\n",name,
+-	 	  (unsigned int) pc, (unsigned int) sz,atleast_one[0]);
++		  (unsigned int) pc, (unsigned int) sz,atleast_one[0]);
+ #if ENABLE_DEBUG == 1
+       {
+         unsigned char *ppc = (unsigned char *) map_va (pc);
+@@ -1031,10 +1031,10 @@ redo_switch:
+     PRDEBUG(" 0x%x illegal ", (unsigned int) b);
+ #endif
+     *aCode=c_ill; return 0;
+-  case c_4: sz++;
+-  case c_3: sz++;
++  case c_4: sz++;/* fallthru */
++  case c_3: sz++;/* fallthru */
+   case c_lb:
+-  case c_2: sz++;
++  case c_2: sz++;/* fallthru */
+   case c_retn: case c_retf:
+   case c_iret: case c_int3:
+   case c_ad: case c_op:
+@@ -1061,7 +1061,7 @@ redo_switch:
+           p = (unsigned char *) map_va (pc + sz);
+           if (!p) { *aCode=c_ill; return 0; }
+ #if ENABLE_DEBUG == 1
+-    enter_save_insn(lw,p[0]);
++	  enter_save_insn(lw,p[0]);
+ #endif
+           b&=~0x7; b|=(p[0]&7);
+ 	  sz+=1;

--- a/packages/mingw-w64/v4.0.6/300-genpeimg-explicit-fallthrough.patch
+++ b/packages/mingw-w64/v4.0.6/300-genpeimg-explicit-fallthrough.patch
@@ -1,0 +1,29 @@
+commit f9f2bd0641b89895ab42b1948f431dadf1e837a4
+Author: sezero <sezero@users.sourceforge.net>
+Date:   Thu Jun 15 09:45:52 2017 +0300
+
+    genpeimg.c (pass_args): add a /* fallthru */ comment in the switch
+     after show_usage() to avoid -Wimplicit-fallthrough
+    (show_usage): mark the function with noreturn attribute.
+
+diff --git a/mingw-w64-tools/genpeimg/src/genpeimg.c b/mingw-w64-tools/genpeimg/src/genpeimg.c
+index b2430bbc..1ebe607d 100644
+--- a/mingw-w64-tools/genpeimg/src/genpeimg.c
++++ b/mingw-w64-tools/genpeimg/src/genpeimg.c
+@@ -28,7 +28,7 @@ unsigned short mask_pe_opt_hdr_dll_chara = 0xffff;
+ int dump_information = 0;
+ static char *file_name = NULL;
+ 
+-static void
++static void __attribute__((noreturn))
+ show_usage (void)
+ {
+   fprintf (stderr, "genpeimg [options] files...\n");
+@@ -204,6 +204,7 @@ pass_args (int argc, char **argv)
+ 	case 'h':
+ 	  if (h[2] == 0)
+ 	    show_usage ();
++	  /* fallthru */
+ 	default:
+ error_point:
+ 	  fprintf (stderr, "Unknown option ,%s'\n", h);

--- a/packages/mingw-w64/v5.0.2/200-gendef-explicit-fallthrough.patch
+++ b/packages/mingw-w64/v5.0.2/200-gendef-explicit-fallthrough.patch
@@ -1,0 +1,42 @@
+commit b4416f9a54ca0f27adc4a5a2d576779ec1288047
+Author: sezero <sezero@users.sourceforge.net>
+Date:   Thu Jun 15 09:50:00 2017 +0300
+
+    gendef.c (getMemonic): add /* fallthru */ comments in the switch to avoid -Wimplicit-fallthrough
+
+diff --git a/mingw-w64-tools/gendef/src/gendef.c b/mingw-w64-tools/gendef/src/gendef.c
+index a935abfe..0c5beaad 100644
+--- a/mingw-w64-tools/gendef/src/gendef.c
++++ b/mingw-w64-tools/gendef/src/gendef.c
+@@ -836,7 +836,7 @@ disassembleRetIntern (uint32_t pc, uint32_t *retpop, sAddresses *seen, sAddresse
+       if (!sz || code == c_ill)
+         {
+           PRDEBUG(" %s = 0x08%x ILL (%u) at least one==%d\n",name,
+-	 	  (unsigned int) pc, (unsigned int) sz,atleast_one[0]);
++		  (unsigned int) pc, (unsigned int) sz,atleast_one[0]);
+ #if ENABLE_DEBUG == 1
+       {
+         unsigned char *ppc = (unsigned char *) map_va (pc);
+@@ -1031,10 +1031,10 @@ redo_switch:
+     PRDEBUG(" 0x%x illegal ", (unsigned int) b);
+ #endif
+     *aCode=c_ill; return 0;
+-  case c_4: sz++;
+-  case c_3: sz++;
++  case c_4: sz++;/* fallthru */
++  case c_3: sz++;/* fallthru */
+   case c_lb:
+-  case c_2: sz++;
++  case c_2: sz++;/* fallthru */
+   case c_retn: case c_retf:
+   case c_iret: case c_int3:
+   case c_ad: case c_op:
+@@ -1061,7 +1061,7 @@ redo_switch:
+           p = (unsigned char *) map_va (pc + sz);
+           if (!p) { *aCode=c_ill; return 0; }
+ #if ENABLE_DEBUG == 1
+-    enter_save_insn(lw,p[0]);
++	  enter_save_insn(lw,p[0]);
+ #endif
+           b&=~0x7; b|=(p[0]&7);
+ 	  sz+=1;

--- a/packages/mingw-w64/v5.0.2/300-genpeimg-explicit-fallthrough.patch
+++ b/packages/mingw-w64/v5.0.2/300-genpeimg-explicit-fallthrough.patch
@@ -1,0 +1,29 @@
+commit f9f2bd0641b89895ab42b1948f431dadf1e837a4
+Author: sezero <sezero@users.sourceforge.net>
+Date:   Thu Jun 15 09:45:52 2017 +0300
+
+    genpeimg.c (pass_args): add a /* fallthru */ comment in the switch
+     after show_usage() to avoid -Wimplicit-fallthrough
+    (show_usage): mark the function with noreturn attribute.
+
+diff --git a/mingw-w64-tools/genpeimg/src/genpeimg.c b/mingw-w64-tools/genpeimg/src/genpeimg.c
+index b2430bbc..1ebe607d 100644
+--- a/mingw-w64-tools/genpeimg/src/genpeimg.c
++++ b/mingw-w64-tools/genpeimg/src/genpeimg.c
+@@ -28,7 +28,7 @@ unsigned short mask_pe_opt_hdr_dll_chara = 0xffff;
+ int dump_information = 0;
+ static char *file_name = NULL;
+ 
+-static void
++static void __attribute__((noreturn))
+ show_usage (void)
+ {
+   fprintf (stderr, "genpeimg [options] files...\n");
+@@ -204,6 +204,7 @@ pass_args (int argc, char **argv)
+ 	case 'h':
+ 	  if (h[2] == 0)
+ 	    show_usage ();
++	  /* fallthru */
+ 	default:
+ error_point:
+ 	  fprintf (stderr, "Unknown option ,%s'\n", h);


### PR DESCRIPTION
Modified by Alexey Neyman: remove obsoleted v5.0.1, propagate the patches
to older versions.

Signed-off-by: Kirill Smirnov <kirill.k.smirnov@gmail.com>
Signed-off-by: Alexey Neyman <stilor@att.net>