### PR TITLE
README: Fix spello uClibc-ng 1.21.0 -> 1.0.21

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Crosstool-NG aims at building toolchains. Toolchains are an essential component 
 
 Refer to [documentation at crosstool-NG website](http://crosstool-ng.github.io/docs/) for more information on how to configure, install and use crosstool-NG.
 
-**Note 1:** If you elect to build a uClibc-based toolchain, you will have to prepare a config file for uClibc with <= crosstool-NG-1.21.0. In >= crosstool-NG-1.22.0 you only need to prepare a config file for uClibc(or uClibc-ng) if you really need a custom config for uClibc.
+**Note 1:** If you elect to build a uClibc-based toolchain, you will have to prepare a config file for uClibc with <= crosstool-NG-1.0.21. In >= crosstool-NG-1.0.22 you only need to prepare a config file for uClibc(or uClibc-ng) if you really need a custom config for uClibc.
 
 **Note 2:** If you call `ct-ng --help` you will get help for `make(2)`. This is because ct-ng is in fact a `make(2)` script. There is no clean workaround for this.
 


### PR DESCRIPTION
Note, the same thing should be fixed in the docs here: http://crosstool-ng.github.io/docs/caveats-features/ in "uClibc/uClibc-NG configuration"
>  Before release ***1.21.0***, it was necessary...