### PR TITLE
Fix hardcoded mirrors for newlib.

### DIFF
--- a/packages/newlib/package.desc
+++ b/packages/newlib/package.desc
@@ -1,6 +1,6 @@
 origin='RedHat'
 repository='git git://sourceware.org/git/newlib-cygwin.git'
-mirrors='ftp://sourceware.org/pub/newlib'
+mirrors='$(CT_Mirrors sourceware newlib)'
 milestones='2.0 2.1 2.2'
 relevantpattern='*.*.*|.'
 archive_formats='.tar.gz'


### PR DESCRIPTION
Behind restrictive firewalls or restrictive networks, fetching newlib fails
because of FTP protocol. Moreover, the address of the newlib package
is hardcoded, so I replaced it with a call to the CT_Mirrors function.