### PR TITLE
zlib: Provide other mirror

### DIFF
--- a/packages/zlib/package.desc
+++ b/packages/zlib/package.desc
@@ -1,4 +1,4 @@
 repository='git https://github.com/madler/zlib.git'
-mirrors='http://downloads.sourceforge.net/project/libpng/zlib/${CT_ZLIB_VERSION}'
+mirrors='http://downloads.sourceforge.net/project/libpng/zlib/${CT_ZLIB_VERSION} https://www.zlib.net/'
 archive_formats='.tar.xz .tar.gz'
 signature_format='packed/.asc'


### PR DESCRIPTION
Currently, SourceForge is down and downloads give a 500 error. That's
not overly uncommon (even less often the case these days). Fortunately,
zlib provides another mirror on their homepage, add that as option to
the package description. (https://www.zlib.net/)