### PR TITLE
uClibc: fix selection of debug level

### DIFF
--- a/config/libc/uClibc.in
+++ b/config/libc/uClibc.in
@@ -107,6 +107,7 @@ config LIBC_UCLIBC_DEBUG_LEVEL
     default 0 if LIBC_UCLIBC_DEBUG_LEVEL_0
     default 1 if LIBC_UCLIBC_DEBUG_LEVEL_1
     default 2 if LIBC_UCLIBC_DEBUG_LEVEL_2
+    default 3 if LIBC_UCLIBC_DEBUG_LEVEL_3
 
 config LIBC_UCLIBC_CONFIG_FILE
     string


### PR DESCRIPTION
Currently if we select uclibc debug level "all" then uclibc will be compiled without debug at all.
This bug was added in commit 2aee11cc when new level of uclibc debugging ("normal") was introduced.