### PR TITLE
Add an ability to modify an exported variable

### DIFF
--- a/scripts/build/binutils/binutils.sh
+++ b/scripts/build/binutils/binutils.sh
@@ -227,9 +227,10 @@ do_binutils_backend() {
         cp -a "${prefix}/bin/${CT_TARGET}-ld"   \
               "${prefix}/${CT_TARGET}/bin/ld"
 
-        # If needed, force using ld.bfd during the toolchain build
-        if [ "${CT_BINUTILS_FORCE_LD_BFD}" = "y" ]; then
-            export CTNG_LD_IS=bfd
+        # If needed, force using ld.bfd during the toolchain build.
+        # Note that
+        if [ "${CT_BINUTILS_FORCE_LD_BFD_DEFAULT}" = "y" ]; then
+            CT_EnvModify export CTNG_LD_IS bfd
         fi
     fi
 }

--- a/scripts/functions
+++ b/scripts/functions
@@ -1026,9 +1026,15 @@ CT_DoConfigSub() {
 # Normally, each step is executed in a sub-shell and thus cannot modify the
 # environment for the next step(s). When this is needed, it can do so by
 # invoking this function.
-# Usage: CT_EnvModify VAR VALUE
+# Usage: CT_EnvModify [export] VAR VALUE
 CT_EnvModify() {
-    echo "${1}=\"${2}\"" >> "${CT_BUILD_DIR}/env.modify.sh"
+    local e
+    if [ "$1" = "export" ]; then
+        shift
+        e="export "
+    fi
+    eval "${e}${1}=\"${2}\""
+    echo "${e}${1}=\"${2}\"" >> "${CT_BUILD_DIR}/env.modify.sh"
 }
 
 # Compute the target tuple from what is provided by the user


### PR DESCRIPTION
... and use that ability to permanently set CTNG_LD_IS in case gold is default linker
and we're building glibc.

Fixes #988. This was a long-standing breakage in crosstool-NG (at least since it began
to run each step in a sub-shell).

Signed-off-by: Alexey Neyman <stilor@att.net>