### PR TITLE
GLIBC 2.28 milestone has a dependency

### DIFF
--- a/packages/glibc/package.desc
+++ b/packages/glibc/package.desc
@@ -3,6 +3,6 @@ repository='git git://sourceware.org/git/glibc.git'
 mirrors='$(CT_Mirrors GNU glibc)'
 # Cannot use MAJOR.MINOR as the releant part because of 2.12: 2.12.2 was the most recent
 # bugfix release, but it didn't have glibc-ports released alongside it.
-milestones='2.14 2.17 2.20 2.23 2.24 2.25 2.26 2.27 2.29 2.30'
+milestones='2.14 2.17 2.20 2.23 2.24 2.25 2.26 2.27 2.28 2.29 2.30'
 archive_formats='.tar.xz .tar.bz2 .tar.gz'
 signature_format='packed/.sig'


### PR DESCRIPTION
... but no definition after af2f3ac9c.

Signed-off-by: Alexey Neyman <stilor@att.net>