### PR TITLE
enable option for binutils deterministic-archives

### DIFF
--- a/config/binutils/binutils.in
+++ b/config/binutils/binutils.in
@@ -156,6 +156,15 @@ config BINUTILS_RELRO
       Setting this option to 'M' configures binutils with their internal
       default for the selected architecture.
 
+config BINUTILS_DETERMINISTIC_ARCHIVES
+    bool
+    prompt "Enable deterministic archives by default" if BINUTILS_2_23_or_later
+    default y if BINUTILS_2_23_or_later
+    help
+      Setting this option will enable deterministic mode by default (-D).
+      ar and ranlib will use zero for UIDs, GIDs,
+      timestamps, and use consistent file modes for all files.
+
 config BINUTILS_EXTRA_CONFIG_ARRAY
     string
     prompt "binutils extra config"
@@ -206,7 +215,7 @@ config ELF2FLT_EXTRA_CONFIG_ARRAY
     default ""
     help
       Extra flags passed onto ./configure when configuring
-      
+
       You can enter multiple arguments here, and arguments can contain spaces
       if they are properly quoted (or escaped, but prefer quotes). Eg.:
           --with-foo="1st arg with 4 spaces" --with-bar=2nd-arg-without-space

--- a/scripts/build/binutils/binutils.sh
+++ b/scripts/build/binutils/binutils.sh
@@ -158,6 +158,9 @@ do_binutils_backend() {
     elif [ "${CT_BINUTILS_RELRO}" != "m" ]; then
         extra_config+=( --disable-relro )
     fi
+    if [ "${CT_BINUTILS_DETERMINISTIC_ARCHIVES}" = "y" ]; then
+        extra_config+=( --enable-deterministic-archives )
+    fi
     if [ "${CT_BINUTILS_HAS_PKGVERSION_BUGURL}" = "y" ]; then
         [ -n "${CT_PKGVERSION}" ] && extra_config+=("--with-pkgversion=${CT_PKGVERSION}")
         [ -n "${CT_TOOLCHAIN_BUGURL}" ] && extra_config+=("--with-bugurl=${CT_TOOLCHAIN_BUGURL}")


### PR DESCRIPTION
This adds an option to configure bintuils with `--enable-deterministic-archives`.
The default is set to enabled as there schould be hardly anyone depending on the noise in static libraries, most people either 

- do not know that ar archives contain stuff like timestamps, uids
- do know because it messes up their [Reproducible builds](https://reproducible-builds.org/)
- do know and could not care less