### PR TITLE
Fix compilation against binutils-2.31.1

### DIFF
--- a/packages/elf2flt/git-6d80ab6c93409e796f85da404bde84b841231531/0000-diagnostics.h.patch
+++ b/packages/elf2flt/git-6d80ab6c93409e796f85da404bde84b841231531/0000-diagnostics.h.patch
@@ -1,0 +1,30 @@
+commit 2c8ab83ec84662f4916b5237da3e4330956a32eb
+Author: Alexey Neyman <stilor@att.net>
+Date:   Sat Sep 29 13:12:08 2018 -0700
+
+    Create symlink to <bfd/diagnostics.h> in bfd-headers
+    
+    Included by <bfd/bfd.h>.
+    
+    Signed-off-by: Alexey Neyman <stilor@att.net>
+
+diff --git a/Makefile.in b/Makefile.in
+index cfad06c..8162cba 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -123,11 +123,14 @@ sinclude .deps
+ 	$(CC) -MM $(CPPFLAGS) $(srcdir)/*.c > .deps
+ 
+ 
++# Not all versions of binutils have all these headers, some may end up
++# as dangling symlinks
+ bfd-headers/.stamp:
+ 	rm -rf bfd-headers
+ 	mkdir bfd-headers
+ 	ln -sf $(BFD_INCLUDE_DIR)/bfd.h bfd-headers/bfd.h
+-	for f in ansidecl filenames hashtab libiberty symcat; do \
++	ln -sf $(BFD_INCLUDE_DIR)/diagnostics.h bfd-headers/diagnostics.h
++	for f in ansidecl filenames hashtab libiberty symcat diagnostics; do \
+ 		ln -sf $(BINUTILS_INCLUDE_DIR)/$$f.h bfd-headers/$$f.h || exit 1; \
+ 	done
+ 	ln -sf $(BINUTILS_INCLUDE_DIR)/elf bfd-headers/elf


### PR DESCRIPTION
... where <bfd/bfd.h> also needs <bfd/diagnostics.h>.

Signed-off-by: Alexey Neyman <stilor@att.net>