### PR TITLE
Pull in fixes for ARM v8m support in gcc 8.2.0

### DIFF
--- a/packages/gcc/8.2.0/0020-ARM-fix-cmse.patch
+++ b/packages/gcc/8.2.0/0020-ARM-fix-cmse.patch
@@ -1,0 +1,69 @@
+From 8155b998a328748ca3d2cd1d012feb5c8286cd65 Mon Sep 17 00:00:00 2001
+From: hainque <hainque@138bc75d-0d04-0410-961f-82ee72b054a4>
+Date: Thu, 17 May 2018 16:36:36 +0000
+Subject: [PATCH] 2018-05-17  Jerome Lambourg  <lambourg@adacore.com>
+
+	gcc/
+	* config/arm/arm_cmse.h (cmse_nsfptr_create, cmse_is_nsfptr): Remove
+	#include <stdint.h>.  Replace intptr_t with __INTPTR_TYPE__.
+
+	libgcc/
+	* config/arm/cmse.c (cmse_check_address_range): Replace
+	UINTPTR_MAX with __UINTPTR_MAX__ and uintptr_t with __UINTPTR_TYPE__.
+
+git-svn-id: svn+ssh://gcc.gnu.org/svn/gcc/trunk@260330 138bc75d-0d04-0410-961f-82ee72b054a4
+---
+ gcc/config/arm/arm_cmse.h | 5 ++---
+ libgcc/config/arm/cmse.c  | 5 +++--
+ 4 files changed, 15 insertions(+), 5 deletions(-)
+
+diff --git a/gcc/config/arm/arm_cmse.h b/gcc/config/arm/arm_cmse.h
+index 367e212dc9c..f972e23659d 100644
+--- a/gcc/config/arm/arm_cmse.h
++++ b/gcc/config/arm/arm_cmse.h
+@@ -35,7 +35,6 @@ extern "C" {
+ #if __ARM_FEATURE_CMSE & 1
+ 
+ #include <stddef.h>
+-#include <stdint.h>
+ 
+ #ifdef __ARM_BIG_ENDIAN
+ 
+@@ -174,9 +173,9 @@ cmse_nonsecure_caller (void)
+ #define CMSE_MPU_NONSECURE	16
+ #define CMSE_NONSECURE		18
+ 
+-#define cmse_nsfptr_create(p) ((typeof ((p))) ((intptr_t) (p) & ~1))
++#define cmse_nsfptr_create(p) ((typeof ((p))) ((__INTPTR_TYPE__) (p) & ~1))
+ 
+-#define cmse_is_nsfptr(p) (!((intptr_t) (p) & 1))
++#define cmse_is_nsfptr(p) (!((__INTPTR_TYPE__) (p) & 1))
+ 
+ #endif /* __ARM_FEATURE_CMSE & 2 */
+ 
+diff --git a/libgcc/config/arm/cmse.c b/libgcc/config/arm/cmse.c
+index 3ded385693a..2ad0af2ecd8 100644
+--- a/libgcc/config/arm/cmse.c
++++ b/libgcc/config/arm/cmse.c
+@@ -36,7 +36,7 @@ cmse_check_address_range (void *p, size_t size, int flags)
+   char *pb = (char *) p, *pe;
+ 
+   /* Check if the range wraps around.  */
+-  if (UINTPTR_MAX - (uintptr_t) p < size)
++  if (__UINTPTR_MAX__ - (__UINTPTR_TYPE__) p < size)
+     return NULL;
+ 
+   /* Check if an unknown flag is present.  */
+@@ -51,7 +51,8 @@ cmse_check_address_range (void *p, size_t size, int flags)
+ 
+   /* Execute the right variant of the TT instructions.  */
+   pe = pb + size - 1;
+-  const int singleCheck = (((uintptr_t) pb ^ (uintptr_t) pe) < 32);
++  const int singleCheck
++    = (((__UINTPTR_TYPE__) pb ^ (__UINTPTR_TYPE__) pe) < 32);
+   switch (flags & known_secure_level)
+     {
+     case 0:
+-- 
+2.14.4
+

--- a/packages/gcc/8.2.0/0021-arm-Make-arm_cmse.h-C99-compatible.patch
+++ b/packages/gcc/8.2.0/0021-arm-Make-arm_cmse.h-C99-compatible.patch
@@ -1,0 +1,40 @@
+From 02a72c22044c079becd5307c8b5c9552ba0c7f53 Mon Sep 17 00:00:00 2001
+From: avieira <avieira@138bc75d-0d04-0410-961f-82ee72b054a4>
+Date: Tue, 5 Jun 2018 15:07:09 +0000
+Subject: [PATCH] [arm] Make arm_cmse.h C99 compatible
+
+gcc/ChangeLog
+2018-06-05  Andre Vieira  <andre.simoesdiasvieira@arm.com>
+
+	* config/arm/arm_cmse.h (cmse_nsfptr_create): Change typeof to
+	__typeof__.
+	(cmse_check_pointed_object): Likewise.
+
+git-svn-id: svn+ssh://gcc.gnu.org/svn/gcc/trunk@261204 138bc75d-0d04-0410-961f-82ee72b054a4
+---
+ gcc/config/arm/arm_cmse.h                     | 4 ++--
+ 4 files changed, 16 insertions(+), 2 deletions(-)
+ create mode 100644 gcc/testsuite/gcc.target/arm/cmse/cmse-1c99.c
+
+diff --git a/gcc/config/arm/arm_cmse.h b/gcc/config/arm/arm_cmse.h
+index f972e23659d..9b35537cd33 100644
+--- a/gcc/config/arm/arm_cmse.h
++++ b/gcc/config/arm/arm_cmse.h
+@@ -173,7 +173,7 @@ cmse_nonsecure_caller (void)
+ #define CMSE_MPU_NONSECURE	16
+ #define CMSE_NONSECURE		18
+ 
+-#define cmse_nsfptr_create(p) ((typeof ((p))) ((__INTPTR_TYPE__) (p) & ~1))
++#define cmse_nsfptr_create(p) ((__typeof__ ((p))) ((__INTPTR_TYPE__) (p) & ~1))
+ 
+ #define cmse_is_nsfptr(p) (!((__INTPTR_TYPE__) (p) & 1))
+ 
+@@ -187,7 +187,7 @@ __extension__ void *
+ cmse_check_address_range (void *, size_t, int);
+ 
+ #define cmse_check_pointed_object(p, f) \
+-  ((typeof ((p))) cmse_check_address_range ((p), sizeof (*(p)), (f)))
++  ((__typeof__ ((p))) cmse_check_address_range ((p), sizeof (*(p)), (f)))
+ 
+ #endif /* __ARM_FEATURE_CMSE & 1 */
+ 


### PR DESCRIPTION
There are some fixes to the cmse code in mainline gcc that we need to
build an embedded toolchain targetting Cortex-M cpus that support the
v8m extensions.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>