### PR TITLE
Restore a missing GDB option

### DIFF
--- a/config/debug/gdb.in
+++ b/config/debug/gdb.in
@@ -17,3 +17,10 @@ config GDB_HAS_PYTHON
 config GDB_INSTALL_GDBINIT
     bool
     default y if GDB_7_0_or_later
+
+# GDB 8.0 now requires C++ for build. GDB 7.12 offered a configure
+# switch to fall back to C. We want to use that option because
+# the conversion in 7.12 was incomplete and had some breakages.
+config GDB_HAS_DISABLE_CXX_BUILD
+    def_bool y
+    depends on GDB_7_12_or_later && !GDB_8_0_or_later

--- a/config/debug/gdb.in.gdbserver
+++ b/config/debug/gdb.in.gdbserver
@@ -16,7 +16,6 @@ config GDB_GDBSERVER_HAS_IPA_LIB
     depends on GDB_7_2_or_later
     default y
 
-# gdbserver is then linked with "-static -Wl,--dynamic-list=..." which
 config GDB_GDBSERVER_STATIC
     bool
     prompt "Build a static gdbserver"

--- a/packages/gdb/package.desc
+++ b/packages/gdb/package.desc
@@ -1,5 +1,5 @@
 origin='GNU'
 repository='git git://sourceware.org/git/binutils-gdb.git'
 mirrors='$(CT_Mirrors GNU gdb) $(CT_Mirrors sourceware gdb/releases)'
-milestones='7.0 7.2 8.0'
+milestones='7.0 7.2 7.12 8.0'
 archive_formats='.tar.xz .tar.gz'

--- a/scripts/build/debug/300-gdb.sh
+++ b/scripts/build/debug/300-gdb.sh
@@ -44,6 +44,10 @@ do_debug_gdb_build() {
 
         cross_extra_config=("${extra_config[@]}")
 
+        if [ "${CT_GDB_HAS_DISABLE_CXX_BUILD}" = "y" ]; then
+            cross_extra_config+=("--disable-build-with-cxx")
+        fi
+
         # For gdb-cross this combination of flags forces
         # gdb configure to fall back to default '-lexpat' flag
         # which is acceptable.
@@ -198,7 +202,7 @@ do_debug_gdb_build() {
         native_extra_config=("${extra_config[@]}")
 
         # We may not have C++ language configured for target
-        if [ "${GDB_TARGET_DISABLE_CXX_BUILD}" = "y" ]; then
+        if [ "${CT_GDB_HAS_DISABLE_CXX_BUILD}" = "y" ]; then
             native_extra_config+=("--disable-build-with-cxx")
         fi
 
@@ -322,7 +326,7 @@ do_debug_gdb_build() {
         gdbserver_extra_config=("${extra_config[@]}")
 
         # We may not have C++ language configured for target
-        if [ "${GDB_TARGET_DISABLE_CXX_BUILD}" = "y" ]; then
+        if [ "${CT_GDB_HAS_DISABLE_CXX_BUILD}" = "y" ]; then
             gdbserver_extra_config+=("--disable-build-with-cxx")
         fi
 


### PR DESCRIPTION
(whether GDB has --disable-build-with-cxx) and use it.

Signed-off-by: Alexey Neyman <stilor@att.net>