### PR TITLE
Don't enable "shared flat"

### DIFF
--- a/config/kernel.in
+++ b/config/kernel.in
@@ -26,6 +26,8 @@ config SHARED_LIBS
     bool
     prompt "Build shared libraries"
     depends on KERNEL_SUPPORTS_SHARED_LIBS
+    # Building "shared flat" currently fails
+    depends on ARCH_USE_MMU || EXPERIMENTAL
     default y
     help
       Say 'y' here, unless you don't want shared libraries.


### PR DESCRIPTION
... unless experimental. This unbreaks m68k-uclinux-uclibc sample which
after the recent change in uClibc.sh attempted to build a shared flat
library and failed. We were not building shared flat libraries before.

Signed-off-by: Alexey Neyman <stilor@att.net>