### PR TITLE
fix toolchain build with linker plugins

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -801,7 +801,7 @@ msg "*** Gathering the list of data files to install"
             scripts/compile | scripts/missing | scripts/depcomp | scripts/ltmain.sh | scripts/install-sh)
                 continue
                 ;;
-            # 
+            #
             # will produce. FIXME: create this file at the time of 'ct-ng build'.
             config/configure.in.in | config/configure.in)
                 continue
@@ -818,6 +818,6 @@ msg "*** Gathering the list of data files to install"
 } > verbatim-data.mk
 
 msg "*** Running autoreconf"
-autoreconf -Wall --force
+autoreconf -Wall --force -I m4
 
 msg "*** Done!"

--- a/config/binutils/binutils.in
+++ b/config/binutils/binutils.in
@@ -156,6 +156,14 @@ config BINUTILS_RELRO
       Setting this option to 'M' configures binutils with their internal
       default for the selected architecture.
 
+config BINUTILS_DETERMINISTIC_ARCHIVES
+    bool
+    prompt "ar and ranlib default to -D behavior" if BINUTILS_2_23_or_later
+    help
+      Setting this option will enable deterministic mode by default.
+      When adding files and the archive index use zero for UIDs, GIDs,
+      timestamps, and use consistent file modes for all files.
+
 config BINUTILS_EXTRA_CONFIG_ARRAY
     string
     prompt "binutils extra config"
@@ -206,7 +214,7 @@ config ELF2FLT_EXTRA_CONFIG_ARRAY
     default ""
     help
       Extra flags passed onto ./configure when configuring
-      
+
       You can enter multiple arguments here, and arguments can contain spaces
       if they are properly quoted (or escaped, but prefer quotes). Eg.:
           --with-foo="1st arg with 4 spaces" --with-bar=2nd-arg-without-space

