### PR TITLE
Supply "very old" and "very new" glibc versions

### DIFF
--- a/scripts/build/cc/gcc.sh
+++ b/scripts/build/cc/gcc.sh
@@ -468,7 +468,11 @@ do_gcc_core_backend() {
         local glibc_version
 
         CT_GetPkgVersion GLIBC glibc_version
-        glibc_version=`echo "${glibc_version}" | sed 's/\([1-9][0-9]*\.[1-9][0-9]*\).*/\1/'`
+        case "${glibc_version}" in
+        new) glibc_version=99.99;;
+        old) glibc_version=1.0;;
+        *) glibc_version=`echo "${glibc_version}" | sed 's/\([1-9][0-9]*\.[1-9][0-9]*\).*/\1/'`;;
+        esac
         extra_config+=("--with-glibc-version=${glibc_version}")
     fi
 


### PR DESCRIPTION
... as 1.0 and 99.99, respectively, to gcc configure.

Fixes #1031.

Signed-off-by: Alexey Neyman <stilor@att.net>