### PR TITLE
Removed http://www.mr511.de/software mirror from libelf package description

### DIFF
--- a/packages/libelf/package.desc
+++ b/packages/libelf/package.desc
@@ -1,5 +1,5 @@
 # FIXME No public repository and no new releases.
 # Consider switching to/adding project elftoolchain?
-mirrors='http://www.mr511.de/software https://fossies.org/linux/misc/old'
+mirrors='https://fossies.org/linux/misc/old'
 relevantpattern='*.*|.'
 archive_formats='.tar.gz'


### PR DESCRIPTION
, as it no longer hosts the source file

Resolves #1199

Signed-off-by: Bart Verhagen <barrie.verhagen@gmail.com>