### PR TITLE
Select KERNEL_SUPPORTS_SHARED_LIBS on Windows

### DIFF
--- a/config/kernel/windows.in
+++ b/config/kernel/windows.in
@@ -7,3 +7,5 @@
 ## select WINDOWS
 ##
 ## help Build a toolchain targeting systems running Windows as host
+
+## select KERNEL_SUPPORTS_SHARED_LIBS


### PR DESCRIPTION
Fix building MinGW only generating libstdc++.a