### PR TITLE
fix deprecated diff option

### DIFF
--- a/samples/samples.mk
+++ b/samples/samples.mk
@@ -99,7 +99,7 @@ $(patsubst %,check-%,$(CT_SAMPLES)): check-%:
 		mv .defconfig "$${CT_NG_SAMPLE}";                                       \
 	    else                                                                        \
 		echo "$* needs update:";                                                \
-		diff -du0 "$${CT_NG_SAMPLE}" .defconfig |tail -n +4;                    \
+		diff -d -U 0 "$${CT_NG_SAMPLE}" .defconfig |tail -n +4;                    \
 	    fi;                                                                         \
 	 fi
 	@rm -f .config.sample* .defconfig


### PR DESCRIPTION
Partially addresses issue #923 

aarch64-rpi3-linux-gnu needs update:
diff: `-0' option is obsolete; use `-U 0'
diff: Try `diff --help' for more information.