### PR TITLE
Correctly reference to libintl when linking.

### DIFF
--- a/kconfig/Makefile.am
+++ b/kconfig/Makefile.am
@@ -18,15 +18,16 @@ AM_CPPFLAGS		= -include config.h -DCONFIG_=\"CT_\"
 AM_LIBTOOLFLAGS	= --tag CC
 
 conf_SOURCES    = conf.c zconf.c
+conf_LDADD      = $(LIBINTL)
 
 nconf_SOURCES	= nconf.c nconf.gui.c zconf.c
 nconf_CFLAGS	= $(CURSES_CFLAGS)
-nconf_LDADD		= $(MENU_LIBS) $(PANEL_LIBS) $(CURSES_LIBS)
+nconf_LDADD     = $(MENU_LIBS) $(PANEL_LIBS) $(CURSES_LIBS) $(LIBINTL)
 
 mconf_SOURCES	= mconf.c zconf.c lxdialog/checklist.c lxdialog/inputbox.c \
 				  lxdialog/menubox.c lxdialog/textbox.c lxdialog/util.c \
 				  lxdialog/yesno.c
-mconf_LDADD		= $(CURSES_LIBS)
+mconf_LDADD     = $(CURSES_LIBS) $(LIBINTL)
 
 # automake's support for yacc/lex/gperf is too idiosyncratic. It doesn't
 # support a common pattern of including lex-generated file into yacc, nor does


### PR DESCRIPTION
I got this error when compiling crosstool-ng with CYGWIN:

```
/usr/bin/libtool  --tag CC  --mode=link gcc  -g -O2   -o conf.exe conf.o zconf.o

libtool: link: gcc -g -O2 -o .libs/conf.exe conf.o zconf.o
mv -f .deps/nconf-zconf.Tpo .deps/nconf-zconf.Po
depbase=`echo lxdialog/checklist.o | sed 's|[^/]*$|.deps/&|;s|\.o$||'`;\
gcc -DHAVE_CONFIG_H -I. -I../../crosstool-ng/kconfig -I..  -include config.h -DCONFIG_=\"CT_\"   -g -O2 -MT lxdialog/checklist.o -MD -MP -MF $depbase.Tpo -c -o lxdialog/checklist.o ../../crosstool-ng/kconfig/lxdialog/checklist.c &&\
mv -f $depbase.Tpo $depbase.Po
conf.o: In function `conf_askvalue':
/home/carlo/c2/kconfig/../../crosstool-ng/kconfig/conf.c:90: undefined reference to `libintl_gettext'
/home/carlo/c2/kconfig/../../crosstool-ng/kconfig/conf.c:90:(.text+0x148): relocation truncated to fit: R_X86_64_PC32 against undefined symbol `libintl_gettext'
conf.o: In function `conf_sym':
/home/carlo/c2/kconfig/../../crosstool-ng/kconfig/conf.c:173: undefined reference to `libintl_gettext'
/home/carlo/c2/kconfig/../../crosstool-ng/kconfig/conf.c:173:(.text+0x2b9): relocation truncated to fit: R_X86_64_PC32 against undefined symbol `libintl_gettext'
conf.o: In function `conf_string':
/home/carlo/c2/kconfig/../../crosstool-ng/kconfig/conf.c:140: undefined reference to `libintl_gettext'
/home/carlo/c2/kconfig/../../crosstool-ng/kconfig/conf.c:140:(.text+0x5f9): relocation truncated to fit: R_X86_64_PC32 against undefined symbol `libintl_gettext'
conf.o: In function `conf':
/home/carlo/c2/kconfig/../../crosstool-ng/kconfig/conf.c:382: undefined reference to `libintl_gettext'
/home/carlo/c2/kconfig/../../crosstool-ng/kconfig/conf.c:382:(.text+0x76b): relocation truncated to fit: R_X86_64_PC32 against undefined symbol `libintl_gettext'
conf.o: In function `conf_choice':
/home/carlo/c2/kconfig/../../crosstool-ng/kconfig/conf.c:270: undefined reference to `libintl_gettext'
/home/carlo/c2/kconfig/../../crosstool-ng/kconfig/conf.c:270:(.text+0x81a): relocation truncated to fit: R_X86_64_PC32 against undefined symbol `libintl_gettext'
conf.o:/home/carlo/c2/kconfig/../../crosstool-ng/kconfig/conf.c:287: more undefined references to `libintl_gettext' follow
conf.o: In function `conf_choice':
/home/carlo/c2/kconfig/../../crosstool-ng/kconfig/conf.c:287:(.text+0x8bf): relocation truncated to fit: R_X86_64_PC32 against undefined symbol `libintl_gettext'
/home/carlo/c2/kconfig/../../crosstool-ng/kconfig/conf.c:291:(.text+0x8ff): relocation truncated to fit: R_X86_64_PC32 against undefined symbol `libintl_gettext'
/home/carlo/c2/kconfig/../../crosstool-ng/kconfig/conf.c:260:(.text+0x91c): relocation truncated to fit: R_X86_64_PC32 against undefined symbol `libintl_gettext'
/home/carlo/c2/kconfig/../../crosstool-ng/kconfig/conf.c:294:(.text+0x9b1): relocation truncated to fit: R_X86_64_PC32 against undefined symbol `libintl_gettext'
/home/carlo/c2/kconfig/../../crosstool-ng/kconfig/conf.c:278:(.text+0xb7c): relocation truncated to fit: R_X86_64_PC32 against undefined symbol `libintl_gettext'
/home/carlo/c2/kconfig/../../crosstool-ng/kconfig/conf.c:294:(.text+0xbf5): additional relocation overflows omitted from the output
conf.o: In function `main':
/home/carlo/c2/kconfig/../../crosstool-ng/kconfig/conf.c:479: undefined reference to `libintl_setlocale'
/home/carlo/c2/kconfig/../../crosstool-ng/kconfig/conf.c:480: undefined reference to `libintl_bindtextdomain'
/home/carlo/c2/kconfig/../../crosstool-ng/kconfig/conf.c:481: undefined reference to `libintl_textdomain'
/home/carlo/c2/kconfig/../../crosstool-ng/kconfig/conf.c:541: undefined reference to `libintl_gettext'
/home/carlo/c2/kconfig/../../crosstool-ng/kconfig/conf.c:565: undefined reference to `libintl_gettext'
/home/carlo/c2/kconfig/../../crosstool-ng/kconfig/conf.c:684: undefined reference to `libintl_gettext'
/home/carlo/c2/kconfig/../../crosstool-ng/kconfig/conf.c:607: undefined reference to `libintl_gettext'
/home/carlo/c2/kconfig/../../crosstool-ng/kconfig/conf.c:621: undefined reference to `libintl_gettext'
conf.o:/home/carlo/c2/kconfig/../../crosstool-ng/kconfig/conf.c:540: more undefined references to `libintl_gettext' follow
collect2: error: ld returned 1 exit status
make[3]: *** [Makefile:509: conf.exe] Error 1
```
After adding LIBINTL to the LDADD variables, the problem is solved and the tool compiled without troubles.

Sincerely.
