### PR TITLE
Supply explicit --tag CC

### DIFF
--- a/kconfig/Makefile.am
+++ b/kconfig/Makefile.am
@@ -1,10 +1,8 @@
 ## vim: set noet :
 
-## TBD turn off program renaming for these? Or account for it in ct-ng script?
-## TBD when kconfig is split into a subpackage, need to remove this option from sub-configure
+## FIXME when kconfig is split into a subpackage, need to remove this option from sub-configure
 transform		= s,x,x,
 
-## TBD install into lib/crosstool-ng/kconfig? or move to libexec which seems more suitable
 pkglibexec_PROGRAMS    = conf nconf mconf
 
 EXTRA_DIST		= zconf.y zconf.l \
@@ -17,6 +15,7 @@ BUILT_SOURCES	= zconf.c zconf.lex.c
 AM_LFLAGS		= -L -Pzconf
 AM_YFLAGS		= -l -b zconf -p zconf
 AM_CPPFLAGS		= -include config.h -DCONFIG_=\"CT_\"
+AM_LIBTOOLFLAGS	= --tag CC
 
 conf_SOURCES    = conf.c zconf.c
 


### PR DESCRIPTION
... to libtool, to allow CC overrides at make stage.

Fixes #940.

Signed-off-by: Alexey Neyman <stilor@att.net>