### PR TITLE
Make defconfig (and a bunch of other targets) phony

### DIFF
--- a/kconfig/kconfig.mk
+++ b/kconfig/kconfig.mk
@@ -16,6 +16,8 @@ NCONF := $(CT_LIB_DIR)/kconfig/nconf
 # Used by conf/mconf/nconf to find the .in files
 export srctree=$(CT_LIB_DIR)
 
+.PHONY: menuconfig nconfig oldconfig savedefconfig defconfig
+
 menuconfig:
 	@$(CT_ECHO) "  CONF  $@"
 	$(SILENT)$(MCONF) $(KCONFIG_TOP)


### PR DESCRIPTION
Otherwise, a file named `defconfig` (which is, ironically, the default name
for the default config expected by this very makefile) prevents the defconfig
target from being run.

Signed-off-by: Alexey Neyman <stilor@att.net>