### PR TITLE
Allow environment override of USE_GPG/DIGESTS

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -91,8 +91,8 @@ create-symlinks:
 gen-tarball-version:
 	echo $(VERSION) > $(distdir)/.tarball-version
 
-DIGESTS		= md5 sha1 sha512
-USE_GPG		= yes
+DIGESTS		?= md5 sha1 sha512
+USE_GPG		?= yes
 
 dist-create-release: distcheck
 	for a in $(DIST_ARCHIVES); do \


### PR DESCRIPTION
... because if it is invoked via create-release.sh, it it not possible
to pass the variables to make otherwise.

Signed-off-by: Alexey Neyman <stilor@att.net>