### PR TITLE
build/internals.sh: Handle pie executables

### DIFF
--- a/scripts/build/internals.sh
+++ b/scripts/build/internals.sh
@@ -83,7 +83,7 @@ do_finish() {
                 case "${_type}" in
                     *script*executable*)
                         ;;
-                    *executable*)
+                    *executable*|*shared*object*)
                         CT_DoExecLog ALL ${CT_HOST}-strip ${strip_args} "${_t}"
                         ;;
                 esac


### PR DESCRIPTION
Fixes: #887

On some systems the file command identifies a pie executable as a shared
object. Update do_finish() to handle this case so that they are stripped
as well.

Signed-off-by: Chris Packham <judge.packham@gmail.com>