### PR TITLE
Use the platform headers in the pass-2 and canadian gcc stages

### DIFF
--- a/scripts/build/cc/gcc.sh
+++ b/scripts/build/cc/gcc.sh
@@ -350,12 +350,11 @@ do_gcc_core_backend() {
             ;;
     esac
 
-    # This is only needed when building libstdc++ in a canadian environment with
-    # this function being used for final step (i.e., when building for bare metal).
-    if [ "${build_step}" = "gcc_build" ]; then
-        CT_DoLog DEBUG "Copying headers to install area of core C compiler"
-        CT_DoExecLog ALL cp -a "${CT_HEADERS_DIR}" "${prefix}/${CT_TARGET}/include"
-    fi
+    case "${build_step}" in
+        core2|gcc_build)
+            CT_DoLog DEBUG "Copying headers to install area of core C compiler"
+            CT_DoExecLog ALL cp -a "${CT_HEADERS_DIR}" "${prefix}/${CT_TARGET}/include"
+    esac
 
     for tmp in ARCH ABI CPU TUNE FPU FLOAT ENDIAN; do
         eval tmp="\${CT_ARCH_WITH_${tmp}}"


### PR DESCRIPTION
I had a problem when compiled ct-ng for a custom bare-metal arch. It didn't find "pthread.h" header and others