### PR TITLE
Create glibc-ports symlink inside CT_SRC_DIR

### DIFF
--- a/scripts/build/libc/glibc.sh
+++ b/scripts/build/libc/glibc.sh
@@ -23,8 +23,8 @@ do_libc_extract() {
         # we do not support concurrent use of the source directory
         # and next run, if using different glibc-ports source, will override
         # this symlink anyway.
-        CT_DoExecLog ALL ln -sf "${CT_GLIBC_PORTS_SRC_DIR}/${CT_GLIBC_PORTS_BASENAME}" \
-                "${CT_GLIBC_SRC_DIR}/${CT_GLIBC_BASENAME}/ports"
+        CT_DoExecLog ALL ln -sf "${CT_SRC_DIR}/${CT_GLIBC_PORTS_DIR_NAME}" \
+                "${CT_SRC_DIR}/${CT_GLIBC_DIR_NAME}/ports"
     fi
 }
 


### PR DESCRIPTION
... so that it works in both "bundled" and "bundled,local" cases.

Fixes #1060.

Signed-off-by: Alexey Neyman <stilor@att.net>