### PR TITLE
Allow ct-ng to be run from non-repo directories

### DIFF
--- a/ct-ng.in
+++ b/ct-ng.in
@@ -17,7 +17,7 @@ export CT_TOP_DIR:=$(shell pwd)
 ifeq (@enable_local@,yes)
 # automake does not allow to set pkgxxxdir, they are always derived from
 # a respective xxxdir. So, for enable-local case, set them directly here.
-export CT_LIB_DIR:=$(shell cd "@srcdir@" && pwd)
+export CT_LIB_DIR:=$(shell dirname $(CT_NG))
 export CT_LIBEXEC_DIR:=$(CT_TOP_DIR)/kconfig
 export CT_DOC_DIR:=$(CT_TOP_DIR)/docs
 else


### PR DESCRIPTION
closes #993 

test:
<pre>
$ crosstool-ng/ct-ng help | more
This is crosstool-NG version 1.23.0.505-5958
</pre>