--- a/scripts/build/binutils/binutils.sh
+++ b/scripts/build/binutils/binutils.sh
@@ -153,7 +153,7 @@ do_binutils_backend() {
     if [ "${CT_BINUTILS_PLUGINS}" = "y" ]; then
         extra_config+=( --enable-plugins )
     fi
-    if [ "${CT_BINUTILES_RELRO}" = "y" ]; then
+    if [ "${CT_BINUTILS_RELRO}" = "y" ]; then
         extra_config+=( --enable-relro )
     elif [ "${CT_BINUTILS_RELRO}" != "m" ]; then
         extra_config+=( --disable-relro )

--- a/scripts/build/binutils/binutils.sh
+++ b/scripts/build/binutils/binutils.sh
@@ -158,6 +158,9 @@ do_binutils_backend() {
     elif [ "${CT_BINUTILS_RELRO}" != "m" ]; then
         extra_config+=( --disable-relro )
     fi
+    if [ "${CT_BINUTILS_DETERMINISTIC_ARCHIVES}" = "y" ]; then
+        extra_config+=( --enable-deterministic-archives )
+    fi
     if [ "${CT_BINUTILS_HAS_PKGVERSION_BUGURL}" = "y" ]; then
         [ -n "${CT_PKGVERSION}" ] && extra_config+=("--with-pkgversion=${CT_PKGVERSION}")
         [ -n "${CT_TOOLCHAIN_BUGURL}" ] && extra_config+=("--with-bugurl=${CT_TOOLCHAIN_BUGURL}")

--- a/scripts/build/cc/gcc.sh
+++ b/scripts/build/cc/gcc.sh
@@ -403,8 +403,8 @@ do_gcc_core_backend() {
         # the libstdc++ is not pulled automatically, although it
         # is needed. Shoe-horn it in our LDFLAGS
         # Ditto libm on some Fedora boxen
-        core_LDFLAGS+=("-lstdc++")
-        core_LDFLAGS+=("-lm")
+        # core_LDFLAGS+=("-lstdc++")
+        # core_LDFLAGS+=("-lm")
     else
         if [ "${CT_CC_GCC_STATIC_LIBSTDCXX}" = "y" ]; then
             # this is from CodeSourcery arm-2010q1-202-arm-none-linux-gnueabi.src.tar.bz2
@@ -419,8 +419,8 @@ do_gcc_core_backend() {
         # the libstdc++ is not pulled automatically, although it
         # is needed. Shoe-horn it in our LDFLAGS
         # Ditto libm on some Fedora boxen
-        core_LDFLAGS+=("-lstdc++")
-        core_LDFLAGS+=("-lm")
+        # core_LDFLAGS+=("-lstdc++")
+        # core_LDFLAGS+=("-lm")
     fi
 
     extra_config+=("--with-gmp=${complibs}")
@@ -988,8 +988,8 @@ do_gcc_backend() {
         # the libstdc++ is not pulled automatically, although it
         # is needed. Shoe-horn it in our LDFLAGS
         # Ditto libm on some Fedora boxen
-        final_LDFLAGS+=("-lstdc++")
-        final_LDFLAGS+=("-lm")
+        # final_LDFLAGS+=("-lstdc++")
+        # final_LDFLAGS+=("-lm")
     else
         if [ "${CT_CC_GCC_STATIC_LIBSTDCXX}" = "y" ]; then
             # this is from CodeSourcery arm-2010q1-202-arm-none-linux-gnueabi.src.tar.bz2
@@ -1004,8 +1004,8 @@ do_gcc_backend() {
         # the libstdc++ is not pulled automatically, although it
         # is needed. Shoe-horn it in our LDFLAGS
         # Ditto libm on some Fedora boxen
-        final_LDFLAGS+=("-lstdc++")
-        final_LDFLAGS+=("-lm")
+        # final_LDFLAGS+=("-lstdc++")
+        # final_LDFLAGS+=("-lm")
     fi
 
     extra_config+=("--with-gmp=${complibs}")

--- a/scripts/crosstool-NG.sh
+++ b/scripts/crosstool-NG.sh
@@ -438,7 +438,7 @@ if [ -z "${CT_RESTART}" ]; then
             t="${!r}-"
         fi
 
-        for tool in ar as dlltool gcc g++ gcj gnatbind gnatmake ld nm objcopy objdump ranlib strip windres; do
+        for tool in ar as dlltool gcc gcc-ar gcc-nm gcc-ranlib g++ gcj gnatbind gnatmake ld nm objcopy objdump ranlib strip windres; do
             # First try with prefix + suffix
             # Then try with prefix only
             # Then try with suffix only, but only for BUILD, and HOST iff REAL_BUILD == REAL_HOST
@@ -489,6 +489,16 @@ if [ -z "${CT_RESTART}" ]; then
                         CT_DoLog DEBUG "  Missing: '${t}${tool}${!s}' or '${t}${tool}' or '${tool}' : not required."
                         ;;
                 esac
+            fi
+        done
+
+        # Incase the toolchain is built using plugins (-flto),
+        # the gcc wrappers are needed for older binutils
+        for tool in ar nm ranlib; do
+            if [ -x "${CT_BUILDTOOLS_PREFIX_DIR}/bin/${!v}-gcc-${tool}" ]; then
+                CT_DoLog DEBUG "  '${!v}-${tool}' -> '${!v}-gcc-${tool}'"
+                # this already is a script, so just copy over
+                CT_DoExecLog ALL cp "${CT_BUILDTOOLS_PREFIX_DIR}/bin/${!v}-gcc-${tool}" "${CT_BUILDTOOLS_PREFIX_DIR}/bin/${!v}-${tool}"
             fi
         done
     done


### PR DESCRIPTION
older binutils dont automatically pick up plugins,
but need to manually use wrappers like gcc-ar.

This fix allows to compile the host toolchain with -ftlo
on debian stretch, which would not work before.

These flags were used:
```
CT_EXTRA_CFLAGS_FOR_HOST="-flto"
CT_EXTRA_LDFLAGS_FOR_HOST="-flto -no-pie"
```