### PR TITLE
patches: mpfr: Fix obsolete ARC asm constraints

### DIFF
--- a/packages/mpfr/4.0.1/0001-Fix-obsolete-ARC-asm-constraints.patch
+++ b/packages/mpfr/4.0.1/0001-Fix-obsolete-ARC-asm-constraints.patch
@@ -1,0 +1,37 @@
+mpfr-longlong.h: Fix obsolete ARC asm constraints
+
+This patch replaces obsolete ARC "J" asm constraint with
+up-to-date "Cal" constraint.
+The patch should be applied to upstream "mpfr" library and
+after that it should be removed from buildroot as soon as 
+mpfr version with current fix will come up.
+
+Signed-off-by: Vlad Zakharov <vzakhar@synopsys.com>
+Signed-off-by: Claudiu Zissulescu <claziss@synopsys.com>
+---
+Index: /src/mpfr-longlong.h
+===================================================================
+--- /src/mpfr-longlong.h	(revision 10963)
++++ /src/mpfr-longlong.h	(working copy)
+@@ -416,17 +416,17 @@
+ 	   : "=r" (sh),							\
+ 	     "=&r" (sl)							\
+ 	   : "r"  ((USItype) (ah)),					\
+-	     "rIJ" ((USItype) (bh)),					\
++	     "rICal" ((USItype) (bh)),					\
+ 	     "%r" ((USItype) (al)),					\
+-	     "rIJ" ((USItype) (bl)))
++	     "rICal" ((USItype) (bl)))
+ #define sub_ddmmss(sh, sl, ah, al, bh, bl) \
+   __asm__ ("sub.f\t%1, %4, %5\n\tsbc\t%0, %2, %3"			\
+ 	   : "=r" (sh),							\
+ 	     "=&r" (sl)							\
+ 	   : "r" ((USItype) (ah)),					\
+-	     "rIJ" ((USItype) (bh)),					\
++	     "rICal" ((USItype) (bh)),					\
+ 	     "r" ((USItype) (al)),					\
+-	     "rIJ" ((USItype) (bl)))
++	     "rICal" ((USItype) (bl)))
+ #endif
+ 
+ #if defined (__arm__) && (defined (__thumb2__) || !defined (__thumb__)) \


### PR DESCRIPTION
Adding this patch fixes errors while building mpfr for native ARC
toolcahin. Error messages are:
-----------------------------------------------------8<------------------
...
[ERROR]   .build/HOST-arc-snps-linux-uclibc/arc-snps-linux-uclibc/src/
  mpfr/src/mpfr-longlong.h:423:3: error: impossible constraint in 'asm'
...
[ERROR]  >>  Build failed in step 'Installing MPFR for host'
-----------------------------------------------------8<------------------

Signed-off-by: Evgeniy Didin <didin@synopsys.com>