### PR TITLE
libc: glibc 2.28 needs make 4.0

### DIFF
--- a/config/libc/glibc.in
+++ b/config/libc/glibc.in
@@ -57,7 +57,7 @@ config GLIBC_DEP_PYTHON
 
 config GLIBC_DEP_MAKE_4_0
     def_bool y
-    depends on GLIBC_2_29_or_later && !CONFIGURE_has_make_4_0_or_newer
+    depends on GLIBC_2_28_or_later && !CONFIGURE_has_make_4_0_or_newer
     select COMP_TOOLS_MAKE
     select MAKE_REQUIRE_4_0_or_later
     select MAKE_GNUMAKE_SYMLINK # Override old host make in .build/tools/bin


### PR DESCRIPTION
Fixes: #1210

Per the release notes for the GNU C library 2.28[1] make 4.0 or newer is
required. Previously the logic was applied to glibc 2.29 or newer.

[1] - https://www.sourceware.org/ml/libc-alpha/2018-08/msg00003.html

Signed-off-by: Chris Packham <judge.packham@gmail.com>