### PR TITLE
DO NOT MERGE: gitlab-ci: setup for using gitlab-ci infrastructure

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,1006 @@
+# Generated file DO NOT EDIT
+
+---
+stages:
+  - build
+  - keystone
+  - world
+  - canadian
+
+cache:
+  paths:
+    - src
+
+# probably worth pushing an image with the required packages to dockerhub.
+image: registry.gitlab.com/cpackham/crosstool-ng/ubuntu18.04-ct-ng-prereq:latest
+
+variables:
+  DEBIAN_FRONTEND: noninteractive
+
+# sudo is needed until this is official: https://gitlab.com/gitlab-org/gitlab-runner/issues/2750
+.do_build:
+  - &do_build
+    sudo -u ctng mkdir -p src;
+    sudo -u ctng ./ct-ng "$CI_JOB_NAME";
+    sudo -u ctng sed -i- -e '/CT_LOG_PROGRESS_BAR/s/y$/n/' .config;
+    sudo -u ctng sed -i- -e '/CT_LOCAL_TARBALLS_DIR/s/HOME/CT_TOP_DIR/' .config;
+    sudo -u ctng sed -i- -e '/CT_PREFIX_DIR/s/HOME/CT_TOP_DIR/' .config;
+    sudo -u ctng ./ct-ng build
+
+crosstool-ng:
+  stage: build
+  script:
+    - sudo -u ctng ./bootstrap
+    - sudo -u ctng ./configure --enable-local
+    - sudo -u ctng make
+  artifacts:
+    untracked: true
+
+
+
+arm-unknown-linux-gnueabi:
+  stage: keystone
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+aarch64-unknown-linux-gnu:
+  stage: keystone
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+mips-unknown-elf:
+  stage: keystone
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+powerpc64-unknown-linux-gnu:
+  stage: keystone
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+powerpc-unknown-linux-gnu:
+  stage: keystone
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+
+
+armeb-unknown-eabi:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+m68k-unknown-uclinux-uclibc:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+i686-ubuntu12.04-linux-gnu:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+i686-ubuntu16.04-linux-gnu:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+x86_64-multilib-linux-gnu:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+i686-centos7-linux-gnu:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+sparc-leon-linux-uclibc:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+xtensa-fsf-elf:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+armv6-nommu-linux-uclibcgnueabi:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+arm-unknown-linux-uclibcgnueabi:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+sh-unknown-elf:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+powerpc-860-linux-gnu:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+arc-archs-linux-gnu:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+x86_64-multilib-linux-musl:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+powerpc64le-unknown-linux-gnu:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+arc-arc700-linux-uclibc:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+i686-centos6-linux-gnu:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+powerpc-405-linux-gnu:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+m68k-unknown-elf:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+s390x-ibm-linux-gnu:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+alphaev56-unknown-linux-gnu:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+i586-geode-linux-uclibc:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+arm-bare_newlib_cortex_m3_nommu-eabi:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+arm-cortexa5-linux-uclibcgnueabihf:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+mips-unknown-linux-uclibc:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+powerpc-e300c3-linux-gnu:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+nios2-unknown-elf:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+powerpc-unknown-linux-uclibc:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+arm-cortexa9_neon-linux-gnueabihf:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+armeb-unknown-linux-uclibcgnueabi:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+arm-cortex_a15-linux-gnueabihf:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+arm-cortex_a8-linux-gnueabi:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+mipsel-sde-elf:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+arm-nano-eabi:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+mips-malta-linux-gnu:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+moxiebox:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+msp430-unknown-elf:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+mipsel-multilib-linux-gnu:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+sparc-unknown-linux-gnu:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+x86_64-unknown-linux-uclibc:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+armeb-unknown-linux-gnueabi:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+moxie-unknown-elf:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+aarch64-unknown-linux-uclibc:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+riscv32-unknown-elf:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+i686-ubuntu14.04-linux-gnu:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+riscv64-unknown-elf:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+armv6-rpi-linux-gnueabi:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+arc-multilib-linux-uclibc:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+x86_64-centos6-linux-gnu:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+aarch64-unknown-linux-android:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+i686-nptl-linux-gnu:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+x86_64-ubuntu14.04-linux-gnu:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+x86_64-ubuntu12.04-linux-gnu:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+sparc64-multilib-linux-gnu:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+aarch64-rpi3-linux-gnu:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+armv8-rpi3-linux-gnueabihf:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+armv7-rpi2-linux-gnueabihf:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+nios2-altera-linux-gnu:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+x86_64-multilib-linux-uclibc:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+powerpc-e500v2-linux-gnuspe:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+mips64el-multilib-linux-uclibc:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+x86_64-unknown-linux-gnu:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+x86_64-ubuntu16.04-linux-gnu:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+arm-multilib-linux-uclibcgnueabi:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+arm-unknown-eabi:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+avr:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+riscv64-unknown-linux-gnu:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+xtensa-fsf-linux-uclibc:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+arc-multilib-linux-gnu:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+riscv32-hifive1-elf:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+sh-multilib-linux-uclibc:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+powerpc64-multilib-linux-gnu:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+powerpc-unknown_nofpu-linux-gnu:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+mips-ar2315-linux-gnu:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+sh-multilib-linux-gnu:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+powerpc-8540-linux-gnu:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+x86_64-w64-mingw32:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+x86_64-centos7-linux-gnu:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+i686-w64-mingw32:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+arm-unknown-linux-musleabi:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+alphaev67-unknown-linux-gnu:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+arm-unknown-linux-uclibcgnueabihf:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+arc-multilib-elf32:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+mipsel-unknown-linux-gnu:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+s390-ibm-linux-gnu:
+  stage: world
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+
+
+x86_64-w64-mingw32,arm-cortexa9_neon-linux-gnueabihf:
+  stage: canadian
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+x86_64-multilib-linux-uclibc,powerpc-unknown-elf:
+  stage: canadian
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+x86_64-multilib-linux-uclibc,moxie-unknown-moxiebox:
+  stage: canadian
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+i686-w64-mingw32,nios2-spico-elf:
+  stage: canadian
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+powerpc-unknown-linux-uclibc,m68k-unknown-uclinux-uclibc:
+  stage: canadian
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+x86_64-w64-mingw32,x86_64-pc-linux-gnu:
+  stage: canadian
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+
+
+

