### PR TITLE
Properly handle newlib configuration flags

### DIFF
--- a/scripts/build/libc/newlib.sh
+++ b/scripts/build/libc/newlib.sh
@@ -65,13 +65,13 @@ IO_LL:newlib-io-long-long
 NEWLIB_REGISTER_FINI:newlib-register-fini
 NANO_MALLOC:newlib-nano-malloc
 NANO_FORMATTED_IO:newlib-nano-formatted-io
-ATEXIT_DYNAMIC_ALLOC:atexit-dynamic-alloc
+ATEXIT_DYNAMIC_ALLOC:newlib-atexit-dynamic-alloc
 GLOBAL_ATEXIT:newlib-global-atexit
 LITE_EXIT:lite-exit
-REENT_SMALL:reent-small
-MULTITHREAD:multithread
+REENT_SMALL:newlib-reent-small
+MULTITHREAD:newlib-multithread
 WIDE_ORIENT:newlib-wide-orient
-UNBUF_STREAM_OPT:unbuf-stream-opt
+UNBUF_STREAM_OPT:newlib-unbuf-stream-opt
 ENABLE_TARGET_OPTSPACE:target-optspace
     "
 


### PR DESCRIPTION
Some configuration-time flags for newlib are prefixed with "newlib-", i.e. we need to pass --enable-newlib-FEATURE to the configure script. Unfortunately, newlib.sh do not add this prefix when enabling the features atexit-dynamic-alloc, reent-small, multithread, and unbuf-stream-opt. Thus, enabling these options in crosstool-ng's config has no effect on the generated libc.
This patch fixes this bug.