### PR TITLE
Fix bug where the backspace key didn't work in QTerminal.

### DIFF
--- a/kconfig/lxdialog/inputbox.c
+++ b/kconfig/lxdialog/inputbox.c
@@ -126,6 +126,7 @@ do_resize:
 			case KEY_DOWN:
 				break;
 			case KEY_BACKSPACE:
+			case 8:
 			case 127:
 				if (pos) {
 					wattrset(dialog, dlg.inputbox.atr);

--- a/kconfig/nconf.c
+++ b/kconfig/nconf.c
@@ -1051,7 +1051,7 @@ static int do_match(int key, struct match_state *state, int *ans)
 		state->match_direction = FIND_NEXT_MATCH_UP;
 		*ans = get_mext_match(state->pattern,
 				state->match_direction);
-	} else if (key == KEY_BACKSPACE || key == 127) {
+	} else if (key == KEY_BACKSPACE || key == 8 || key == 127) {
 		state->pattern[strlen(state->pattern)-1] = '\0';
 		adj_match_dir(&state->match_direction);
 	} else

--- a/kconfig/nconf.gui.c
+++ b/kconfig/nconf.gui.c
@@ -439,6 +439,7 @@ int dialog_inputbox(WINDOW *main_window,
 		case KEY_F(F_EXIT):
 		case KEY_F(F_BACK):
 			break;
+		case 8:
 		case 127:
 		case KEY_BACKSPACE:
 			if (cursor_position > 0) {


### PR DESCRIPTION
I was having a hard time with QTerminal, which is the default on the LXQt. I couldn't use the backspace key to remove any text in a textbox. QTerminal uses the ASCII code 0x08 for backspace, which seems to be different than the other terminals. In this PR, I simply added `case 8:` to the necessary switch statements and `|| keycode == 8` in one if block. I checked the linux kernel's Kconfig, and it already had these exact changes.