### PR TITLE
package/gcc: Don't use --with-glibc-version if version is not 123.123

### DIFF
--- a/scripts/build/cc/gcc.sh
+++ b/scripts/build/cc/gcc.sh
@@ -468,8 +468,10 @@ do_gcc_core_backend() {
         local glibc_version
 
         CT_GetPkgVersion GLIBC glibc_version
-        glibc_version=`echo "${glibc_version}" | sed 's/\([1-9][0-9]*\.[1-9][0-9]*\).*/\1/'`
-        extra_config+=("--with-glibc-version=${glibc_version}")
+        glibc_version=`echo "${glibc_version}" | sed -n 's/\([1-9][0-9]*\.[1-9][0-9]*\).*/\1/p'`
+        if [ ! -z "${glibc_version}" ]; then
+            extra_config+=("--with-glibc-version=${glibc_version}")
+        fi
     fi
 
     case "${CT_CC_GCC_LDBL_128}" in


### PR DESCRIPTION
If GLIBC_VERY_NEW is used (for example we build Glibc from trunk)
we end-up configuring GCC with "-with-glibc-version=new" which GCC
doesn't like barking like that:
------------------>8--------------
"error: option --with-glibc-version requires a version number M.N"
------------------>8--------------

So let's make sure "-with-glibc-version" is not used at all if
Glibc version is not a numeric value.

Note the fix consists of 2 parts:
 1. Improve SED command such that it doesn't print input line if
    required pattern is not found.
 2. Check if version string is not empty and only then pass
    "--with-glibc-version" to GCC's configuration script.

Signed-off-by: Alexey Brodkin <abrodkin@synopsys.com>