### PR TITLE
Add a symlink to LTO for binutils

### DIFF
--- a/scripts/build/binutils/binutils.sh
+++ b/scripts/build/binutils/binutils.sh
@@ -208,6 +208,12 @@ do_binutils_backend() {
     CT_DoLog EXTRA "Installing binutils"
     CT_DoExecLog ALL make install
 
+    if [ "${CT_BINUTILS_PLUGINS}" = "y" ]; then
+        # Create a directory for plugins such as LTO (to be installed by
+        # their providers later)
+        CT_DoExecLog ALL mkdir -p "${CT_PREFIX_DIR}/lib/bfd-plugins"
+    fi
+
     if [ "${build_manuals}" = "y" ]; then
         CT_DoLog EXTRA "Building and installing the binutils manuals"
         manuals_for=( gas binutils ld gprof )

--- a/scripts/build/cc/gcc.sh
+++ b/scripts/build/cc/gcc.sh
@@ -713,6 +713,13 @@ do_gcc_core_backend() {
 
     cc_gcc_multilib_housekeeping cc="${prefix}/bin/${CT_TARGET}-${CT_CC}" \
         host="${host}"
+
+    # If binutils want the LTO plugin, point them to it
+    if [ -d "${CT_PREFIX_DIR}/lib/bfd-plugins" -a "${build_step}" = "gcc_host" ]; then
+        local gcc_version=$(cat "${CT_SRC_DIR}/gcc/gcc/BASE-VER" )
+        CT_DoExecLog ALL ln -sfv "../../libexec/gcc/${CT_TARGET}/${gcc_version}/liblto_plugin.so" \
+                "${CT_PREFIX_DIR}/lib/bfd-plugins/liblto_plugin.so"
+    fi
 }
 
 #------------------------------------------------------------------------------
@@ -1186,4 +1193,11 @@ do_gcc_backend() {
 
     cc_gcc_multilib_housekeeping cc="${prefix}/bin/${CT_TARGET}-${CT_CC}" \
         host="${host}"
+
+    # If binutils want the LTO plugin, point them to it
+    if [ -d "${CT_PREFIX_DIR}/lib/bfd-plugins" -a "${build_step}" = "gcc_host" ]; then
+        local gcc_version=$(cat "${CT_SRC_DIR}/gcc/gcc/BASE-VER" )
+        CT_DoExecLog ALL ln -sfv "../../libexec/gcc/${CT_TARGET}/${gcc_version}/liblto_plugin.so" \
+                "${CT_PREFIX_DIR}/lib/bfd-plugins/liblto_plugin.so"
+    fi
 }

--- a/scripts/build/internals.sh
+++ b/scripts/build/internals.sh
@@ -70,20 +70,10 @@ do_finish() {
                              "${CT_TARGET}/debug-root/usr/bin/gdbserver${exe_suffix}"
         fi
         if [ "${CT_CC_GCC}" = "y" ]; then
-            # TBD GCC 3.x/2.x is no longer supported by ctng
             # We can not use the version in CT_GCC_VERSION because
             # of the Linaro stuff. So, harvest the version string
             # directly from the gcc sources...
-            # All gcc 4.x seem to have the version in gcc/BASE-VER
-            # while version prior to 4.x have the version in gcc/version.c
-            # Of course, here is not the better place to do that...
-            if [ -f "${CT_SRC_DIR}/gcc/gcc/BASE-VER" ]; then
-                gcc_version=$( cat "${CT_SRC_DIR}/gcc/gcc/BASE-VER" )
-            else
-                gcc_version=$(sed -r -e '/version_string/!d; s/^.+= "([^"]+)".*$/\1/;' \
-                                   "${CT_SRC_DIR}/gcc/gcc/version.c" \
-                             )
-            fi
+            gcc_version=$( cat "${CT_SRC_DIR}/gcc/gcc/BASE-VER" )
             for _t in "bin/${CT_TARGET}-"*                                      \
                       "${CT_TARGET}/bin/"*                                      \
                       "libexec/gcc/${CT_TARGET}/${gcc_version}/"*               \


### PR DESCRIPTION
... so that ar can find the plugin even when invoked directly, not
via the gcc-ar plugin.

Fixes #1113.

Signed-off-by: Alexey Neyman <stilor@att.net>