### PR TITLE
Add option to build binary toolchain tarball

### DIFF
--- a/config/global/paths.in
+++ b/config/global/paths.in
@@ -137,3 +137,31 @@ config STRIP_TARGET_TOOLCHAIN_EXECUTABLES
       An install-strip make target is provided that installs stripped
       executables, and may install libraries with unneeded or debugging
       sections stripped. 
+
+config TARBALL_RESULT
+    bool
+    depends on EXPERIMENTAL
+    prompt "Create binary toolchain tarball"
+    default n
+    help
+      Create tarball of the final binary toolchain.
+
+if TARBALL_RESULT
+
+config TARBALL_RESULT_DIR
+    string
+    depends on TARBALL_RESULT
+    prompt "Output directory"
+    default "${CT_TOP_DIR}"
+    help
+      Directory where tarball will be created.
+
+config TARBALL_RESULT_FILENAME
+    string
+    depends on TARBALL_RESULT
+    prompt "Output filename"
+    default "toolchain-${CT_TOOLCHAIN_PKGVERSION}-${CT_HOST:+HOST-${CT_HOST}-}${CT_TARGET}"
+    help
+      Filename for toolchain tarball, without extension.
+
+endif

--- a/config/global/paths.in
+++ b/config/global/paths.in
@@ -160,7 +160,7 @@ config TARBALL_RESULT_FILENAME
     string
     depends on TARBALL_RESULT
     prompt "Output filename"
-    default "toolchain-${CT_TOOLCHAIN_PKGVERSION}-${CT_HOST:+HOST-${CT_HOST}-}${CT_TARGET}"
+    default "toolchain${CT_TOOLCHAIN_PKGVERSION:+-${CT_TOOLCHAIN_PKGVERSION}}-${CT_HOST:+HOST-${CT_HOST}-}${CT_TARGET}"
     help
       Filename for toolchain tarball, without extension.
 

--- a/scripts/build/internals.sh
+++ b/scripts/build/internals.sh
@@ -31,6 +31,7 @@ do_finish() {
     local strip_args
     local gcc_version
     local exe_suffix
+    local tarball
 
     CT_DoStep INFO "Finalizing the toolchain's directory"
 
@@ -136,6 +137,17 @@ do_finish() {
 
     if [ "${CT_INSTALL_LICENSES}" = y ]; then
         CT_InstallCopyingInformation
+    fi
+
+    if [ "${CT_TARBALL_RESULT}" = y ]; then
+        tarball="${CT_TARBALL_RESULT_DIR}/${CT_TARBALL_RESULT_FILENAME}.tar.xz"
+        CT_DoLog EXTRA "Creating binary toolchain tarball: ${tarball}"
+        cp "${CT_TOP_DIR}/.config" "${CT_PREFIX_DIR}/${CT_TOOLCHAIN_PKGVERSION}.config"
+        tar -C "${CT_PREFIX_DIR}" -Jcf "${tarball}" \
+            --sort=name --numeric-owner --owner=0 --group=0 \
+            --transform "s,^\./\.,${CT_TARBALL_RESULT_FILENAME},S" ./.
+        CT_DoLog EXTRA "Calculating binary toolchain checksum"
+        sha256sum "${tarball}" > "${tarball}.asc"
     fi
 
     CT_EndStep

--- a/scripts/build/internals.sh
+++ b/scripts/build/internals.sh
@@ -143,9 +143,10 @@ do_finish() {
         tarball="${CT_TARBALL_RESULT_DIR}/${CT_TARBALL_RESULT_FILENAME}.tar.xz"
         CT_DoLog EXTRA "Creating binary toolchain tarball: ${tarball}"
         cp "${CT_TOP_DIR}/.config" "${CT_PREFIX_DIR}/${CT_TOOLCHAIN_PKGVERSION}.config"
-        tar -C "${CT_PREFIX_DIR}" -Jcf "${tarball}" \
-            --sort=name --numeric-owner --owner=0 --group=0 \
-            --transform "s,^\./\.,${CT_TARBALL_RESULT_FILENAME},S" ./.
+        find "${CT_PREFIX_DIR}" -print0 | LC_ALL=C sort -z \
+            | tar --numeric-owner --owner=0 --group=0 \
+                  --transform "s,^\./\.,${CT_TARBALL_RESULT_FILENAME},S" \
+                  --no-recursion --null -T - -Jcf "${tarball}"
         CT_DoLog EXTRA "Calculating binary toolchain checksum"
         sha256sum "${tarball}" > "${tarball}.asc"
     fi


### PR DESCRIPTION
Adds an option to tarball the final built toolchain. The output directory and tar filename are configurable. The compression type is xz - this is not configurable but it should not be too difficult to implement.

The produced tar has a top level directory that matches the filename. This is done using the tar `--transform` option rather than copying to a new directory. There are pros and cons to this method: it is faster and uses less disk space, but the nature of regex makes it somewhat difficult to understand.

The ct-ng configuration is copied in to the prefix before archiving.

The file ownership inside the tar is reset. It was also suggested to use ustar format and reset the file mtimes; the former did not work for me and I don't see any reason to do the latter.

The tar file is also checksummed using sha256. Again, this is not configurable, but it could be.

The feature is marked as experimental.