### PR TITLE
Support 'nano' runtime libraries

### DIFF
--- a/config/cc/gcc.in
+++ b/config/cc/gcc.in
@@ -184,11 +184,21 @@ comment "Settings for libraries running on target"
 config CC_GCC_ENABLE_TARGET_OPTSPACE
     bool
     prompt "Optimize gcc libs for size"
-    default y
     help
       Pass --enable-target-optspace to crossgcc's configure.
       
       This will compile crossgcc's libs with -Os.
+
+config CC_GCC_LIBSTDCXX_NANO
+    bool
+    prompt "Compile libstdc++ nano variant"
+    help
+      Builds the additional nano variant of libstdc++ that is linked when
+      "--specs=nano.specs" is specified. This option compiles an additional
+      target libstdc++ using "-Os" (optimise for size) option flag.
+
+      Note that if "CC_GCC_ENABLE_TARGET_OPTSPACE" is enabled, the default and
+      nano versions will be identical.
 
 config CC_GCC_LIBMUDFLAP
     bool

--- a/config/global/paths.in
+++ b/config/global/paths.in
@@ -133,3 +133,11 @@ config STRIP_TARGET_TOOLCHAIN_EXECUTABLES
       An install-strip make target is provided that installs stripped
       executables, and may install libraries with unneeded or debugging
       sections stripped. 
+
+config STRIP_TARGET_TOOLCHAIN_LIBRARIES
+    bool
+    prompt "Strip target toolchain libraries"
+    default y
+    help
+      Ensures that the target toolchain libraries are stripped of any unneeded
+      or debugging information.

--- a/config/libc/newlib.in
+++ b/config/libc/newlib.in
@@ -179,7 +179,6 @@ config LIBC_NEWLIB_WIDE_ORIENT
 config LIBC_NEWLIB_ENABLE_TARGET_OPTSPACE
     bool
     prompt "Optimize newlib for size"
-    default y
     help
       Pass --enable-target-optspace to newlib configure.
 
@@ -222,3 +221,217 @@ config LIBC_NEWLIB_EXTRA_CONFIG_ARRAY
     default ""
     help
       Extra flags to pass onto ./configure when configuring the newlib.
