### PR TITLE
testing/docker: set default value for CTNG_UID/CTNG_GID

### DIFF
--- a/testing/docker/alpine3.8/Dockerfile
+++ b/testing/docker/alpine3.8/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.8
-ARG CTNG_UID
-ARG CTNG_GID
+ARG CTNG_UID=1000
+ARG CTNG_GID=1000
 RUN addgroup -g $CTNG_GID ctng
 RUN adduser -D -h /home/ctng -G ctng -u $CTNG_UID -s /bin/bash ctng
 # Activate community and testing repositories

--- a/testing/docker/archlinux/Dockerfile
+++ b/testing/docker/archlinux/Dockerfile
@@ -1,6 +1,6 @@
 FROM archlinux/base:latest
-ARG CTNG_UID
-ARG CTNG_GID
+ARG CTNG_UID=1000
+ARG CTNG_GID=1000
 RUN pacman -Sy --noconfirm archlinux-keyring
 RUN pacman -Syu --noconfirm
 RUN pacman -S --noconfirm base-devel git help2man python unzip wget audit

--- a/testing/docker/centos6/Dockerfile
+++ b/testing/docker/centos6/Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:6
-ARG CTNG_UID
-ARG CTNG_GID
+ARG CTNG_UID=1000
+ARG CTNG_GID=1000
 RUN groupadd -g $CTNG_GID ctng
 RUN useradd -d /home/ctng -m -g $CTNG_GID -u $CTNG_UID -s /bin/bash ctng
 RUN yum install -y epel-release

--- a/testing/docker/centos7/Dockerfile
+++ b/testing/docker/centos7/Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:7
-ARG CTNG_UID
-ARG CTNG_GID
+ARG CTNG_UID=1000
+ARG CTNG_GID=1000
 RUN groupadd -g $CTNG_GID ctng
 RUN useradd -d /home/ctng -m -g $CTNG_GID -u $CTNG_UID -s /bin/bash ctng
 RUN yum install -y epel-release

--- a/testing/docker/fedora29/Dockerfile
+++ b/testing/docker/fedora29/Dockerfile
@@ -1,6 +1,6 @@
 FROM fedora:29
-ARG CTNG_UID
-ARG CTNG_GID
+ARG CTNG_UID=1000
+ARG CTNG_GID=1000
 RUN groupadd -g $CTNG_GID ctng
 RUN useradd -d /home/ctng -m -g $CTNG_GID -u $CTNG_UID -s /bin/bash ctng
 RUN yum install -y autoconf gperf bison file flex texinfo help2man gcc-c++ libtool make patch \

--- a/testing/docker/gentoo-amd64/Dockerfile
+++ b/testing/docker/gentoo-amd64/Dockerfile
@@ -1,6 +1,6 @@
 FROM gentoo/stage3-amd64-hardened
-ARG CTNG_UID
-ARG CTNG_GID
+ARG CTNG_UID=1000
+ARG CTNG_GID=1000
 RUN groupadd -g $CTNG_GID ctng
 RUN useradd -d /home/ctng -m -g $CTNG_GID -u $CTNG_UID -s /bin/bash ctng
 RUN wget -O /sbin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.1/dumb-init_1.2.1_amd64

--- a/testing/docker/mint19-amd64/Dockerfile
+++ b/testing/docker/mint19-amd64/Dockerfile
@@ -1,6 +1,6 @@
 FROM linuxmintd/mint19-amd64
-ARG CTNG_UID
-ARG CTNG_GID
+ARG CTNG_UID=1000
+ARG CTNG_GID=1000
 RUN groupadd -g $CTNG_GID ctng
 RUN useradd -d /home/ctng -m -g $CTNG_GID -u $CTNG_UID -s /bin/bash ctng
 RUN apt-get update

--- a/testing/docker/ubuntu16.04/Dockerfile
+++ b/testing/docker/ubuntu16.04/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
-ARG CTNG_UID
-ARG CTNG_GID
+ARG CTNG_UID=1000
+ARG CTNG_GID=1000
 RUN groupadd -g $CTNG_GID ctng
 RUN useradd -d /home/ctng -m -g $CTNG_GID -u $CTNG_UID -s /bin/bash ctng
 RUN apt-get update

--- a/testing/docker/ubuntu18.04/Dockerfile
+++ b/testing/docker/ubuntu18.04/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
-ARG CTNG_UID
-ARG CTNG_GID
+ARG CTNG_UID=1000
+ARG CTNG_GID=1000
 RUN groupadd -g $CTNG_GID ctng
 RUN useradd -d /home/ctng -m -g $CTNG_GID -u $CTNG_UID -s /bin/bash ctng
 RUN apt-get update

--- a/testing/docker/ubuntu19.10/Dockerfile
+++ b/testing/docker/ubuntu19.10/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:19.10
-ARG CTNG_UID
-ARG CTNG_GID
+ARG CTNG_UID=1000
+ARG CTNG_GID=1000
 RUN groupadd -g $CTNG_GID ctng
 RUN useradd -d /home/ctng -m -g $CTNG_GID -u $CTNG_UID -s /bin/bash ctng
 RUN apt-get update


### PR DESCRIPTION
Make the creation of docker images easier so that CTNG_UID/CTNG_GID have
a default value if it's not explicitly specified when building. This
will allow publishing of images on various package repositories (e.g.
docker hub, gitlab containers). dmgr.sh can still be used to set the
UID/GID to that of the current user when building a custom container.

Signed-off-by: Chris Packham <judge.packham@gmail.com>