### PR TITLE
overlay: treat overlay as a package

### DIFF
--- a/config/arch/xtensa.in
+++ b/config/arch/xtensa.in
@@ -35,3 +35,7 @@ config ARCH_xtensa_fsf
     bool "fsf - Default configuration"
 
 endchoice
+
+if XTENSA_CUSTOM
+source "config/overlay.in"
+endif

--- a/config/overlay.in
+++ b/config/overlay.in
@@ -1,0 +1,68 @@
+# The component directory name
+config OVERLAY_DIR_NAME
+    string
+    default "overlay"
+
+config OVERLAY_PKG_NAME
+    string
+    default "overlay"
+
+choice
+    bool "Source of overlay"
+
+config OVERLAY_SRC_RELEASE
+    bool "Tarball"
+    help
+      Download an overlay tarball.
+
+if OVERLAY_SRC_RELEASE
+
+config OVERLAY_SRC_URL
+    string "Overlay archive URL"
+    help
+      Overlay archive URL.
+
+endif
+
+config OVERLAY_SRC_CUSTOM
+    bool "Custom location"
+    help
+      Custom overlay directory or tarball.
+
+if OVERLAY_SRC_CUSTOM
+
+config OVERLAY_CUSTOM_LOCATION
+    string "Overlay location"
+    help
+      Path to the directory or tarball with overlay components.
+
+endif
+
+endchoice
+
+config OVERLAY_MIRRORS
+    string
+    default "$(dirname ${CT_OVERLAY_SRC_URL})" if OVERLAY_SRC_RELEASE
+
+config OVERLAY_VERSION
+    string "Overlay version"
+    help
+      Overlay configuration name. There may be multiple overlay releases
+      for the same hardware. Releases with the same version in this
+      configuration entry are considered the same.
+
+config OVERLAY_ARCHIVE_FILENAME
+    string
+    default "xtensa_@{version}"
+
+config OVERLAY_ARCHIVE_DIRNAME
+    string
+    default "xtensa_@{version}"
+
+config OVERLAY_ARCHIVE_FORMATS
+    string
+    default ".tar .tar.gz"
+
+config OVERLAY_SIGNATURE_FORMAT
+    string
+    default "packed/.sig"

--- a/config/target.in
+++ b/config/target.in
@@ -458,27 +458,4 @@ config ARCH_FLOAT
 config TARGET_USE_OVERLAY
     bool
 
-if TARGET_USE_OVERLAY
-
-config OVERLAY_NAME
-    string "Custom processor configuration name"
-    help
-      Enter the name of the custom processor configuration.
-      Overlay file for that configuration must be called
-      '<ARCH>_<OVERLAY_NAME>.tar' (optionally, with .gz/.bz2/.lzma/.xz
-      extension).
-
-      Leave blank to use the default '<ARCH>_overlay.tar'.
-      For more information about this option, please also consult the
-      section 'Using crosstool-NG to build Xtensa toolchains' in the
-      in http://crosstool-ng.github.io/docs/caveats-features/
-
-config OVERLAY_LOCATION
-    string "Full path to custom configuration (overlay)"
-    help
-      Enter the path to the directory for the custom processor
-      configuration file.
-
-endif
-
 endmenu

--- a/scripts/build/overlay.sh
+++ b/scripts/build/overlay.sh
@@ -1,0 +1,7 @@
+# This file adds functions to get xtensa overlay
+# Licensed under the GPL v2. See COPYING in the root of this package
+
+# Download overlay
+do_overlay_get() {
+    CT_Fetch OVERLAY
+}

--- a/scripts/crosstool-NG.sh
+++ b/scripts/crosstool-NG.sh
@@ -644,6 +644,7 @@ if [ -z "${CT_RESTART}" ]; then
     do_companion_tools_get
     do_kernel_get
     do_companion_libs_get
+    do_overlay_get
     do_binutils_get
     do_cc_get
     do_libc_get

--- a/scripts/functions
+++ b/scripts/functions
@@ -27,6 +27,7 @@ CT_LoadConfig() {
     . "${CT_LIB_DIR}/scripts/build/cc/${CT_CC}.sh"
     . "${CT_LIB_DIR}/scripts/build/debug.sh"
     . "${CT_LIB_DIR}/scripts/build/test_suite.sh"
+    . "${CT_LIB_DIR}/scripts/build/overlay.sh"
 
     # Target tuple: CT_TARGET needs a little love:
     CT_DoBuildTargetTuple
@@ -2223,14 +2224,17 @@ CT_DoExtractPatch()
     # this component.
     if [ "${CT_TARGET_USE_OVERLAY}" = "y" -a ! -d "${CT_BUILD_DIR}/overlay" ]; then
         CT_DoExecLog ALL mkdir -p "${CT_BUILD_DIR}/overlay"
-        overlay="${CT_OVERLAY_LOCATION}/${CT_ARCH}_${CT_OVERLAY_NAME:-overlay}"
+        if [ "${CT_OVERLAY_SRC_RELEASE}" = "y" ]; then
+            overlay="${CT_TARBALLS_DIR}/"$(basename "${CT_OVERLAY_SRC_URL}")
+        elif [ "${CT_OVERLAY_SRC_CUSTOM}" = "y" ]; then
+            overlay="${CT_OVERLAY_CUSTOM_LOCATION}"
+        fi
         if [ -d "${overlay}" ]; then
             CT_DoExecLog ALL cp -av "${overlay}/." "${CT_BUILD_DIR}/overlay"
+        elif [ -f "${overlay}" ]; then
+            CT_Extract "${overlay}" "${CT_BUILD_DIR}/overlay"
         else
-            if ! ext=`CT_GetFileExtension "${overlay}"`; then
-                CT_Abort "Overlay ${overlay} not found"
-            fi
-            CT_Extract "${overlay}${ext}" "${CT_BUILD_DIR}/overlay"
+            CT_Abort "Overlay ${overlay} not found"
         fi
     fi
 


### PR DESCRIPTION
Hello,

This change allows downloading overlay archive from an URL or getting it from a custom location.
With this change it is possible to make self-contained ct-ng configurations for xtensa toolchains for any xtensa CPU.
Please consider merging it.