### PR TITLE
expat: Build without docbook

### DIFF
--- a/scripts/build/companion_libs/210-expat.sh
+++ b/scripts/build/companion_libs/210-expat.sh
@@ -99,6 +99,7 @@ do_expat_backend() {
         --host=${host}                                              \
         --prefix="${prefix}"                                        \
         --enable-static                                             \
+        --without-docbook                                           \
         "${extra_config[@]}"
 
     CT_DoLog EXTRA "Building expat"


### PR DESCRIPTION
This fixes following build error on Debian 9:

   configure: error: Your local docbook2man was found to work with SGML rather
      than XML. Please install docbook2X and use variable DOCBOOK_TO_MAN to point
      configure to command docbook2x-man of docbook2X.
      Or use DOCBOOK_TO_MAN="xmlto man --skip-validation" if you have xmlto around.
      You can also configure using --without-docbook if you can do without a man
      page for xmlwf.

Signed-off-by: Bernhard Walle <bernhard@bwalle.de>