### PR TITLE
Add newlib retargetable locking configuration

### DIFF
--- a/config/libc/newlib.in
+++ b/config/libc/newlib.in
@@ -152,6 +152,13 @@ config LIBC_NEWLIB_MULTITHREAD
     help
         Enable support for multiple threads.
 
+config LIBC_NEWLIB_RETARGETABLE_LOCKING
+    bool
+    prompt "Enable retargetable locking"
+    help
+        Enable retargetable locking to allow the operating system to override
+        the dummy lock functions defined within the newlib.
+
 config LIBC_NEWLIB_EXTRA_SECTIONS
     bool
     prompt "Place each function & data element in their own section"

--- a/scripts/build/libc/newlib.sh
+++ b/scripts/build/libc/newlib.sh
@@ -63,6 +63,7 @@ GLOBAL_ATEXIT:newlib-global-atexit
 LITE_EXIT:lite-exit
 REENT_SMALL:newlib-reent-small
 MULTITHREAD:newlib-multithread
+RETARGETABLE_LOCKING:newlib-retargetable-locking
 WIDE_ORIENT:newlib-wide-orient
 UNBUF_STREAM_OPT:newlib-unbuf-stream-opt
 ENABLE_TARGET_OPTSPACE:target-optspace


### PR DESCRIPTION
This commit adds support for the newlib configuration option
'--enable-newlib-retargetable-locking'.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>