### PR TITLE
Add a "which" dependency into the configure script

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -126,6 +126,7 @@ CTNG_CHECK_PROGS_REQ([xz], [xz])
 CTNG_CHECK_PROGS_REQ([unzip], [unzip])
 CTNG_CHECK_PROGS_REQ([help2man], [help2man])
 CTNG_CHECK_PROGS_REQ([file], [file])
+CTNG_CHECK_PROGS_REQ([which], [which])
 
 # Not a fatal failure even if we have neither - the tarballs may
 # be provided in a local directory.


### PR DESCRIPTION
Sometimes ago I noticed 'file' and 'which' missed dependencies. The first one you've added recently