### PR TITLE
Fix glibc-ports symbolic link

### DIFF
--- a/scripts/build/libc/glibc.sh
+++ b/scripts/build/libc/glibc.sh
@@ -23,8 +23,8 @@ do_libc_extract() {
         # we do not support concurrent use of the source directory
         # and next run, if using different glibc-ports source, will override
         # this symlink anyway.
-        CT_DoExecLog ALL ln -sf "${CT_GLIBC_PORTS_SRC_DIR}/${CT_GLIBC_PORTS_BASENAME}" \
-                "${CT_GLIBC_SRC_DIR}/${CT_GLIBC_BASENAME}/ports"
+        CT_DoExecLog ALL ln -sf "${CT_GLIBC_PORTS_SRC_DIR}/${CT_GLIBC_PORTS_DIR_NAME}" \
+                "${CT_GLIBC_SRC_DIR}/${CT_GLIBC_DIR_NAME}/ports"
     fi
 }
 


### PR DESCRIPTION
It fixes the following error:

```
...
[DEBUG]    ==> Executing:  'mv' '/home/oblique/git/crosstool-ng/.build/arm-none-linux-gnueabi/src/glibc-2.12.1' '/home/oblique/git/crosstool-ng/.build/arm-none-linux-gnueabi/src/glibc'
...
[DEBUG]    ==> Executing:  'mv' '/home/oblique/git/crosstool-ng/.build/arm-none-linux-gnueabi/src/glibc-ports-2.12.1' '/home/oblique/git/crosstool-ng/.build/arm-none-linux-gnueabi/src/glibc-ports'
...
[DEBUG]    ==> Executing:  'ln' '-sf' '/home/oblique/git/crosstool-ng/.build/arm-none-linux-gnueabi/src/glibc-ports-2.12.1' '/home/oblique/git/crosstool-ng/.build/arm-none-linux-gnueabi/src/glibc-2.12.1/ports'
[ALL  ]    ln: failed to create symbolic link '/home/oblique/git/crosstool-ng/.build/arm-none-linux-gnueabi/src/glibc-2.12.1/ports': No such file or directory
```

Signed-off-by: oblique <psyberbits@gmail.com>