### PR TITLE
Last fixes for 1.24

### DIFF
--- a/config/arch/riscv.in
+++ b/config/arch/riscv.in
@@ -13,6 +13,7 @@
 ## select GCC_REQUIRE_7_or_later
 ## select BINUTILS_REQUIRE_2_28_or_later
 ## select GDB_REQUIRE_8_0_or_later if DEBUG_GDB
+## select GLIBC_REQUIRE_2_29_or_later if LIBC_GLIBC
 
 ## help The RISC-V architecture, as defined by:
 ## help     http://www.riscv.org/

--- a/testing/docker/ubuntu16.04/Dockerfile
+++ b/testing/docker/ubuntu16.04/Dockerfile
@@ -5,7 +5,7 @@ RUN groupadd -g $CTNG_GID ctng
 RUN useradd -d /home/ctng -m -g $CTNG_GID -u $CTNG_UID -s /bin/bash ctng
 RUN apt-get update
 RUN apt-get install -y gcc g++ gperf bison flex texinfo help2man make libncurses5-dev \
-    python-dev autoconf automake libtool libtool-bin gawk wget bzip2 xz-utils unzip \
+    python3-dev autoconf automake libtool libtool-bin gawk wget bzip2 xz-utils unzip \
     patch libstdc++6
 RUN wget -O /sbin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.1/dumb-init_1.2.1_amd64
 RUN chmod a+x /sbin/dumb-init

--- a/testing/docker/ubuntu18.04/Dockerfile
+++ b/testing/docker/ubuntu18.04/Dockerfile
@@ -5,7 +5,7 @@ RUN groupadd -g $CTNG_GID ctng
 RUN useradd -d /home/ctng -m -g $CTNG_GID -u $CTNG_UID -s /bin/bash ctng
 RUN apt-get update
 RUN apt-get install -y gcc g++ gperf bison flex texinfo help2man make libncurses5-dev \
-    python-dev autoconf automake libtool libtool-bin gawk wget bzip2 xz-utils unzip \
+    python3-dev autoconf automake libtool libtool-bin gawk wget bzip2 xz-utils unzip \
     patch libstdc++6
 RUN wget -O /sbin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.1/dumb-init_1.2.1_amd64
 RUN chmod a+x /sbin/dumb-init

--- a/testing/docker/ubuntu18.10/Dockerfile
+++ b/testing/docker/ubuntu18.10/Dockerfile
@@ -5,7 +5,7 @@ RUN groupadd -g $CTNG_GID ctng
 RUN useradd -d /home/ctng -m -g $CTNG_GID -u $CTNG_UID -s /bin/bash ctng
 RUN apt-get update
 RUN apt-get install -y gcc g++ gperf bison flex texinfo help2man make libncurses5-dev \
-    python-dev autoconf automake libtool libtool-bin gawk wget bzip2 xz-utils unzip \
+    python3-dev autoconf automake libtool libtool-bin gawk wget bzip2 xz-utils unzip \
     patch libstdc++6
 RUN wget -O /sbin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.1/dumb-init_1.2.1_amd64
 RUN chmod a+x /sbin/dumb-init


### PR DESCRIPTION
Retesting Ubuntu18.10 for build-all, and - if no other regressions - releasing.