### PR TITLE
Fix distclean

### DIFF
--- a/ct-ng.in
+++ b/ct-ng.in
@@ -17,7 +17,7 @@ export CT_TOP_DIR:=$(shell pwd)
 ifeq (@enable_local@,yes)
 # automake does not allow to set pkgxxxdir, they are always derived from
 # a respective xxxdir. So, for enable-local case, set them directly here.
-export CT_LIB_DIR:=$(dir $(CT_NG))
+export CT_LIB_DIR:=$(patsubst %/,%,$(dir $(CT_NG)))
 export CT_LIBEXEC_DIR:=$(CT_LIB_DIR)/kconfig
 export CT_DOC_DIR:=$(CT_LIB_DIR)/docs
 else


### PR DESCRIPTION
After d4aa8d9, make distclean removes scripts in ct-ng configured
with --enable-local.

Signed-off-by: Alexey Neyman <stilor@att.net>