### PR TITLE
glibc: arc: Don't interfere with other architectures

### DIFF
--- a/packages/glibc/2.29/0001-Add-ARC-architecture.patch
+++ b/packages/glibc/2.29/0001-Add-ARC-architecture.patch
@@ -2290,16 +2290,16 @@ index 00000000000..1152a179c4a
 +arc*)
 +	base_machine=arc
 +	machine=arc
++
++	gccfloat=`$CC $CFLAGS $CPPFLAGS -E -dM -xc /dev/null | grep __ARC_FPU_| wc -l`
++	if test "$gccfloat" != "0"; then
++		echo "glibc being configured for double precision floating point"
++		with_fp_cond=1
++	else
++		with_fp_cond=0
++	fi
 +	;;
 +esac
-+
-+gccfloat=`$CC $CFLAGS $CPPFLAGS -E -dM -xc /dev/null | grep __ARC_FPU_| wc -l`
-+if test "$gccfloat" != "0"; then
-+	echo "glibc being configured for double precision floating point"
-+	with_fp_cond=1
-+else
-+	with_fp_cond=0
-+fi
 diff --git a/sysdeps/arc/setjmp.S b/sysdeps/arc/setjmp.S
 new file mode 100644
 index 00000000000..518545a99e8


### PR DESCRIPTION
Fixes: #1227

Adjust the ARC patch so that it only sets with_fp_cond when the machine
is arc.

https://github.com/foss-for-synopsys-dwc-arc-processors/glibc/issues/7

Signed-off-by: Chris Packham <judge.packham@gmail.com>