### PR TITLE
Resepct CT_TARGET_{C,LD}FLAGS when building musl

### DIFF
--- a/scripts/build/libc/musl.sh
+++ b/scripts/build/libc/musl.sh
@@ -98,7 +98,8 @@ musl_backend_once() {
     #   host    : same as --target
     #   target  : the machine musl runs on
     CT_DoExecLog CFG                                      \
-    CFLAGS="${extra_cflags[*]}"                           \
+    CFLAGS="${CT_TARGET_CFLAGS} ${extra_cflags[*]}"       \
+    LDFLAGS="${CT_TARGET_LDFLAGS}"                        \
     CROSS_COMPILE="${CT_TARGET}-"                         \
     ${CONFIG_SHELL}                                       \
     ${src_dir}/configure                                  \


### PR DESCRIPTION
I was trying to build static binaries for a range of Broadcom soft-float ARMv7
SoCs and kept getting SIGILL, although I was targeting Cortex A7 (and A5,
later), even on A9 and A15.

I found out that once I add -msoft-float, +mp+sec is to blame:

```
   Attribute Section: aeabi
   File Attributes
  -  Tag_CPU_name: "7VE"
  +  Tag_CPU_name: "7"
     Tag_CPU_arch: v7
  -  Tag_CPU_arch_profile: Application
  -  Tag_ARM_ISA_use: Yes
     Tag_THUMB_ISA_use: Thumb-2
     Tag_ABI_PCS_wchar_t: 4
     Tag_ABI_FP_rounding: Needed
  @@ -12,8 +10,5 @@ File Attributes
     Tag_ABI_FP_number_model: IEEE 754
     Tag_ABI_align_needed: 8-byte
     Tag_ABI_enum_size: int
     Tag_ABI_optimization_goals: Aggressive Size
     Tag_CPU_unaligned_access: v6
  -  Tag_MPextension_use: Allowed
  -  Tag_DIV_use: Allowed in v7-A with integer division extension
  -  Tag_Virtualization_use: TrustZone and Virtualization Extensions
```

(This is the readelf -A diff, before and after armv7-a+nofp -> armv7+nofp).

I kept getting SIGILL even after building my application with a toolchain built
with the correct CFLAGS and found out that crosstool-ng doesn't pass the host
CFLAGS when building musl, which pollutes my binary with these ARMv7 extensions.

Signed-off-by: Dima Krasner <dima@dimakrasner.com>