### PR TITLE
samples: G+ is gone, update reporter_url

### DIFF
--- a/samples/arm-cortexa5-linux-uclibcgnueabihf/reported.by
+++ b/samples/arm-cortexa5-linux-uclibcgnueabihf/reported.by
@@ -1,3 +1,3 @@
 reporter_name="Alexandre Belloni"
-reporter_url="https://plus.google.com/+AlexandreBelloni"
+reporter_url="https://bootlin.com"
 reporter_comment="Cortex-A5 using the hard-float GNU EABI (VFPV4-D16 without NEON)."

--- a/samples/arm-unknown-linux-uclibcgnueabi/reported.by
+++ b/samples/arm-unknown-linux-uclibcgnueabi/reported.by
@@ -1,3 +1,3 @@
 reporter_name="Thomas Petazzoni"
-reporter_url="https://plus.google.com/+ThomasPetazzoni"
+reporter_url="https://bootlin.com"
 reporter_comment=""


### PR DESCRIPTION
G+ is now defunct, update the reporter_url to bootlin as both Thomas and I
are working there.

Signed-off-by: Alexandre Belloni <alexandre.belloni@bootlin.com>