### PR TITLE
Add compatibility with automake < 1.14

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -87,6 +87,8 @@ AC_CONFIG_HEADERS([config.h])
 
 # Modern GCC/GDB releases require C++ support in the compiler
 AC_PROG_CC
+# Add for legacy reasons (automake < 1.14)
+AM_PROG_CC_C_O
 AC_PROG_CXX
 AC_PROG_CPP
 AC_PROG_LEX


### PR DESCRIPTION
As we support CentOS, for example, we have a problem there

    automake: warnings are treated as errors
    kconfig/Makefile.am:26: warning: compiling 'lxdialog/checklist.c' in subdir requires 'AM_PROG_CC_C_O' in
    'configure.ac'
    autoreconf: automake failed with exit status: 1

https://www.gnu.org/software/automake/manual/html_node/Public-Macros.html

CentOS 7, automake 1.13