### PR TITLE
Include Makefile.in in gettext 0.19.8.1 patch

### DIFF
--- a/packages/gettext/0.19.8.1/120-Fix-Woe32-link-errors-when-compiling-with-O0.patch
+++ b/packages/gettext/0.19.8.1/120-Fix-Woe32-link-errors-when-compiling-with-O0.patch
@@ -34,9 +34,29 @@ Subject: [PATCH] Fix Woe32 link errors when compiling with -O0.
 Additional fix (COLOR_SOURCE) by Ray Donnelly <mingw.android@gmail.com>
 Regenerated for 0.19.8.1 by Alexey Neyman <stilor@att.net>
 
-diff -urpN gettext-0.19.8.1.orig/gettext-tools/src/color.c gettext-0.19.8.1/gettext-tools/src/color.c
---- gettext-0.19.8.1.orig/gettext-tools/src/color.c	2017-01-23 15:13:25.448209511 -0800
-+++ gettext-0.19.8.1/gettext-tools/src/color.c	2017-01-23 15:13:53.168490941 -0800
+diff -urpN '--exclude=autom4te.cache' gettext-0.19.8.1.orig/gettext-tools/Makefile.in gettext-0.19.8.1/gettext-tools/Makefile.in
+--- gettext-0.19.8.1.orig/gettext-tools/Makefile.in	2016-06-11 06:01:11.000000000 -0700
++++ gettext-0.19.8.1/gettext-tools/Makefile.in	2017-11-04 10:16:23.980314440 -0700
+@@ -468,10 +468,12 @@ am__DIST_COMMON = $(srcdir)/Makefile.in
+ 	$(top_srcdir)/../gettext-runtime/intl/Makefile.in \
+ 	../build-aux/ar-lib ../build-aux/compile \
+ 	../build-aux/config.guess ../build-aux/config.rpath \
+-	../build-aux/config.sub ../build-aux/install-sh \
+-	../build-aux/ltmain.sh ../build-aux/missing \
+-	../build-aux/mkinstalldirs ../build-aux/texinfo.tex ABOUT-NLS \
+-	AUTHORS COPYING ChangeLog INSTALL NEWS README
++	../build-aux/config.sub ../build-aux/depcomp \
++	../build-aux/install-sh ../build-aux/ltmain.sh \
++	../build-aux/mdate-sh ../build-aux/missing \
++	../build-aux/mkinstalldirs ../build-aux/texinfo.tex \
++	../build-aux/ylwrap ABOUT-NLS AUTHORS COPYING ChangeLog \
++	INSTALL NEWS README
+ DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
+ distdir = $(PACKAGE)-$(VERSION)
+ top_distdir = $(distdir)
+diff -urpN '--exclude=autom4te.cache' gettext-0.19.8.1.orig/gettext-tools/src/color.c gettext-0.19.8.1/gettext-tools/src/color.c
+--- gettext-0.19.8.1.orig/gettext-tools/src/color.c	2016-03-20 00:37:53.000000000 -0700
++++ gettext-0.19.8.1/gettext-tools/src/color.c	2017-11-04 10:15:55.755985937 -0700
 @@ -28,6 +28,7 @@
  #include <sys/types.h>
  #include <sys/stat.h>
@@ -45,9 +65,9 @@ diff -urpN gettext-0.19.8.1.orig/gettext-tools/src/color.c gettext-0.19.8.1/gett
  #include "term-ostream.h"
  #include "xalloc.h"
  #include "relocatable.h"
-diff -urpN gettext-0.19.8.1.orig/gettext-tools/src/Makefile.am gettext-0.19.8.1/gettext-tools/src/Makefile.am
---- gettext-0.19.8.1.orig/gettext-tools/src/Makefile.am	2017-01-23 15:13:25.452209551 -0800
-+++ gettext-0.19.8.1/gettext-tools/src/Makefile.am	2017-01-23 15:13:53.168490941 -0800
+diff -urpN '--exclude=autom4te.cache' gettext-0.19.8.1.orig/gettext-tools/src/Makefile.am gettext-0.19.8.1/gettext-tools/src/Makefile.am
+--- gettext-0.19.8.1.orig/gettext-tools/src/Makefile.am	2016-05-27 17:29:03.000000000 -0700
++++ gettext-0.19.8.1/gettext-tools/src/Makefile.am	2017-11-04 10:15:55.751985891 -0700
 @@ -145,10 +145,26 @@ FORMAT_SOURCE += \
    format-lua.c \
    format-javascript.c
