### PR TITLE
Fix native gdb aarch64 musl build

### DIFF
--- a/packages/gdb/8.2.1/0005-musl-aarch64-sigcontext.patch
+++ b/packages/gdb/8.2.1/0005-musl-aarch64-sigcontext.patch
@@ -1,0 +1,17 @@
+---
+ gdb/nat/aarch64-sve-linux-ptrace.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gdb/nat/aarch64-sve-linux-ptrace.h b/gdb/nat/aarch64-sve-linux-ptrace.h
+index 029e753ffe..172ae39432 100644
+--- a/gdb/nat/aarch64-sve-linux-ptrace.h
++++ b/gdb/nat/aarch64-sve-linux-ptrace.h
+@@ -20,7 +20,7 @@
+ #ifndef AARCH64_SVE_LINUX_PTRACE_H
+ #define AARCH64_SVE_LINUX_PTRACE_H
+
+-#include <asm/sigcontext.h>
++#include <signal.h>
+ #include <sys/utsname.h>
+ #include <sys/ptrace.h>
+ #include <asm/ptrace.h>


### PR DESCRIPTION
Apply the patch from https://patchwork.openembedded.org/patch/161442/, which explains why gdb should include <signal.h> instead of <asm/sigcontext.h>.