### PR TITLE
Disallow linux versions before 4.8 for ARC

### DIFF
--- a/config/arch/arc.in
+++ b/config/arch/arc.in
@@ -10,6 +10,7 @@
 ## select ARCH_SUPPORTS_WITH_CPU
 ## select GCC_REQUIRE_7_or_later
 ## select BINUTILS_REQUIRE_2_30_or_later
+## select LINUX_REQUIRE_4_8_or_later if KERNEL_LINUX
 ##
 ## help The Synopsys DesignWare ARC architecture, see more info here:
 ## help     https://www.synopsys.com/designware-ip/processor-solutions/arc-processors.html

--- a/packages/linux/package.desc
+++ b/packages/linux/package.desc
@@ -1,6 +1,6 @@
 repository='git git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git'
 mirrors='$(CT_Mirrors kernel.org linux ${CT_LINUX_VERSION})'
 relevantpattern='2.*.*|. *.*|.'
-milestones='3.2 3.7'
+milestones='3.2 3.7 4.8'
 archive_formats='.tar.xz .tar.gz'
 signature_format='unpacked/.sign'


### PR DESCRIPTION
Inspired by a similar fix for AArch64 in 481cbaac9b23.

The point is in Linux v4.8 we introduced new ABIv4 which is now used in
both Linux kernel and up-to-date GNU tools for ARC (based on GCC 6.x+).
See [1] for more details.

[1] https://github.com/foss-for-synopsys-dwc-arc-processors/linux/wiki/ARC-Linux-Syscall-ABI-Compatibility

Signed-off-by: Alexey Brodkin <abrodkin@synopsys.com>