### PR TITLE
Store the uClibc .config alongside the ct-ng .config

### DIFF
--- a/scripts/build/libc/uClibc.sh
+++ b/scripts/build/libc/uClibc.sh
@@ -416,4 +416,8 @@ uClibc_post_cc()
     # Moreover, need to do this after the final compiler is built: on targets
     # that use elf2flt, the core compilers cannot find ld when running elf2flt.
     CT_MultilibFixupLDSO
+
+    if [ -n "${CT_LIBC_UCLIBC_CONFIG_FILE}" ]; then
+        CT_InstallConfigurationFile "$CT_LIBC_UCLIBC_CONFIG_FILE" libc
+    fi
 }

--- a/scripts/build/libc/uClibc.sh
+++ b/scripts/build/libc/uClibc.sh
@@ -418,6 +418,6 @@ uClibc_post_cc()
     CT_MultilibFixupLDSO
 
     if [ -n "${CT_LIBC_UCLIBC_CONFIG_FILE}" ]; then
-        CT_InstallConfigurationFile "$CT_LIBC_UCLIBC_CONFIG_FILE" libc
+        CT_InstallConfigurationFile "${CT_LIBC_UCLIBC_CONFIG_FILE}" libc
     fi
 }

--- a/scripts/crosstool-NG.sh
+++ b/scripts/crosstool-NG.sh
@@ -613,15 +613,7 @@ if [ -z "${CT_RESTART}" ]; then
     rm -f "${testc}"
 
     CT_DoLog EXTRA "Installing user-supplied crosstool-NG configuration"
-    CT_DoExecLog ALL mkdir -p "${CT_PREFIX_DIR}/bin"
-    CT_DoExecLog DEBUG ${install} -m 0755 "${CT_LIB_DIR}/scripts/toolchain-config.in" "${CT_PREFIX_DIR}/bin/${CT_TARGET}-ct-ng.config"
-    CT_DoExecLog DEBUG ${sed} -i -e 's,@@grep@@,"'"${grep}"'",;' "${CT_PREFIX_DIR}/bin/${CT_TARGET}-ct-ng.config"
-    if [ -n "$CT_LIBC_UCLIBC_CONFIG_FILE" ]
-    then
-        ${install} -m 0755 "${CT_PREFIX_DIR}/bin/${CT_TARGET}-ct-ng.config" "${CT_PREFIX_DIR}/bin/${CT_TARGET}-libc.config"
-        bzip2 -c -9 "$CT_LIBC_UCLIBC_CONFIG_FILE" >>"${CT_PREFIX_DIR}/bin/${CT_TARGET}-libc.config"
-    fi
-    bzip2 -c -9 .config >>"${CT_PREFIX_DIR}/bin/${CT_TARGET}-ct-ng.config"
+    CT_InstallConfigurationFile .config ct-ng
 
     CT_DoStep EXTRA "Dumping internal crosstool-NG configuration"
     CT_DoLog EXTRA "Building a toolchain for:"

--- a/scripts/crosstool-NG.sh
+++ b/scripts/crosstool-NG.sh
@@ -616,6 +616,11 @@ if [ -z "${CT_RESTART}" ]; then
     CT_DoExecLog ALL mkdir -p "${CT_PREFIX_DIR}/bin"
     CT_DoExecLog DEBUG ${install} -m 0755 "${CT_LIB_DIR}/scripts/toolchain-config.in" "${CT_PREFIX_DIR}/bin/${CT_TARGET}-ct-ng.config"
     CT_DoExecLog DEBUG ${sed} -i -e 's,@@grep@@,"'"${grep}"'",;' "${CT_PREFIX_DIR}/bin/${CT_TARGET}-ct-ng.config"
+    if [ -n "$CT_LIBC_UCLIBC_CONFIG_FILE" ]
+    then
+        ${install} -m 0755 "${CT_PREFIX_DIR}/bin/${CT_TARGET}-ct-ng.config" "${CT_PREFIX_DIR}/bin/${CT_TARGET}-libc.config"
+        bzip2 -c -9 "$CT_LIBC_UCLIBC_CONFIG_FILE" >>"${CT_PREFIX_DIR}/bin/${CT_TARGET}-libc.config"
+    fi
     bzip2 -c -9 .config >>"${CT_PREFIX_DIR}/bin/${CT_TARGET}-ct-ng.config"
 
     CT_DoStep EXTRA "Dumping internal crosstool-NG configuration"

--- a/scripts/functions
+++ b/scripts/functions
@@ -2453,3 +2453,14 @@ CT_InstallCopyingInformation()
 
     shopt -u nullglob
 }
+
+CT_InstallConfigurationFile()
+{
+    local path="${1}"
+    local suffix="${2}"
+
+    CT_DoExecLog ALL mkdir -p "${CT_PREFIX_DIR}/bin"
+    CT_DoExecLog DEBUG ${install} -m 0755 "${CT_LIB_DIR}/scripts/toolchain-config.in" "${CT_PREFIX_DIR}/bin/${CT_TARGET}-$suffix.config"
+    CT_DoExecLog DEBUG ${sed} -i -e 's,@@grep@@,"'"${grep}"'",;' "${CT_PREFIX_DIR}/bin/${CT_TARGET}-$suffix.config"
+    bzip2 -c -9 "$1" >>"${CT_PREFIX_DIR}/bin/${CT_TARGET}-$suffix.config"
+}

--- a/scripts/functions
+++ b/scripts/functions
@@ -2460,7 +2460,7 @@ CT_InstallConfigurationFile()
     local suffix="${2}"
 
     CT_DoExecLog ALL mkdir -p "${CT_PREFIX_DIR}/bin"
-    CT_DoExecLog DEBUG ${install} -m 0755 "${CT_LIB_DIR}/scripts/toolchain-config.in" "${CT_PREFIX_DIR}/bin/${CT_TARGET}-$suffix.config"
-    CT_DoExecLog DEBUG ${sed} -i -e 's,@@grep@@,"'"${grep}"'",;' "${CT_PREFIX_DIR}/bin/${CT_TARGET}-$suffix.config"
-    bzip2 -c -9 "$1" >>"${CT_PREFIX_DIR}/bin/${CT_TARGET}-$suffix.config"
+    CT_DoExecLog DEBUG ${install} -m 0755 "${CT_LIB_DIR}/scripts/toolchain-config.in" "${CT_PREFIX_DIR}/bin/${CT_TARGET}-${suffix}.config"
+    CT_DoExecLog DEBUG ${sed} -i -e 's,@@grep@@,"'"${grep}"'",;' "${CT_PREFIX_DIR}/bin/${CT_TARGET}-${suffix}.config"
+    bzip2 -c -9 "${path}" >>"${CT_PREFIX_DIR}/bin/${CT_TARGET}-${suffix}.config"
 }


### PR DESCRIPTION
This way, a uClibc-based toolchain is reproducible. `.config` has the `ct-ng` version and the `ct-ng` configuration,  but the external uClibc configuration (if supplied) is not part of the build output.