### PR TITLE
Decouple darwin clang

### DIFF
--- a/scripts/build/debug/300-gdb.sh
+++ b/scripts/build/debug/300-gdb.sh
@@ -104,18 +104,17 @@ do_debug_gdb_build() {
             cross_LDFLAGS+=" -static"
         fi
 
-        case "${CT_HOST}" in
-            *darwin*)
-                # FIXME: Really, we should be testing for host compiler being clang.
-                cross_CFLAGS+=" -Qunused-arguments"
-                cross_CXXFLAGS+=" -Qunused-arguments"
-                # clang detects the line from gettext's _ macro as format string
-                # not being a string literal and produces a lot of warnings - which
-                # ct-ng's logger faithfully relays to user if this happens in the
-                # error() function. Suppress them.
-                cross_extra_config+=("--enable-build-warnings=,-Wno-format-nonliteral,-Wno-format-security")
-                ;;
-        esac
+        if ${CT_HOST}-gcc --version 2>&1 | grep clang; then
+            # FIXME: Now we really are testing for host compiler being clang
+            # (also in crosstool-NG.sh), commented
+            # cross_CFLAGS+=" -Qunused-arguments"
+            cross_CXXFLAGS+=" -Qunused-arguments"
+            # clang detects the line from gettext's _ macro as format string
+            # not being a string literal and produces a lot of warnings - which
+            # ct-ng's logger faithfully relays to user if this happens in the
+            # error() function. Suppress them.
+            cross_extra_config+=("--enable-build-warnings=,-Wno-format-nonliteral,-Wno-format-security")
+        fi
 
         # Fix up whitespace. Some older GDB releases (e.g. 6.8a) get confused if there
         # are multiple consecutive spaces: sub-configure scripts replace them with a

--- a/scripts/crosstool-NG.sh
+++ b/scripts/crosstool-NG.sh
@@ -519,6 +519,9 @@ if [ -z "${CT_RESTART}" ]; then
     CT_LDFLAGS_FOR_BUILD="-L${CT_BUILDTOOLS_PREFIX_DIR}/lib"
     CT_LDFLAGS_FOR_BUILD+=" ${CT_EXTRA_LDFLAGS_FOR_BUILD}"
 
+    if ${CT_BUILD}-gcc --version 2>&1 | grep clang; then
+        CT_CFLAGS_FOR_BUILD+=" -Qunused-arguments"
+    fi
     case "${CT_BUILD}" in
         *darwin*)
             # Two issues while building on MacOS. Really, we should be checking for
@@ -546,6 +549,9 @@ if [ -z "${CT_RESTART}" ]; then
     CT_CFLAGS_FOR_HOST+=" ${CT_EXTRA_CFLAGS_FOR_HOST}"
     CT_LDFLAGS_FOR_HOST="-L${CT_HOST_COMPLIBS_DIR}/lib"
     CT_LDFLAGS_FOR_HOST+=" ${CT_EXTRA_LDFLAGS_FOR_HOST}"
+    if ${CT_HOST}-gcc --version 2>&1 | grep clang; then
+        CT_CFLAGS_FOR_HOST+=" -Qunused-arguments"
+    fi
     case "${CT_HOST}" in
         *darwin*)
             # Same as above, for host


### PR DESCRIPTION
Originally part of discussion in #712 as an issue for building gdb in the `debug` step which is still preventing successful configuring of gdb on darwin 17.7, gcc (MacPorts 6.4.0_2). Test in `300-gdb.sh` in 1.23 leads to a successful build there.  Addition to `crosstool-NG.sh` is untested, but appears to be what was desired in the discussion.