### PR TITLE
Allow GNU gettext v0.19.7, which is in Ubuntu 16.04 LTS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -287,7 +287,7 @@ AC_FUNC_REALLOC
 AC_FUNC_ALLOCA
 
 AM_GNU_GETTEXT([external])
-AM_GNU_GETTEXT_VERSION([0.19.8])
+AM_GNU_GETTEXT_VERSION([0.19.7])
 
 # For now, curses are needed to build kconfig. We may support a command-line
 # only configuration without curses later. For now, fail in configure but


### PR DESCRIPTION
Signed-off-by: Joachim Nilsson <troglobit@gmail.com>