### PR TITLE
Expat: Provide a non-sourceforge download link

### DIFF
--- a/packages/expat/package.desc
+++ b/packages/expat/package.desc
@@ -1,6 +1,6 @@
 repository='git https://github.com/libexpat/libexpat.git'
 repository_subdir='expat'
 bootstrap='./buildconf.sh && make -C doc all'
-mirrors='http://downloads.sourceforge.net/project/expat/expat/${CT_EXPAT_VERSION}'
+mirrors='http://downloads.sourceforge.net/project/expat/expat/${CT_EXPAT_VERSION} https://github.com/libexpat/libexpat/releases/download/R_${CT_EXPAT_VERSION//./_}'
 archive_formats='.tar.bz2'
 relevantpattern='*.*|.'


### PR DESCRIPTION
The same binaries are now hosted on GitHub releases (and looking at the
homepage, that's the only download location they are offering). Use that
mirror at least as an option.