+
+# newlib nano variant options
+comment "Options for newlib nano"
+
+config LIBC_NANO_NEWLIB
+    bool
+    prompt "Enable newlib nano variant"
+    help
+      Enables the additional `nano' variant of newlib to be built.  The build
+      options for this variant can be configured separately to produce the
+      smallest library size.  The nano variant can be used by specifying
+      `--specs=nano.specs' during linking.
+
+if LIBC_NANO_NEWLIB
+
+config LIBC_NANO_NEWLIB_TARGET_CFLAGS
+    string
+    prompt "Target CFLAGS for newlib nano"
+    default ""
+    help
+      Used to add specific options when compiling the target libraries
+      (eg. -ffunction-sections -fdata-sections), which can't be defined
+      in global TARGET_CFLAGS, because they shall be not used for the
+      gcc target libraries.
+      Note:  Both TARGET_CFLAGS and LIBC_NANO_NEWLIB_TARGET_CFLAGS are used
+             to compile the libraries.
+
+      Leave blank if you don't know better.
+
+config LIBC_NANO_NEWLIB_IO_C99FMT
+    bool
+    prompt "Enable IOs on C99 formats"
+    help
+      Enable support for IOs on C99 formats.
+
+config LIBC_NANO_NEWLIB_IO_LL
+    bool
+    prompt "Enable IOs on long long"
+    help
+      Enable support for IOs on long long integers.
+
+config LIBC_NANO_NEWLIB_IO_FLOAT
+    bool
+    prompt "Enable IOs on floats and doubles"
+    help
+      Enable support for IOs on floating point
+      values (float and double).
+
+config LIBC_NANO_NEWLIB_IO_LDBL
+    bool
+    prompt "Enable IOs on long doubles"
+    depends on LIBC_NANO_NEWLIB_IO_FLOAT
+    help
+      Enable support for IOs on long doubles.
+
+config LIBC_NANO_NEWLIB_IO_POS_ARGS
+    bool
+    prompt "Enable printf-family positional arg support"
+    help
+        Enable printf-family positional arg support.
+
+config LIBC_NANO_NEWLIB_FVWRITE_IN_STREAMIO
+    bool
+    prompt "Vector buffer mechanism to support stream IO buffering"
+    default y
+    help
+        NEWLIB implements the vector buffer mechanism to support stream IO
+        buffering required by C standard.  This feature is possibly
+        unnecessary for embedded systems which won't change file buffering
+        with functions like `setbuf' or `setvbuf'.  The buffering mechanism
+        still acts as default for STDIN/STDOUT/STDERR even if this option
+        is specified.
+
+config LIBC_NANO_NEWLIB_UNBUF_STREAM_OPT
+    bool
+    prompt "Optimize fprintf to unbuffered unix file"
+    help
+        NEWLIB does optimization when `fprintf to write only unbuffered unix
+        file'.  It creates a temorary buffer to do the optimization that
+        increases stack consumption by about `BUFSIZ' bytes. Disabling this option
+        disables the optimization and saves size of text and stack.
+
+config LIBC_NANO_NEWLIB_FSEEK_OPTIMIZATION
+    bool
+    prompt "Fseek optimisation"
+    help
+        Disabling fseek optimisation can decrease code size.
+
+config LIBC_NANO_NEWLIB_DISABLE_SUPPLIED_SYSCALLS
+    bool
+    prompt "Disable the syscalls supplied with newlib"
+    help
+      Disable the syscalls that come with newlib. You
+      will have to implement your own _sbrk, _read,
+      _write... If you plan to port newlib to a new
+      platform/board, say Yes.
+
+config LIBC_NANO_NEWLIB_REGISTER_FINI
+    bool
+    prompt "Enable finalization function registration using atexit"
+    help
+        Enable finalization function registration using atexit.
+
+config LIBC_NANO_NEWLIB_ATEXIT_DYNAMIC_ALLOC
+    bool
+    prompt "Enable dynamic allocation of atexit entries"
+    default y
+    help
+        Enable dynamic allocation of atexit entries.
+
+config LIBC_NANO_NEWLIB_GLOBAL_ATEXIT
+    bool
+    prompt "Enable atexit data structure as global variable"
+    default y
+    help
+        Enable atexit data structure as global variable.  By doing so it is
+        move out of _reent structure, and can be garbage collected if atexit
+        is not referenced.
+
+config LIBC_NANO_NEWLIB_LITE_EXIT
+    bool
+    prompt "Enable lite exit"
+    default y
+    help
+        Enable lite exit, a size-reduced implementation of exit that doesn't
+        invoke clean-up functions such as _fini or global destructors.
+
+config LIBC_NANO_NEWLIB_REENT_SMALL
+    bool
+    prompt "Enable small reentrant struct support"
+    default y
+    help
+        Enable small reentrant struct support.
+
+config LIBC_NANO_NEWLIB_MULTITHREAD
+    bool
+    prompt "Enable support for multiple threads"
+    default y
+    help
+        Enable support for multiple threads.
+
+config LIBC_NANO_NEWLIB_RETARGETABLE_LOCKING
+    bool
+    prompt "Enable retargetable locking"
+    help
+        Enable retargetable locking to allow the operating system to override
+        the dummy lock functions defined within the newlib.
+
+config LIBC_NANO_NEWLIB_EXTRA_SECTIONS
+    bool
+    prompt "Place each function & data element in their own section"
+    help
+        Place each function & data symbol in their own section. This allows
+        the linker to garbage collect unused symbols at link time.
+
+config LIBC_NANO_NEWLIB_WIDE_ORIENT
+    bool
+    prompt "Allow wide C99 stream orientation"
+    help
+        C99 states that each stream has an orientation, wide or byte.  This
+        feature is possibly unnecessary for embedded systems which only do
+        byte input/output operations on stream. Disabling this feature can
+        decrease code size.
+
+config LIBC_NANO_NEWLIB_ENABLE_TARGET_OPTSPACE
+    bool
+    prompt "Optimize newlib for size"
+    default y
+    help
+      Pass --enable-target-optspace to newlib configure.
+
+      This will compile newlib with -Os.
+
+config LIBC_NANO_NEWLIB_LTO
+    bool
+    prompt "Enable Link Time Optimization"
+    depends on CC_GCC_USE_LTO
+    help
+      Builds the libraries with -flto to enable more aggressive link time
+      optimization. You will need to add -flto-partition=one to your
+      application's link line to keep the RETURN assembler macro together
+      with it's consumers.
+
+config LIBC_NANO_NEWLIB_NANO_MALLOC
+    bool
+    prompt "Enable Nano Malloc"
+    default y
+    depends on NEWLIB_HAS_NANO_MALLOC
+    help
+      NEWLIB has two implementations of malloc family's functions, one in
+      `mallocr.c' and the other one in `nano-mallocr.c'.  This options
+      enables the nano-malloc implementation, which is for small systems
+      with very limited memory.  Note that this implementation does not
+      support `--enable-malloc-debugging' any more.
+
+config LIBC_NANO_NEWLIB_NANO_FORMATTED_IO
+    bool
+    prompt "Enable Nano Formatted I/O"
+    default y
+    depends on NEWLIB_HAS_NANO_FORMATTED_IO
+    help
+      This builds NEWLIB with a special implementation of formatted I/O
+      functions, designed to lower the size of application on small systems
+      with size constraint issues.  This option does not affect wide-char
+      formatted I/O functions.
+
+config LIBC_NANO_NEWLIB_EXTRA_CONFIG_ARRAY
+    string
+    prompt "Extra config for newlib"
+    default ""
+    help
+      Extra flags to pass onto ./configure when configuring the newlib.
+
+endif # LIBC_NANO_NEWLIB

--- a/ct-ng.in
+++ b/ct-ng.in
@@ -282,6 +282,7 @@ CT_STEPS := \
             libc_main                  \
             cc_for_build               \
             cc_for_host                \
+            cc_libstdcxx_nano          \
             libc_post_cc               \
             companion_libs_for_target  \
             binutils_for_target        \

--- a/scripts/build/cc/gcc.sh
+++ b/scripts/build/cc/gcc.sh
@@ -279,8 +279,8 @@ do_cc_core_pass_2() {
 #   build_manuals       : whether to build manuals or not           : bool      : no
 #   cflags              : cflags to use                             : string    : (empty)
 #   ldflags             : ldflags to use                            : string    : (empty)
-#   build_step          : build step 'core1', 'core2', 'gcc_build'
-#                         or 'gcc_host'                             : string    : (none)
+#   build_step          : build step 'core1', 'core2', 'gcc_build',
+#                         'libstdcxx_nano' or 'gcc_host'            : string    : (none)
 # Usage: do_gcc_core_backend mode=[static|shared|baremetal] build_libgcc=[yes|no] build_staticlinked=[yes|no]
 do_gcc_core_backend() {
     local mode
@@ -327,8 +327,16 @@ do_gcc_core_backend() {
             # to inhibit the libiberty and libgcc tricks later on
             build_libgcc=no
             ;;
+        libstdcxx_nano)
+            CT_DoLog EXTRA "Configuring libstdc++ nano"
+            extra_config+=( "${CT_CC_SYSROOT_ARG[@]}" )
+            extra_user_config=( "${CT_CC_GCC_EXTRA_CONFIG_ARRAY[@]}" )
+            log_txt="libstdc++ nano library"
+            # to inhibit the libiberty and libgcc tricks later on
+            build_libgcc=no
+            ;;
         *)
-            CT_Abort "Internal Error: 'build_step' must be one of: 'core1', 'core2', 'gcc_build' or 'gcc_host', not '${build_step:-(empty)}'"
+            CT_Abort "Internal Error: 'build_step' must be one of: 'core1', 'core2', 'gcc_build', 'gcc_host' or 'libstdcxx_nano', not '${build_step:-(empty)}'"
             ;;
     esac
 
@@ -447,7 +455,8 @@ do_gcc_core_backend() {
         extra_config+=("--with-host-libstdcxx=${host_libstdcxx_flags[*]}")
     fi
 
-    if [ "${CT_CC_GCC_ENABLE_TARGET_OPTSPACE}" = "y" ]; then
+    if [ "${CT_CC_GCC_ENABLE_TARGET_OPTSPACE}" = "y" ] || \
+       [ "${build_step}" = "libstdcxx_nano" ]; then
         extra_config+=("--enable-target-optspace")
     fi
     if [ "${CT_CC_GCC_DISABLE_PCH}" = "y" ]; then
@@ -871,6 +880,74 @@ do_cc_for_host() {
 }
 
 #------------------------------------------------------------------------------
+# Build an additional target libstdc++ with "-Os" (optimise for speed) option
+# flag for libstdc++ "nano" variant.
+do_cc_libstdcxx_nano()
+{
+    local -a final_opts
+    local final_backend
+
+    if [ "${CT_CC_GCC_LIBSTDCXX_NANO}" = "y" ]; then
+        final_opts+=( "host=${CT_HOST}" )
+        final_opts+=( "prefix=${CT_BUILD_DIR}/build-cc-libstdcxx-nano/target-libs" )
+        final_opts+=( "complibs=${CT_HOST_COMPLIBS_DIR}" )
+        final_opts+=( "cflags=${CT_CFLAGS_FOR_HOST}" )
+        final_opts+=( "ldflags=${CT_LDFLAGS_FOR_HOST}" )
+        final_opts+=( "lang_list=$( cc_gcc_lang_list )" )
+        final_opts+=( "build_step=libstdcxx_nano" )
+
+        if [ "${CT_BARE_METAL}" = "y" ]; then
+            final_opts+=( "mode=baremetal" )
+            final_opts+=( "build_libgcc=yes" )
+            final_opts+=( "build_libstdcxx=yes" )
+            final_opts+=( "build_libgfortran=yes" )
+            if [ "${CT_STATIC_TOOLCHAIN}" = "y" ]; then
+                final_opts+=( "build_staticlinked=yes" )
+            fi
+            final_backend=do_gcc_core_backend
+        else
+            final_backend=do_gcc_backend
+        fi
+
+        CT_DoStep INFO "Installing libstdc++ nano"
+        CT_mkdir_pushd "${CT_BUILD_DIR}/build-cc-libstdcxx-nano"
+        "${final_backend}" "${final_opts[@]}"
+        CT_Popd
+
+        # GCC installs stuff (including libgcc) into its own /lib dir,
+        # outside of sysroot, breaking linking with -static-libgcc.
+        # Fix up by moving the libraries into the sysroot.
+        if [ "${CT_USE_SYSROOT}" = "y" ]; then
+            CT_mkdir_pushd "${CT_BUILD_DIR}/build-cc-gcc-final-movelibs"
+            CT_IterateMultilibs gcc_movelibs movelibs
+            CT_Popd
+        fi
+
+        # Copy lib{std,sup}c++ as nano libraries
+        CT_mkdir_pushd "${CT_BUILD_DIR}/build-cc-libstdcxx-nano-copy"
+        CT_IterateMultilibs libstdcxx_nano_copy_multilibs copylibs
+        CT_Popd
+
+        CT_EndStep
+    fi
+}
+
+libstdcxx_nano_copy_multilibs()
+{
+    local nano_lib_dir="${CT_BUILD_DIR}/build-cc-libstdcxx-nano/target-libs"
+    local multi_flags multi_dir multi_os_dir multi_os_dir_gcc multi_root multi_index multi_count
+
+    for arg in "$@"; do
+        eval "${arg// /\\ }"
+    done
+
+    CT_DoExecLog ALL cp -f "${nano_lib_dir}/${CT_TARGET}/lib/${multi_dir}/libstdc++.a" \
+                           "${CT_PREFIX_DIR}/${CT_TARGET}/lib/${multi_dir}/libstdc++_nano.a"
+    CT_DoExecLog ALL cp -f "${nano_lib_dir}/${CT_TARGET}/lib/${multi_dir}/libsupc++.a" \
+                           "${CT_PREFIX_DIR}/${CT_TARGET}/lib/${multi_dir}/libsupc++_nano.a"
+}
+
+#------------------------------------------------------------------------------
 # Build the final gcc
 # Usage: do_gcc_backend param=value [...]
 #   Parameter     : Definition                          : Type      : Default
@@ -881,6 +958,8 @@ do_cc_for_host() {
 #   ldflags       : ldflags to use                      : string    : (empty)
 #   lang_list     : the list of languages to build      : string    : (empty)
 #   build_manuals : whether to build manuals or not     : bool      : no
+#   build_step    : build step 'gcc_build', 'gcc_host',
+#                   or 'libstdcxx_nano'                 : string    : (none)
 do_gcc_backend() {
     local host
     local prefix
@@ -890,6 +969,8 @@ do_gcc_backend() {
     local cflags_for_build
     local ldflags
     local build_manuals
+    local build_step
+    local log_txt
     local -a host_libstdcxx_flags
     local -a extra_config
     local -a final_LDFLAGS
@@ -900,7 +981,20 @@ do_gcc_backend() {
         eval "${arg// /\\ }"
     done
 
-    CT_DoLog EXTRA "Configuring final gcc compiler"
+    # This function gets called for both final gcc and libstdcxx_nano.
+    case "${build_step}" in
+        gcc_build|gcc_host)
+            log_txt="final gcc compiler"
+            ;;
+        libstdcxx_nano)
+            log_txt="libstdc++ nano library"
+            ;;
+        *)
+            CT_Abort "Internal Error: 'build_step' must be one of: 'gcc_build', 'gcc_host' or 'libstdcxx_nano', not '${build_step:-(empty)}'"
+            ;;
+    esac
+
+    CT_DoLog EXTRA "Configuring ${log_txt}"
 
     # Enable selected languages
     extra_config+=("--enable-languages=${lang_list}")
@@ -1043,11 +1137,18 @@ do_gcc_backend() {
         fi
     fi
 
-    if [ "${CT_CC_GCC_ENABLE_TARGET_OPTSPACE}" = "y" ]; then
+    if [ "${CT_CC_GCC_ENABLE_TARGET_OPTSPACE}" = "y" ] || \
+       [ "${build_step}" = "libstdcxx_nano" ]; then
         extra_config+=("--enable-target-optspace")
     fi
     if [ "${CT_CC_GCC_DISABLE_PCH}" = "y" ]; then
         extra_config+=("--disable-libstdcxx-pch")
+    fi
+
+    if [ "${build_step}" = "libstdcxx_nano" ]; then
+        extra_config+=("-ffunction-sections")
+        extra_config+=("-fdata-sections")
+        extra_config+=("-fno-exceptions")
     fi
 
     case "${CT_CC_GCC_LDBL_128}" in
@@ -1172,11 +1273,11 @@ do_gcc_backend() {
         CT_DoExecLog ALL make ${CT_JOBSFLAGS} all-build-libiberty
     fi
 
-    CT_DoLog EXTRA "Building final gcc compiler"
+    CT_DoLog EXTRA "Building ${log_txt}"
     CT_DoExecLog ALL make ${CT_JOBSFLAGS} all
 
     # See the note on issues with parallel 'make install' in GCC above.
-    CT_DoLog EXTRA "Installing final gcc compiler"
+    CT_DoLog EXTRA "Installing ${log_txt}"
     if [ "${CT_STRIP_TARGET_TOOLCHAIN_EXECUTABLES}" = "y" ]; then
         CT_DoExecLog ALL make install-strip
     else
@@ -1187,7 +1288,7 @@ do_gcc_backend() {
     # tree makes the libtoolized utilities that are built next assume
     # that, for example, libsupc++ is an "accessory library", and not include
     # -lsupc++ to the link flags. That breaks ltrace, for example.
-    CT_DoLog EXTRA "Housekeeping for final gcc compiler"
+    CT_DoLog EXTRA "Housekeeping for ${log_txt}"
     CT_Pushd "${prefix}"
     find . -type f -name "*.la" -exec rm {} \; |CT_DoLog ALL
     CT_Popd

--- a/scripts/build/cc/gcc.sh
+++ b/scripts/build/cc/gcc.sh
@@ -583,6 +583,9 @@ do_gcc_core_backend() {
         cflags_for_target="${cflags_for_target} -idirafter ${CT_HEADERS_DIR}"
     fi
 
+    # Assume '-O2' by default for building target libraries.
+    cflags_for_target="-g -O2 ${cflags_for_target}"
+
     # Use --with-local-prefix so older gccs don't look in /usr/local (http://gcc.gnu.org/PR10532).
     # Pass only user-specified CFLAGS/LDFLAGS in CFLAGS_FOR_TARGET/LDFLAGS_FOR_TARGET: during
     # the build of, for example, libatomic, GCC tried to compile multiple variants for runtime
@@ -967,6 +970,7 @@ do_gcc_backend() {
     local lang_list
     local cflags
     local cflags_for_build
+    local cflags_for_target
     local ldflags
     local build_manuals
     local build_step
@@ -1227,8 +1231,9 @@ do_gcc_backend() {
 
     CT_DoLog DEBUG "Extra config passed: '${extra_config[*]}'"
 
-    # We may need to modify host/build CFLAGS separately below
+    # We may need to modify host/build/target CFLAGS separately below
     cflags_for_build="${cflags}"
+    cflags_for_target="${CT_TARGET_CFLAGS}"
 
     # Clang's default bracket-depth is 256, and building GCC
     # requires somewhere between 257 and 512.
@@ -1244,6 +1249,9 @@ do_gcc_backend() {
         fi
     fi
 
+    # Assume '-O2' by default for building target libraries.
+    cflags_for_target="-g -O2 ${cflags_for_target}"
+
     # NB: not using CT_ALL_TARGET_CFLAGS/CT_ALL_TARGET_LDFLAGS here!
     # See do_gcc_core_backend for explanation.
     CT_DoExecLog CFG                                   \
@@ -1253,8 +1261,8 @@ do_gcc_backend() {
     CXXFLAGS="${cflags}"                               \
     CXXFLAGS_FOR_BUILD="${cflags_for_build}"           \
     LDFLAGS="${final_LDFLAGS[*]}"                      \
-    CFLAGS_FOR_TARGET="${CT_TARGET_CFLAGS}"            \
-    CXXFLAGS_FOR_TARGET="${CT_TARGET_CFLAGS}"          \
+    CFLAGS_FOR_TARGET="${cflags_for_target}"           \
+    CXXFLAGS_FOR_TARGET="${cflags_for_target}"         \
     LDFLAGS_FOR_TARGET="${CT_TARGET_LDFLAGS}"          \
     ${CONFIG_SHELL}                                    \
     "${CT_SRC_DIR}/gcc/configure"                      \

--- a/scripts/build/libc/newlib.sh
+++ b/scripts/build/libc/newlib.sh
@@ -18,7 +18,7 @@ newlib_start_files()
     CT_EndStep
 }
 
-newlib_main()
+newlib_main_full()
 {
     local -a newlib_opts
     local cflags_for_target
@@ -51,23 +51,6 @@ newlib_main()
     else
         newlib_opts+=( "--enable-newlib-supplied-syscalls" )
     fi
-
-    yn_args="IO_POS_ARGS:newlib-io-pos-args
-IO_C99FMT:newlib-io-c99-formats
-IO_LL:newlib-io-long-long
-NEWLIB_REGISTER_FINI:newlib-register-fini
-NANO_MALLOC:newlib-nano-malloc
-NANO_FORMATTED_IO:newlib-nano-formatted-io
-ATEXIT_DYNAMIC_ALLOC:newlib-atexit-dynamic-alloc
-GLOBAL_ATEXIT:newlib-global-atexit
-LITE_EXIT:lite-exit
-REENT_SMALL:newlib-reent-small
-MULTITHREAD:newlib-multithread
-RETARGETABLE_LOCKING:newlib-retargetable-locking
-WIDE_ORIENT:newlib-wide-orient
-UNBUF_STREAM_OPT:newlib-unbuf-stream-opt
-ENABLE_TARGET_OPTSPACE:target-optspace
-    "
 
     for ynarg in $yn_args; do
         var="CT_LIBC_NEWLIB_${ynarg%:*}"
@@ -131,4 +114,143 @@ ENABLE_TARGET_OPTSPACE:target-optspace
 
     CT_Popd
     CT_EndStep
+}
+
+newlib_main_nano()
+{
+    local -a newlib_opts
+    local cflags_for_target
+
+    CT_DoStep INFO "Installing C library (nano)"
+
+    CT_mkdir_pushd "${CT_BUILD_DIR}/build-libc-nano"
+
+    CT_DoLog EXTRA "Configuring C library (nano)"
+
+    # Multilib is the default, so if it is not enabled, disable it.
+    if [ "${CT_MULTILIB}" != "y" ]; then
+        newlib_opts+=("--disable-multilib")
+    fi
+
+    if [ "${CT_LIBC_NANO_NEWLIB_IO_FLOAT}" = "y" ]; then
+        newlib_opts+=( "--enable-newlib-io-float" )
+        if [ "${CT_LIBC_NANO_NEWLIB_IO_LDBL}" = "y" ]; then
+            newlib_opts+=( "--enable-newlib-io-long-double" )
+        else
+            newlib_opts+=( "--disable-newlib-io-long-double" )
+        fi
+    else
+        newlib_opts+=( "--disable-newlib-io-float" )
+        newlib_opts+=( "--disable-newlib-io-long-double" )
+    fi
+
+    if [ "${CT_LIBC_NANO_NEWLIB_DISABLE_SUPPLIED_SYSCALLS}" = "y" ]; then
+        newlib_opts+=( "--disable-newlib-supplied-syscalls" )
+    else
+        newlib_opts+=( "--enable-newlib-supplied-syscalls" )
+    fi
+
+    for ynarg in $yn_args; do
+        var="CT_LIBC_NANO_NEWLIB_${ynarg%:*}"
+        eval var=\$${var}
+        argument=${ynarg#*:}
+
+
+        if [ "${var}" = "y" ]; then
+            newlib_opts+=( "--enable-$argument" )
+        else
+            newlib_opts+=( "--disable-$argument" )
+        fi
+    done
+
+    [ "${CT_LIBC_NANO_NEWLIB_EXTRA_SECTIONS}" = "y" ] && \
+        CT_LIBC_NANO_NEWLIB_TARGET_CFLAGS="${CT_LIBC_NANO_NEWLIB_TARGET_CFLAGS} -ffunction-sections -fdata-sections"
+
+    [ "${CT_LIBC_NANO_NEWLIB_LTO}" = "y" ] && \
+        CT_LIBC_NANO_NEWLIB_TARGET_CFLAGS="${CT_LIBC_NANO_NEWLIB_TARGET_CFLAGS} -flto"
+
+    cflags_for_target="${CT_ALL_TARGET_CFLAGS} ${CT_LIBC_NANO_NEWLIB_TARGET_CFLAGS}"
+
+    # Note: newlib handles the build/host/target a little bit differently
+    # than one would expect:
+    #   build  : not used
+    #   host   : the machine building newlib
+    #   target : the machine newlib runs on
+    CT_DoExecLog CFG                                               \
+    CC_FOR_BUILD="${CT_BUILD}-gcc"                                 \
+    CFLAGS_FOR_TARGET="${cflags_for_target}"                       \
+    AR_FOR_TARGET="`which ${CT_TARGET}-gcc-ar`"                    \
+    RANLIB_FOR_TARGET="`which ${CT_TARGET}-gcc-ranlib`"            \
+    ${CONFIG_SHELL}                                                \
+    "${CT_SRC_DIR}/newlib/configure"                               \
+        --host=${CT_BUILD}                                         \
+        --target=${CT_TARGET}                                      \
+        --prefix=${CT_BUILD_DIR}/build-libc-nano/target-libs       \
+        "${newlib_opts[@]}"                                        \
+        "${CT_LIBC_NANO_NEWLIB_EXTRA_CONFIG_ARRAY[@]}"
+
+    CT_DoLog EXTRA "Building C library (nano)"
+    CT_DoExecLog ALL make ${CT_JOBSFLAGS}
+
+    CT_DoLog EXTRA "Installing C library (nano)"
+    CT_DoExecLog ALL make install
+
+    CT_mkdir_pushd "${CT_BUILD_DIR}/build-libc-nano-copy"
+    CT_IterateMultilibs newlib_nano_copy_multilibs copylibs
+    CT_Popd
+
+    CT_DoExecLog ALL mkdir -p "${CT_PREFIX_DIR}/${CT_TARGET}/include/newlib-nano"
+    CT_DoExecLog ALL cp -f "${CT_BUILD_DIR}/build-libc-nano/target-libs/${CT_TARGET}/include/newlib.h" \
+                           "${CT_PREFIX_DIR}/${CT_TARGET}/include/newlib-nano/newlib.h"
+
+    CT_Popd
+    CT_EndStep
+}
+
+newlib_main()
+{
+    yn_args="IO_POS_ARGS:newlib-io-pos-args
+IO_C99FMT:newlib-io-c99-formats
+IO_LL:newlib-io-long-long
+NEWLIB_REGISTER_FINI:newlib-register-fini
+NANO_MALLOC:newlib-nano-malloc
+NANO_FORMATTED_IO:newlib-nano-formatted-io
+ATEXIT_DYNAMIC_ALLOC:newlib-atexit-dynamic-alloc
+GLOBAL_ATEXIT:newlib-global-atexit
+LITE_EXIT:lite-exit
+REENT_SMALL:newlib-reent-small
+MULTITHREAD:newlib-multithread
+RETARGETABLE_LOCKING:newlib-retargetable-locking
+WIDE_ORIENT:newlib-wide-orient
+UNBUF_STREAM_OPT:newlib-unbuf-stream-opt
+ENABLE_TARGET_OPTSPACE:target-optspace
+    "
+
+    # Build the full variant (libc.a, libg.a, ...)
+    newlib_main_full
+
+    # Build the nano variant (libc_nano.a, libg_nano.a, ...)
+    if [ "${CT_LIBC_NANO_NEWLIB}" = "y" ]; then
+        newlib_main_nano
+    fi
+}
+
+newlib_nano_copy_multilibs()
+{
+    local nano_lib_dir="${CT_BUILD_DIR}/build-libc-nano/target-libs"
+    local multi_flags multi_dir multi_os_dir multi_os_dir_gcc multi_root multi_index multi_count
+
+    for arg in "$@"; do
+        eval "${arg// /\\ }"
+    done
+
+    CT_DoExecLog ALL cp -f "${nano_lib_dir}/${CT_TARGET}/lib/${multi_dir}/libc.a" \
+                           "${CT_PREFIX_DIR}/${CT_TARGET}/lib/${multi_dir}/libc_nano.a"
+    CT_DoExecLog ALL cp -f "${nano_lib_dir}/${CT_TARGET}/lib/${multi_dir}/libg.a" \
+                           "${CT_PREFIX_DIR}/${CT_TARGET}/lib/${multi_dir}/libg_nano.a"
+
+    if [ -f ${nano_lib_dir}/${CT_TARGET}/lib/${multi_dir}/librdimon.a ]; then
+        CT_DoExecLog ALL cp -f "${nano_lib_dir}/${CT_TARGET}/lib/${multi_dir}/librdimon.a" \
+                               "${CT_PREFIX_DIR}/${CT_TARGET}/lib/${multi_dir}/librdimon_nano.a"
+    fi
 }


### PR DESCRIPTION
This PR includes a series of commits required to support building the 'nano' variant of C/C++ runtime libraries (using newlib; other libc support can be added in the future using a similar method).

The 'nano' runtime libraries are specified by the `nano.specs` file and are often included in embedded toolchains (e.g. GNU ARM Embedded) for memory-constrained target devices.

The following is a brief summary of the changes introduced by this PR:

1. Add nano variant-specific newlib configurations in `config/libc/newlib.in`.

    - Keep all `LIBC_NEWLIB_...` configs as is. These configurations will be used to build the normal variant (`lib{c,g}.a`).
    - Mirror all `LIBC_NEWLIB_...` configs to `LIBC_NANO_NEWLIB_...` configs. These configurations will be used to build the nano variant (`lib{c,g}_nano.a`).

2. Modify newlib build script to build `LIBC` and `LIBC_NANO` variants separately.

3. Build an additional libstdc++ with `-Os` (optimise for size) and place it as `lib{std,sup}c++_nano.a` (the default libstdc++ is built with `-O2`).

4. Strip debug information from the built libraries.

Refer to the following issues for the rationale of supporting both normal (non-nano) and nano variants: https://github.com/zephyrproject-rtos/sdk-ng/issues/151

This PR supersedes #1225, which only renames the default runtime libraries to comply with `nano.specs` without actually building a separate nano variant.