### PR TITLE
debian: include curl and wget in Build-Depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: devel
 Priority: optional
 Maintainer: Multiple Candidates <open@example.com>
 Build-Depends: debhelper (>= 9), autoconf, automake, autotools-dev,
- libncursesw5-dev, libncurses5-dev, bison, flex,
+ libncursesw5-dev, libncurses5-dev, bison, flex, curl, wget,
  texinfo, help2man, gawk, git, subversion, bzip2, libtool-bin
 Standards-Version: 3.9.8
 Homepage: http://crosstool-ng.org/
@@ -11,6 +11,7 @@ Homepage: http://crosstool-ng.org/
 Package: crosstool-ng
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, build-essential, texinfo
+Recommends: curl | wget
 Description: create your own cross toolchains
  Crosstool-NG aims at building toolchains. Toolchains are an essential
  component in a software development project. It will compile, assemble and


### PR DESCRIPTION
If these are not present during build, we will end up with a ct-ng that can't download anything.