### PR TITLE
Collect licenses for the distribution

### DIFF
--- a/scripts/build/internals.sh
+++ b/scripts/build/internals.sh
@@ -144,5 +144,7 @@ do_finish() {
         CT_DoForceRmdir "${CT_DEBUGROOT_DIR}/"{,usr/}{,share/}{man,info}
     fi
 
+    CT_InstallCopyingInformation
+
     CT_EndStep
 }

--- a/scripts/functions
+++ b/scripts/functions
@@ -2396,3 +2396,34 @@ else
     CT_Error "Not found: paths.sh"
 fi
 . "${paths_sh_location}"
+
+CT_InstallCopyingInformation()
+{
+    local pkgname
+    local pkgdir
+    local licfile
+    local dstdir
+
+    CT_DoLog EXTRA "Collect license information from: ${CT_SRC_DIR}"
+    CT_DoLog EXTRA "Put the license information to: ${CT_PREFIX_DIR}/share/licenses"
+
+    shopt -s nullglob
+
+    for pkgdir in ${CT_SRC_DIR}/*; do
+        pkgname=$(basename "${pkgdir}")
+        for licfile in ${pkgdir}/{COPYING*,LICENSE*}; do
+            dstdir="${CT_PREFIX_DIR}/share/licenses/${pkgname}"
+            mkdir -p "${dstdir}"
+            CT_DoExecLog ALL cp -av "${licfile}" "${dstdir}/"
+        done
+    done
+
+    # Also add crosstool's information
+    for licfile in ${CT_TOP_DIR}/{COPYING*,LICENSE*,licenses.d}; do
+        dstdir="${CT_PREFIX_DIR}/share/licenses/crosstool-ng"
+        mkdir -p "${dstdir}"
+        CT_DoExecLog ALL cp -av "${licfile}" "${dstdir}/"
+    done
+
+    shopt -u nullglob
+}


### PR DESCRIPTION
Maybe it will be interesting for you. It collects all licenses that used in the current toolchain build. Although I suspect that the change is not pretty generic.

For my tared directory the result looks like:

```
xtensa-esp32-elf-gcc8_2_0-esp32-2018r1-linux-amd64.tar.xz:/
...
    share/
        licenses/
            gdb/
            gdb/COPYING3.LIB
            gdb/COPYING
            gdb/COPYING.NEWLIB
            gdb/COPYING.LIB
            gdb/COPYING.LIBGLOSS
            gdb/COPYING3
            mpc/
            mpc/COPYING.LESSER
            mpfr/
            mpfr/COPYING
            mpfr/COPYING.LESSER
            autoconf/
            autoconf/COPYINGv3
            autoconf/COPYING
            autoconf/COPYING.EXCEPTION
            binutils/
            binutils/COPYING3.LIB
            binutils/COPYING
            binutils/COPYING.NEWLIB
            binutils/COPYING.LIB
            binutils/COPYING.LIBGLOSS
            binutils/COPYING3
            newlib/
            newlib/COPYING3.LIB
            newlib/COPYING
            newlib/COPYING.NEWLIB
            newlib/COPYING.LIB
            newlib/COPYING.LIBGLOSS
            newlib/COPYING3
            gcc/
            gcc/COPYING3.LIB
            gcc/COPYING.RUNTIME
            gcc/COPYING
            gcc/COPYING.LIB
            gcc/COPYING3
            isl/
            isl/LICENSE
            gmp/
            gmp/COPYING.LESSERv3
            gmp/COPYINGv3
            gmp/COPYING
            gmp/COPYINGv2
            expat/
            expat/COPYING
            automake/
            automake/COPYING
            ncurses/
            ncurses/COPYING
            crosstool-ng/
            crosstool-ng/COPYING
            crosstool-ng/licenses.d/
            crosstool-ng/licenses.d/by-sa/
            crosstool-ng/licenses.d/by-sa/deed_files/
            crosstool-ng/licenses.d/by-sa/deed_files/popup.gif
            crosstool-ng/licenses.d/by-sa/deed_files/logo_deed.gif
            crosstool-ng/licenses.d/by-sa/deed_files/deed_002.gif
            crosstool-ng/licenses.d/by-sa/deed_files/deeds.css
            crosstool-ng/licenses.d/by-sa/deed_files/deed.gif
            crosstool-ng/licenses.d/by-sa/legalcode_files/
            crosstool-ng/licenses.d/by-sa/legalcode_files/deeds.css
            crosstool-ng/licenses.d/by-sa/legalcode_files/logo_code.gif
            crosstool-ng/licenses.d/by-sa/legalcode
            crosstool-ng/licenses.d/by-sa/deed.en
            crosstool-ng/licenses.d/lgpl.txt
            crosstool-ng/licenses.d/gpl.txt
            crosstool-ng/LICENSE
```