--- a/.gitlab-ci.yml.in
+++ b/.gitlab-ci.yml.in
@@ -1,0 +1,50 @@
+---
+stages:
+  - build
+  - keystone
+  - world
+  - canadian
+
+cache:
+  paths:
+    - src
+
+# probably worth pushing an image with the required packages to dockerhub.
+image: registry.gitlab.com/cpackham/crosstool-ng/ubuntu18.04-ct-ng-prereq:latest
+
+variables:
+  DEBIAN_FRONTEND: noninteractive
+
+# sudo is needed until this is official: https://gitlab.com/gitlab-org/gitlab-runner/issues/2750
+.do_build:
+  - &do_build
+    sudo -u ctng mkdir -p src;
+    sudo -u ctng ./ct-ng "$CI_JOB_NAME";
+    sudo -u ctng sed -i- -e '/CT_LOG_PROGRESS_BAR/s/y$/n/' .config;
+    sudo -u ctng sed -i- -e '/CT_LOCAL_TARBALLS_DIR/s/HOME/CT_TOP_DIR/' .config;
+    sudo -u ctng sed -i- -e '/CT_PREFIX_DIR/s/HOME/CT_TOP_DIR/' .config;
+    sudo -u ctng ./ct-ng build
+
+crosstool-ng:
+  stage: build
+  script:
+    - sudo -u ctng ./bootstrap
+    - sudo -u ctng ./configure --enable-local
+    - sudo -u ctng make
+  artifacts:
+    untracked: true
+
+{% for stage in ['keystone', 'world', 'canadian'] %}
+{% for config in configs[stage] %}
+{{ config }}:
+  stage: {{ stage }}
+  script:
+    - *do_build
+  artifacts:
+    when: always
+    paths:
+      - build.log
+      - .config
+{% endfor %}
+{% endfor %}
+

--- a/generate.py
+++ b/generate.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+import os
+
+from jinja2 import Environment, FileSystemLoader
+
+env = Environment(loader=FileSystemLoader('./'))
+template = env.get_template(name='.gitlab-ci.yml.in')
+
+configs = {
+        'keystone': [
+            'arm-unknown-linux-gnueabi',
+            'aarch64-unknown-linux-gnu',
+            'mips-unknown-elf',
+            'powerpc64-unknown-linux-gnu',
+            'powerpc-unknown-linux-gnu'],
+        'world': [],
+        'canadian': [],
+    }
+
+for root, _, files in os.walk('samples'):
+    if 'crosstool.config' in files:
+        config = os.path.basename(root)
+        if config in configs['keystone']:
+            continue
+
+        key = 'canadian' if ',' in config else 'world'
+        configs[key].append(config)
+
+print('# Generated file DO NOT EDIT\n')
+print(template.render(configs=configs))


### PR DESCRIPTION
This is based on earlier work done by Bryan. The actual .gitlab-ci.yml
is generated based on the .gitlab-ci.yml.in. A few configurations are
deemed to be keystone builds, if these don't build then there's no point
trying the others. The canadian builds are left for last since they take
the longest. Everything else ends up in the world stage.

I've been playing with gitlab in my own fork, this is the result. With
gitlab we do have the ability to set a project wide timeout for jobs.
I've had to set this to 2h 30m. One thing with gitlab.com is that there
is still an overall limit of 2000 minutes on build runner time. When I
finally got a configuration for a full run this is when I hit the limit
so I'm not sure how close to that limit we'd be generally.

We could probably just to the keystone builds for CI and leave the other
configurations for release time.