### PR TITLE
prevent the glibc build from overwriting flags

### DIFF
--- a/scripts/build/libc/glibc.sh
+++ b/scripts/build/libc/glibc.sh
@@ -199,7 +199,7 @@ glibc_backend_once()
     printf "%s\n" "${CT_GLIBC_CONFIGPARMS}" > configparms
 
     # glibc can't be built without -O2 (reference needed!)
-    glibc_cflags+=" -O2"
+    glibc_cflags+=" -g -O2"
 
     case "${CT_GLIBC_ENABLE_FORTIFIED_BUILD}" in
         y)  ;;
@@ -260,9 +260,12 @@ glibc_backend_once()
 
     # CFLAGS are only applied when compiling .c files. .S files are compiled with ASFLAGS,
     # but they are not passed by configure. Thus, pass everything in CC instead.
+    # The CFLAGS variable needs to be cleared, else the default "-g -O2"
+    # would override previous flags.
     CT_DoExecLog CFG                                                \
     BUILD_CC=${CT_BUILD}-gcc                                        \
     CC="${CT_TARGET}-${CT_CC} ${glibc_cflags}"                      \
+    CFLAGS=""                                                       \
     AR=${CT_TARGET}-ar                                              \
     RANLIB=${CT_TARGET}-ranlib                                      \
     "${CONFIG_SHELL}"                                               \


### PR DESCRIPTION
The glibc will append the content of the CFLAGS variable,
overriding previous flags.
If unset, the CFLAGS variable is not empty, so explicitly set it.
Instead prepend the default CFLAGS flags.