### PR TITLE
Redirect cd output to /dev/null in bootstrap

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -557,7 +557,7 @@ enter_fork()
         info[repository_url]=${info[repository]#* }
     fi
 
-    versions=`cd packages/${fork} && \
+    versions=`cd packages/${fork} &>/dev/null && \
         for f in */version.desc; do [ -r "${f}" ] && echo "${f%/version.desc}"; done`
     versions=`sort_versions ${versions}`
 
@@ -604,7 +604,7 @@ gen_packages()
     local -A pkg_forks pkg_milestones pkg_nforks pkg_relevantpattern
     local -a pkg_masters pkg_all pkg_preferred
 
-    pkg_all=( `cd packages && \
+    pkg_all=( `cd packages &>/dev/null && \
         ls */package.desc 2>/dev/null | \
         while read f; do [ -r "${f}" ] && echo "${f%/package.desc}"; done | \
         xargs echo` )


### PR DESCRIPTION
I'm using CDPATH in bash which results in printing the new directory.
Redirect this output to /dev/null so it doesn't mess up the bootstrap script.

Signed-off-by: Stanislav Fomichev <kernel@fomichev.me>