### PR TITLE
Use /usr/bin/env to locate bash

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
     echo "Your BASH shell version (${BASH_VERSION}) is too old." >&2


### PR DESCRIPTION
On some systems (e.g. macOS), the bash provided by the system at `/bin/bash` is not new enough for the bootstrap script, while users may install a bash instance elsewhere. In that case, `/usr/bin/env` can get the bash in the current environment.