@@ -76,55 +96,224 @@ diff -urpN gettext-0.19.8.1.orig/gettext-tools/src/Makefile.am gettext-0.19.8.1/
  msgl-ascii.c msgl-iconv.c msgl-equal.c msgl-cat.c msgl-header.c msgl-english.c \
  msgl-check.c file-list.c msgl-charset.c po-time.c plural-exp.c plural-eval.c \
  plural-table.c quote.h sentence.h sentence.c \
-diff -urpN gettext-0.19.8.1.orig/gettext-tools/woe32dll/c++color.cc gettext-0.19.8.1/gettext-tools/woe32dll/c++color.cc
+diff -urpN '--exclude=autom4te.cache' gettext-0.19.8.1.orig/gettext-tools/src/Makefile.in gettext-0.19.8.1/gettext-tools/src/Makefile.in
+--- gettext-0.19.8.1.orig/gettext-tools/src/Makefile.in	2016-06-11 06:01:14.000000000 -0700
++++ gettext-0.19.8.1/gettext-tools/src/Makefile.in	2017-11-04 10:16:26.392342570 -0700
+@@ -407,17 +407,20 @@ libgettextsrc_la_LIBADD =
+ am__libgettextsrc_la_SOURCES_DIST = message.c po-error.c po-xerror.c \
+ 	read-catalog-abstract.c po-lex.c po-gram-gen.y po-charset.c \
+ 	read-po.c read-properties.c read-stringtable.c open-catalog.c \
+-	dir-list.c str-list.c read-catalog.c color.c write-catalog.c \
+-	write-properties.c write-stringtable.c write-po.c msgl-ascii.c \
+-	msgl-iconv.c msgl-equal.c msgl-cat.c msgl-header.c \
+-	msgl-english.c msgl-check.c file-list.c msgl-charset.c \
+-	po-time.c plural-exp.c plural-eval.c plural-table.c quote.h \
+-	sentence.h sentence.c format.c format-invalid.h format-c.c \
+-	format-c-parse.h format-sh.c format-python.c \
+-	format-python-brace.c format-lisp.c format-elisp.c \
+-	format-librep.c format-scheme.c format-java.c format-csharp.c \
+-	format-awk.c format-pascal.c format-ycp.c format-tcl.c \
+-	format-perl.c format-perl-brace.c format-php.c \
++	dir-list.c str-list.c read-catalog.c color.c \
++	../woe32dll/c++color.cc write-catalog.c write-properties.c \
++	write-stringtable.c write-po.c ../woe32dll/c++write-catalog.cc \
++	../woe32dll/c++write-properties.cc \
++	../woe32dll/c++write-stringtable.cc ../woe32dll/c++write-po.cc \
++	msgl-ascii.c msgl-iconv.c msgl-equal.c msgl-cat.c \
++	msgl-header.c msgl-english.c msgl-check.c file-list.c \
++	msgl-charset.c po-time.c plural-exp.c plural-eval.c \
++	plural-table.c quote.h sentence.h sentence.c format.c \
++	format-invalid.h format-c.c format-c-parse.h format-sh.c \
++	format-python.c format-python-brace.c format-lisp.c \
++	format-elisp.c format-librep.c format-scheme.c format-java.c \
++	format-csharp.c format-awk.c format-pascal.c format-ycp.c \
++	format-tcl.c format-perl.c format-perl-brace.c format-php.c \
+ 	format-gcc-internal.c format-gfc-internal.c format-qt.c \
+ 	format-qt-plural.c format-kde.c format-kde-kuit.c \
+ 	format-boost.c format-lua.c format-javascript.c \
+@@ -433,7 +436,18 @@ am__objects_1 = libgettextsrc_la-message
+ 	libgettextsrc_la-open-catalog.lo libgettextsrc_la-dir-list.lo \
+ 	libgettextsrc_la-str-list.lo
+ am__dirstamp = $(am__leading_dot)dirstamp
+-@WOE32DLL_FALSE@am__objects_2 = libgettextsrc_la-format.lo \
++@WOE32DLL_FALSE@am__objects_2 = libgettextsrc_la-color.lo
++@WOE32DLL_TRUE@am__objects_2 =  \
++@WOE32DLL_TRUE@	../woe32dll/libgettextsrc_la-c++color.lo
++@WOE32DLL_FALSE@am__objects_3 = libgettextsrc_la-write-catalog.lo \
++@WOE32DLL_FALSE@	libgettextsrc_la-write-properties.lo \
++@WOE32DLL_FALSE@	libgettextsrc_la-write-stringtable.lo \
++@WOE32DLL_FALSE@	libgettextsrc_la-write-po.lo
++@WOE32DLL_TRUE@am__objects_3 = ../woe32dll/libgettextsrc_la-c++write-catalog.lo \
++@WOE32DLL_TRUE@	../woe32dll/libgettextsrc_la-c++write-properties.lo \
++@WOE32DLL_TRUE@	../woe32dll/libgettextsrc_la-c++write-stringtable.lo \
++@WOE32DLL_TRUE@	../woe32dll/libgettextsrc_la-c++write-po.lo
++@WOE32DLL_FALSE@am__objects_4 = libgettextsrc_la-format.lo \
+ @WOE32DLL_FALSE@	libgettextsrc_la-format-c.lo \
+ @WOE32DLL_FALSE@	libgettextsrc_la-format-sh.lo \
+ @WOE32DLL_FALSE@	libgettextsrc_la-format-python.lo \
+@@ -460,7 +474,7 @@ am__dirstamp = $(am__leading_dot)dirstam
+ @WOE32DLL_FALSE@	libgettextsrc_la-format-boost.lo \
+ @WOE32DLL_FALSE@	libgettextsrc_la-format-lua.lo \
+ @WOE32DLL_FALSE@	libgettextsrc_la-format-javascript.lo
+-@WOE32DLL_TRUE@am__objects_2 =  \
++@WOE32DLL_TRUE@am__objects_4 =  \
+ @WOE32DLL_TRUE@	../woe32dll/libgettextsrc_la-c++format.lo \
+ @WOE32DLL_TRUE@	libgettextsrc_la-format-c.lo \
+ @WOE32DLL_TRUE@	libgettextsrc_la-format-sh.lo \
+@@ -488,13 +502,10 @@ am__dirstamp = $(am__leading_dot)dirstam
+ @WOE32DLL_TRUE@	libgettextsrc_la-format-boost.lo \
+ @WOE32DLL_TRUE@	libgettextsrc_la-format-lua.lo \
+ @WOE32DLL_TRUE@	libgettextsrc_la-format-javascript.lo
+-@WOE32DLL_TRUE@am__objects_3 = ../woe32dll/libgettextsrc_la-gettextsrc-exports.lo
++@WOE32DLL_TRUE@am__objects_5 = ../woe32dll/libgettextsrc_la-gettextsrc-exports.lo
+ am_libgettextsrc_la_OBJECTS = $(am__objects_1) \
+-	libgettextsrc_la-read-catalog.lo libgettextsrc_la-color.lo \
+-	libgettextsrc_la-write-catalog.lo \
+-	libgettextsrc_la-write-properties.lo \
+-	libgettextsrc_la-write-stringtable.lo \
+-	libgettextsrc_la-write-po.lo libgettextsrc_la-msgl-ascii.lo \
++	libgettextsrc_la-read-catalog.lo $(am__objects_2) \
++	$(am__objects_3) libgettextsrc_la-msgl-ascii.lo \
+ 	libgettextsrc_la-msgl-iconv.lo libgettextsrc_la-msgl-equal.lo \
+ 	libgettextsrc_la-msgl-cat.lo libgettextsrc_la-msgl-header.lo \
+ 	libgettextsrc_la-msgl-english.lo \
+@@ -502,9 +513,9 @@ am_libgettextsrc_la_OBJECTS = $(am__obje
+ 	libgettextsrc_la-msgl-charset.lo libgettextsrc_la-po-time.lo \
+ 	libgettextsrc_la-plural-exp.lo libgettextsrc_la-plural-eval.lo \
+ 	libgettextsrc_la-plural-table.lo libgettextsrc_la-sentence.lo \
+-	$(am__objects_2) libgettextsrc_la-read-desktop.lo \
++	$(am__objects_4) libgettextsrc_la-read-desktop.lo \
+ 	libgettextsrc_la-locating-rule.lo libgettextsrc_la-its.lo \
+-	libgettextsrc_la-search-path.lo $(am__objects_3)
++	libgettextsrc_la-search-path.lo $(am__objects_5)
+ libgettextsrc_la_OBJECTS = $(am_libgettextsrc_la_OBJECTS)
+ PROGRAMS = $(bin_PROGRAMS) $(noinst_PROGRAMS)
+ am_cldr_plurals_OBJECTS = cldr_plurals-cldr-plural.$(OBJEXT) \
+@@ -2255,16 +2266,29 @@ dir-list.c str-list.c
+ @WOE32DLL_TRUE@	format-qt.c format-qt-plural.c format-kde.c \
+ @WOE32DLL_TRUE@	format-kde-kuit.c format-boost.c format-lua.c \
+ @WOE32DLL_TRUE@	format-javascript.c
++@WOE32DLL_FALSE@COLOR_SOURCE = color.c
++@WOE32DLL_TRUE@COLOR_SOURCE = ../woe32dll/c++color.cc
++@WOE32DLL_FALSE@OUTPUT_SOURCE = \
++@WOE32DLL_FALSE@  write-catalog.c \
++@WOE32DLL_FALSE@  write-properties.c \
++@WOE32DLL_FALSE@  write-stringtable.c \
++@WOE32DLL_FALSE@  write-po.c
++
++@WOE32DLL_TRUE@OUTPUT_SOURCE = \
++@WOE32DLL_TRUE@  ../woe32dll/c++write-catalog.cc \
++@WOE32DLL_TRUE@  ../woe32dll/c++write-properties.cc \
++@WOE32DLL_TRUE@  ../woe32dll/c++write-stringtable.cc \
++@WOE32DLL_TRUE@  ../woe32dll/c++write-po.cc
++
+ 
+ # libgettextsrc contains all code that is needed by at least two programs.
+-libgettextsrc_la_SOURCES = $(COMMON_SOURCE) read-catalog.c color.c \
+-	write-catalog.c write-properties.c write-stringtable.c \
+-	write-po.c msgl-ascii.c msgl-iconv.c msgl-equal.c msgl-cat.c \
+-	msgl-header.c msgl-english.c msgl-check.c file-list.c \
+-	msgl-charset.c po-time.c plural-exp.c plural-eval.c \
+-	plural-table.c quote.h sentence.h sentence.c $(FORMAT_SOURCE) \
+-	read-desktop.c locating-rule.c its.c search-path.c \
+-	$(am__append_2)
++libgettextsrc_la_SOURCES = $(COMMON_SOURCE) read-catalog.c \
++	$(COLOR_SOURCE) $(OUTPUT_SOURCE) msgl-ascii.c msgl-iconv.c \
++	msgl-equal.c msgl-cat.c msgl-header.c msgl-english.c \
++	msgl-check.c file-list.c msgl-charset.c po-time.c plural-exp.c \
++	plural-eval.c plural-table.c quote.h sentence.h sentence.c \
++	$(FORMAT_SOURCE) read-desktop.c locating-rule.c its.c \
++	search-path.c $(am__append_2)
+ 
+ # msggrep needs pattern matching.
+ LIBGREP = ../libgrep/libgrep.a
+@@ -2626,6 +2650,15 @@ clean-libLTLIBRARIES:
+ ../woe32dll/$(am__dirstamp):
+ 	@$(MKDIR_P) ../woe32dll
+ 	@: > ../woe32dll/$(am__dirstamp)
++../woe32dll/libgettextsrc_la-c++color.lo: ../woe32dll/$(am__dirstamp)
++../woe32dll/libgettextsrc_la-c++write-catalog.lo:  \
++	../woe32dll/$(am__dirstamp)
++../woe32dll/libgettextsrc_la-c++write-properties.lo:  \
++	../woe32dll/$(am__dirstamp)
++../woe32dll/libgettextsrc_la-c++write-stringtable.lo:  \
++	../woe32dll/$(am__dirstamp)
++../woe32dll/libgettextsrc_la-c++write-po.lo:  \
++	../woe32dll/$(am__dirstamp)
+ ../woe32dll/libgettextsrc_la-c++format.lo:  \
+ 	../woe32dll/$(am__dirstamp)
+ ../woe32dll/libgettextsrc_la-gettextsrc-exports.lo:  \
+@@ -3431,6 +3464,21 @@ xgettext-x-desktop.obj: x-desktop.c
+ .cc.lo:
+ 	$(AM_V_CXX)$(LTCXXCOMPILE) -c -o $@ $<
+ 
++../woe32dll/libgettextsrc_la-c++color.lo: ../woe32dll/c++color.cc
++	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libgettextsrc_la_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -c -o ../woe32dll/libgettextsrc_la-c++color.lo `test -f '../woe32dll/c++color.cc' || echo '$(srcdir)/'`../woe32dll/c++color.cc
++
++../woe32dll/libgettextsrc_la-c++write-catalog.lo: ../woe32dll/c++write-catalog.cc
++	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libgettextsrc_la_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -c -o ../woe32dll/libgettextsrc_la-c++write-catalog.lo `test -f '../woe32dll/c++write-catalog.cc' || echo '$(srcdir)/'`../woe32dll/c++write-catalog.cc
++
++../woe32dll/libgettextsrc_la-c++write-properties.lo: ../woe32dll/c++write-properties.cc
++	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libgettextsrc_la_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -c -o ../woe32dll/libgettextsrc_la-c++write-properties.lo `test -f '../woe32dll/c++write-properties.cc' || echo '$(srcdir)/'`../woe32dll/c++write-properties.cc
++
++../woe32dll/libgettextsrc_la-c++write-stringtable.lo: ../woe32dll/c++write-stringtable.cc
++	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libgettextsrc_la_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -c -o ../woe32dll/libgettextsrc_la-c++write-stringtable.lo `test -f '../woe32dll/c++write-stringtable.cc' || echo '$(srcdir)/'`../woe32dll/c++write-stringtable.cc
++
++../woe32dll/libgettextsrc_la-c++write-po.lo: ../woe32dll/c++write-po.cc
++	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libgettextsrc_la_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -c -o ../woe32dll/libgettextsrc_la-c++write-po.lo `test -f '../woe32dll/c++write-po.cc' || echo '$(srcdir)/'`../woe32dll/c++write-po.cc
++
+ ../woe32dll/libgettextsrc_la-c++format.lo: ../woe32dll/c++format.cc
+ 	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libgettextsrc_la_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -c -o ../woe32dll/libgettextsrc_la-c++format.lo `test -f '../woe32dll/c++format.cc' || echo '$(srcdir)/'`../woe32dll/c++format.cc
+ 
+diff -urpN '--exclude=autom4te.cache' gettext-0.19.8.1.orig/gettext-tools/woe32dll/c++color.cc gettext-0.19.8.1/gettext-tools/woe32dll/c++color.cc
 --- gettext-0.19.8.1.orig/gettext-tools/woe32dll/c++color.cc	1969-12-31 16:00:00.000000000 -0800
-+++ gettext-0.19.8.1/gettext-tools/woe32dll/c++color.cc	2017-01-23 15:13:53.168490941 -0800
++++ gettext-0.19.8.1/gettext-tools/woe32dll/c++color.cc	2017-11-04 10:15:55.755985937 -0700
 @@ -0,0 +1 @@
 +#include "../src/color.c"
-diff -urpN gettext-0.19.8.1.orig/gettext-tools/woe32dll/c++file-ostream.cc gettext-0.19.8.1/gettext-tools/woe32dll/c++file-ostream.cc
+diff -urpN '--exclude=autom4te.cache' gettext-0.19.8.1.orig/gettext-tools/woe32dll/c++file-ostream.cc gettext-0.19.8.1/gettext-tools/woe32dll/c++file-ostream.cc
 --- gettext-0.19.8.1.orig/gettext-tools/woe32dll/c++file-ostream.cc	1969-12-31 16:00:00.000000000 -0800
-+++ gettext-0.19.8.1/gettext-tools/woe32dll/c++file-ostream.cc	2017-01-23 15:13:53.168490941 -0800
++++ gettext-0.19.8.1/gettext-tools/woe32dll/c++file-ostream.cc	2017-11-04 10:15:55.755985937 -0700
 @@ -0,0 +1,2 @@
 +#include "../gnulib-lib/file-ostream.c"
 +
-diff -urpN gettext-0.19.8.1.orig/gettext-tools/woe32dll/c++html-ostream.cc gettext-0.19.8.1/gettext-tools/woe32dll/c++html-ostream.cc
+diff -urpN '--exclude=autom4te.cache' gettext-0.19.8.1.orig/gettext-tools/woe32dll/c++html-ostream.cc gettext-0.19.8.1/gettext-tools/woe32dll/c++html-ostream.cc
 --- gettext-0.19.8.1.orig/gettext-tools/woe32dll/c++html-ostream.cc	1969-12-31 16:00:00.000000000 -0800
-+++ gettext-0.19.8.1/gettext-tools/woe32dll/c++html-ostream.cc	2017-01-23 15:13:53.168490941 -0800
++++ gettext-0.19.8.1/gettext-tools/woe32dll/c++html-ostream.cc	2017-11-04 10:15:55.755985937 -0700
 @@ -0,0 +1 @@
 +#include "../gnulib-lib/html-ostream.c"
-diff -urpN gettext-0.19.8.1.orig/gettext-tools/woe32dll/c++styled-ostream.cc gettext-0.19.8.1/gettext-tools/woe32dll/c++styled-ostream.cc
+diff -urpN '--exclude=autom4te.cache' gettext-0.19.8.1.orig/gettext-tools/woe32dll/c++styled-ostream.cc gettext-0.19.8.1/gettext-tools/woe32dll/c++styled-ostream.cc
 --- gettext-0.19.8.1.orig/gettext-tools/woe32dll/c++styled-ostream.cc	1969-12-31 16:00:00.000000000 -0800
-+++ gettext-0.19.8.1/gettext-tools/woe32dll/c++styled-ostream.cc	2017-01-23 15:13:53.168490941 -0800
++++ gettext-0.19.8.1/gettext-tools/woe32dll/c++styled-ostream.cc	2017-11-04 10:15:55.755985937 -0700
 @@ -0,0 +1 @@
 +#include "../gnulib-lib/styled-ostream.c"
-diff -urpN gettext-0.19.8.1.orig/gettext-tools/woe32dll/c++term-ostream.cc gettext-0.19.8.1/gettext-tools/woe32dll/c++term-ostream.cc
+diff -urpN '--exclude=autom4te.cache' gettext-0.19.8.1.orig/gettext-tools/woe32dll/c++term-ostream.cc gettext-0.19.8.1/gettext-tools/woe32dll/c++term-ostream.cc
 --- gettext-0.19.8.1.orig/gettext-tools/woe32dll/c++term-ostream.cc	1969-12-31 16:00:00.000000000 -0800
-+++ gettext-0.19.8.1/gettext-tools/woe32dll/c++term-ostream.cc	2017-01-23 15:13:53.168490941 -0800
++++ gettext-0.19.8.1/gettext-tools/woe32dll/c++term-ostream.cc	2017-11-04 10:15:55.755985937 -0700
 @@ -0,0 +1 @@
 +#include "../gnulib-lib/term-ostream.c"
-diff -urpN gettext-0.19.8.1.orig/gettext-tools/woe32dll/c++write-catalog.cc gettext-0.19.8.1/gettext-tools/woe32dll/c++write-catalog.cc
+diff -urpN '--exclude=autom4te.cache' gettext-0.19.8.1.orig/gettext-tools/woe32dll/c++write-catalog.cc gettext-0.19.8.1/gettext-tools/woe32dll/c++write-catalog.cc
 --- gettext-0.19.8.1.orig/gettext-tools/woe32dll/c++write-catalog.cc	1969-12-31 16:00:00.000000000 -0800
-+++ gettext-0.19.8.1/gettext-tools/woe32dll/c++write-catalog.cc	2017-01-23 15:13:53.168490941 -0800
++++ gettext-0.19.8.1/gettext-tools/woe32dll/c++write-catalog.cc	2017-11-04 10:15:55.755985937 -0700
 @@ -0,0 +1 @@
 +#include "../src/write-catalog.c"
-diff -urpN gettext-0.19.8.1.orig/gettext-tools/woe32dll/c++write-po.cc gettext-0.19.8.1/gettext-tools/woe32dll/c++write-po.cc
+diff -urpN '--exclude=autom4te.cache' gettext-0.19.8.1.orig/gettext-tools/woe32dll/c++write-po.cc gettext-0.19.8.1/gettext-tools/woe32dll/c++write-po.cc
 --- gettext-0.19.8.1.orig/gettext-tools/woe32dll/c++write-po.cc	1969-12-31 16:00:00.000000000 -0800
-+++ gettext-0.19.8.1/gettext-tools/woe32dll/c++write-po.cc	2017-01-23 15:13:53.168490941 -0800
++++ gettext-0.19.8.1/gettext-tools/woe32dll/c++write-po.cc	2017-11-04 10:15:55.755985937 -0700
 @@ -0,0 +1 @@
 +#include "../src/write-po.c"
-diff -urpN gettext-0.19.8.1.orig/gettext-tools/woe32dll/c++write-properties.cc gettext-0.19.8.1/gettext-tools/woe32dll/c++write-properties.cc
+diff -urpN '--exclude=autom4te.cache' gettext-0.19.8.1.orig/gettext-tools/woe32dll/c++write-properties.cc gettext-0.19.8.1/gettext-tools/woe32dll/c++write-properties.cc
 --- gettext-0.19.8.1.orig/gettext-tools/woe32dll/c++write-properties.cc	1969-12-31 16:00:00.000000000 -0800
-+++ gettext-0.19.8.1/gettext-tools/woe32dll/c++write-properties.cc	2017-01-23 15:13:53.168490941 -0800
++++ gettext-0.19.8.1/gettext-tools/woe32dll/c++write-properties.cc	2017-11-04 10:15:55.755985937 -0700
 @@ -0,0 +1 @@
 +#include "../src/write-properties.c"
-diff -urpN gettext-0.19.8.1.orig/gettext-tools/woe32dll/c++write-stringtable.cc gettext-0.19.8.1/gettext-tools/woe32dll/c++write-stringtable.cc
+diff -urpN '--exclude=autom4te.cache' gettext-0.19.8.1.orig/gettext-tools/woe32dll/c++write-stringtable.cc gettext-0.19.8.1/gettext-tools/woe32dll/c++write-stringtable.cc
 --- gettext-0.19.8.1.orig/gettext-tools/woe32dll/c++write-stringtable.cc	1969-12-31 16:00:00.000000000 -0800
-+++ gettext-0.19.8.1/gettext-tools/woe32dll/c++write-stringtable.cc	2017-01-23 15:13:53.168490941 -0800
++++ gettext-0.19.8.1/gettext-tools/woe32dll/c++write-stringtable.cc	2017-11-04 10:15:55.755985937 -0700
 @@ -0,0 +1 @@
 +#include "../src/write-stringtable.c"
-diff -urpN gettext-0.19.8.1.orig/gnulib-local/modules/file-ostream gettext-0.19.8.1/gnulib-local/modules/file-ostream
---- gettext-0.19.8.1.orig/gnulib-local/modules/file-ostream	2017-01-23 15:13:25.060205571 -0800
-+++ gettext-0.19.8.1/gnulib-local/modules/file-ostream	2017-01-23 15:13:53.168490941 -0800
+diff -urpN '--exclude=autom4te.cache' gettext-0.19.8.1.orig/gnulib-local/modules/file-ostream gettext-0.19.8.1/gnulib-local/modules/file-ostream
+--- gettext-0.19.8.1.orig/gnulib-local/modules/file-ostream	2012-12-03 22:28:58.000000000 -0800
++++ gettext-0.19.8.1/gnulib-local/modules/file-ostream	2017-11-04 10:15:55.755985937 -0700
 @@ -12,7 +12,11 @@ xalloc
  configure.ac:
  
@@ -137,9 +326,9 @@ diff -urpN gettext-0.19.8.1.orig/gnulib-local/modules/file-ostream gettext-0.19.
  # This is a Makefile rule that generates multiple files at once; see the
  # automake documentation, node "Multiple Outputs", for details.
  file-ostream.h : $(top_srcdir)/build-aux/moopp file-ostream.oo.h file-ostream.oo.c ostream.oo.h
-diff -urpN gettext-0.19.8.1.orig/gnulib-local/modules/html-ostream gettext-0.19.8.1/gnulib-local/modules/html-ostream
---- gettext-0.19.8.1.orig/gnulib-local/modules/html-ostream	2017-01-23 15:13:25.060205571 -0800
-+++ gettext-0.19.8.1/gnulib-local/modules/html-ostream	2017-01-23 15:13:53.168490941 -0800
+diff -urpN '--exclude=autom4te.cache' gettext-0.19.8.1.orig/gnulib-local/modules/html-ostream gettext-0.19.8.1/gnulib-local/modules/html-ostream
+--- gettext-0.19.8.1.orig/gnulib-local/modules/html-ostream	2012-12-03 22:28:58.000000000 -0800
++++ gettext-0.19.8.1/gnulib-local/modules/html-ostream	2017-11-04 10:15:55.755985937 -0700
 @@ -15,7 +15,11 @@ xalloc
  configure.ac:
  
@@ -152,9 +341,9 @@ diff -urpN gettext-0.19.8.1.orig/gnulib-local/modules/html-ostream gettext-0.19.
  # This is a Makefile rule that generates multiple files at once; see the
  # automake documentation, node "Multiple Outputs", for details.
  html-ostream.h : $(top_srcdir)/build-aux/moopp html-ostream.oo.h html-ostream.oo.c ostream.oo.h
-diff -urpN gettext-0.19.8.1.orig/gnulib-local/modules/ostream gettext-0.19.8.1/gnulib-local/modules/ostream
---- gettext-0.19.8.1.orig/gnulib-local/modules/ostream	2017-01-23 15:13:25.060205571 -0800
-+++ gettext-0.19.8.1/gnulib-local/modules/ostream	2017-01-23 15:13:53.168490941 -0800
+diff -urpN '--exclude=autom4te.cache' gettext-0.19.8.1.orig/gnulib-local/modules/ostream gettext-0.19.8.1/gnulib-local/modules/ostream
+--- gettext-0.19.8.1.orig/gnulib-local/modules/ostream	2012-12-03 22:28:58.000000000 -0800
++++ gettext-0.19.8.1/gnulib-local/modules/ostream	2017-11-04 10:15:55.755985937 -0700
 @@ -11,7 +11,11 @@ moo
  configure.ac:
  
@@ -167,9 +356,9 @@ diff -urpN gettext-0.19.8.1.orig/gnulib-local/modules/ostream gettext-0.19.8.1/g
  # This is a Makefile rule that generates multiple files at once; see the
  # automake documentation, node "Multiple Outputs", for details.
  ostream.h : $(top_srcdir)/build-aux/moopp ostream.oo.h ostream.oo.c
-diff -urpN gettext-0.19.8.1.orig/gnulib-local/modules/styled-ostream gettext-0.19.8.1/gnulib-local/modules/styled-ostream
---- gettext-0.19.8.1.orig/gnulib-local/modules/styled-ostream	2017-01-23 15:13:25.060205571 -0800
-+++ gettext-0.19.8.1/gnulib-local/modules/styled-ostream	2017-01-23 15:13:53.168490941 -0800
+diff -urpN '--exclude=autom4te.cache' gettext-0.19.8.1.orig/gnulib-local/modules/styled-ostream gettext-0.19.8.1/gnulib-local/modules/styled-ostream
+--- gettext-0.19.8.1.orig/gnulib-local/modules/styled-ostream	2012-12-03 22:28:58.000000000 -0800
++++ gettext-0.19.8.1/gnulib-local/modules/styled-ostream	2017-11-04 10:15:55.755985937 -0700
 @@ -11,7 +11,11 @@ ostream
  configure.ac:
  
@@ -182,9 +371,9 @@ diff -urpN gettext-0.19.8.1.orig/gnulib-local/modules/styled-ostream gettext-0.1
  # This is a Makefile rule that generates multiple files at once; see the
  # automake documentation, node "Multiple Outputs", for details.
  styled-ostream.h : $(top_srcdir)/build-aux/moopp styled-ostream.oo.h styled-ostream.oo.c ostream.oo.h
-diff -urpN gettext-0.19.8.1.orig/gnulib-local/modules/term-ostream gettext-0.19.8.1/gnulib-local/modules/term-ostream
---- gettext-0.19.8.1.orig/gnulib-local/modules/term-ostream	2017-01-23 15:13:25.060205571 -0800
-+++ gettext-0.19.8.1/gnulib-local/modules/term-ostream	2017-01-23 15:13:53.172490983 -0800
+diff -urpN '--exclude=autom4te.cache' gettext-0.19.8.1.orig/gnulib-local/modules/term-ostream gettext-0.19.8.1/gnulib-local/modules/term-ostream
+--- gettext-0.19.8.1.orig/gnulib-local/modules/term-ostream	2012-12-03 22:28:58.000000000 -0800
++++ gettext-0.19.8.1/gnulib-local/modules/term-ostream	2017-11-04 10:15:55.755985937 -0700
 @@ -22,7 +22,11 @@ configure.ac:
  gl_TERM_OSTREAM
  


### PR DESCRIPTION
Otherwise, make tries to rebuild it and fails.

Fixes #770.

Signed-off-by: Alexey Neyman <stilor@att.net>