### PR TITLE
Makefile.in: check for configure being up to date

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -44,7 +44,7 @@ __silent_rmdir = $(call __silent,RMDIR,$1)rm -rf $1
 # Remove any suffix rules
 .SUFFIXES:
 
-all: Makefile build
+all: configure Makefile build
 
 ###############################################################################
 # Configuration variables
@@ -102,6 +102,10 @@ PROG_NAME := $(shell echo 'ct-ng' |$(sed) -r -e '$(PROG_SED)' )
 # Check if Makefile is up to date:
 Makefile: Makefile.in
 	@echo "$< changed: you must re-run './configure'"
+	@false
+
+configure: configure.ac
+	@echo "$< changed: you must re-run './bootstrap'"
 	@false
 
 # If installing with DESTDIR, check it's an absolute path


### PR DESCRIPTION
Fixes #934

Add a rule that errors out with a message if configure.ac is newer than
configure. This should catch times where someone is building from the
repo without running bootstrap.

Signed-off-by: Chris Packham <judge.packham@gmail.com>