### PR TITLE
Seems like ArchLinux renamed its base on dockerhub

### DIFF
--- a/testing/docker/archlinux/Dockerfile
+++ b/testing/docker/archlinux/Dockerfile
@@ -1,8 +1,7 @@
-FROM base/archlinux:latest
+FROM archlinux/base:latest
 ARG CTNG_UID
 ARG CTNG_GID
-RUN pacman -Sy archlinux-keyring
-RUN pacman -Su
+RUN pacman -Sy --noconfirm archlinux-keyring
 RUN pacman -Syu --noconfirm
 RUN pacman -S --noconfirm base-devel git help2man python unzip wget audit
 RUN groupadd -g $CTNG_GID ctng


### PR DESCRIPTION
... awhile ago; I had it cached on one machine.

Signed-off-by: Alexey Neyman <stilor@att.net>