### PR TITLE
Restore *-android build

### DIFF
--- a/scripts/build/libc/bionic.sh
+++ b/scripts/build/libc/bionic.sh
@@ -26,7 +26,13 @@ do_libc() {
     fi
     CT_DoStep INFO "Installing C library binaries"
     CT_DoExecLog ALL cp -r "${CT_SRC_DIR}/android-ndk/platforms/android-${CT_ANDROID_API}/arch-${arch}/usr" "${CT_SYSROOT_DIR}"
-    CT_EnvModify CT_ALL_TARGET_CFLAGS "${CT_ALL_TARGET_CFLAGS} -D__ANDROID_API__=${CT_ANDROID_API}"
+
+    # NB: Modifying CT_TARGET_CFLAGS here, not CT_ALL_TARGET_CFLAGS: the __ANDROID_API__
+    # definition needs to be passed into GCC build, or the resulting libstdc++ gets
+    # miscompiled (attempt to link against it results in unresolved symbols to stdout/...).
+    # And since __ANDROID_API__ is a user config option, placing it with other user-supplied
+    # options isn't completely out of character.
+    CT_EnvModify CT_TARGET_CFLAGS "${CT_TARGET_CFLAGS} -D__ANDROID_API__=${CT_ANDROID_API}"
 }
 
 do_libc_post_cc() {


### PR DESCRIPTION
Modify CT_TARGET_CFLAGS (which are passed to GCC's FOR_TARGET flags) rather
than CT_ALL_TARGET_CFLAGS.

Fixes #1006.

Signed-off-by: Alexey Neyman <stilor@att.net>