### PR TITLE
Warn if architecture is empty on x86/32bit

### DIFF
--- a/config/target.in
+++ b/config/target.in
@@ -268,7 +268,9 @@ config ARCH_ARCH
       target CPU.
       
       Leave blank if you don't know, or if your target architecture does not
-      offer this option.
+      offer this option. Must be specified for 32-bit x86 that uses some
+      C library (glibc, uClibc-ng, ...) - the default, "i386" is not supported
+      by these libraries.
 
 config ARCH_ABI
     string

--- a/scripts/build/arch/x86.sh
+++ b/scripts/build/arch/x86.sh
@@ -10,7 +10,11 @@ CT_DoArchTupleValues() {
         arch="${CT_ARCH_ARCH}"
         [ -z "${arch}" ] && arch="${CT_ARCH_TUNE}"
         case "${arch}" in
-            "")                           CT_TARGET_ARCH=i386;;
+            "")
+                CT_DoLog WARN "Architecture level is not specified for 32-bit x86; defaulting to i386."
+                CT_DoLog WARN "This may not be supported by the C library."
+                CT_TARGET_ARCH=i386
+            ;;
             i386|i486|i586|i686)          CT_TARGET_ARCH="${arch}";;
             winchip*)                     CT_TARGET_ARCH=i486;;
             pentium|pentium-mmx|c3*)      CT_TARGET_ARCH=i586;;


### PR DESCRIPTION
as that defaults to i386, which will fail with glibc (and likely other
libcs).

Fixes #617.

Signed-off-by: Alexey Neyman <stilor@att.net>