### PR TITLE
debian: no need to override dh_auto_install

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -26,9 +26,5 @@ override_dh_auto_configure:
 	test -e configure || ./bootstrap
 	dh_auto_configure
 
-#Make sure to include bash completion file in the package
-override_dh_auto_install:
-	dh_auto_install
-
 override_dh_update_autotools_config:
     @:


### PR DESCRIPTION
Since fda857aeb851e5329b5dec664cc14903bf4d20a6 and d6f5c308f9b9564df548d7d6a245a56dbf5360bc, there is no longer any need to override dh_auto_install