### PR TITLE
Remove android-ndk-r18

### DIFF
--- a/packages/android-ndk/r18/DO_NOT_IMPORT
+++ b/packages/android-ndk/r18/DO_NOT_IMPORT
@@ -1,0 +1,2 @@
+r18 removed the support for GCC and is therefore useless in
+crosstool-NG (unless clang is supported).

--- a/packages/android-ndk/r18/chksum
+++ b/packages/android-ndk/r18/chksum
@@ -1,4 +1,0 @@
-md5 android-ndk-r18-linux-x86_64.zip 41a86d61b2c003db139f2c8ba139086c
-sha1 android-ndk-r18-linux-x86_64.zip 2ac2e8e1ef73ed551cac3a1479bb28bd49369212
-sha256 android-ndk-r18-linux-x86_64.zip c413dd014edc37f822d0dc88fabc05b64232d07d5c6e9345224e47073fdf140b
-sha512 android-ndk-r18-linux-x86_64.zip 7a8b372be53a7d5a008b6cafda451096623af33aea910edd8e98ee4b15682da5d2ad641727ab12eca522ba965073a3eb247cd3cd850c9b602e2c7b1cd6eec708


### PR DESCRIPTION
It no longer supports GCC.

Fixes #1047.

Signed-off-by: Alexey Neyman <stilor@att.net>