### PR TITLE
Fix CT_GDB_NATIVE_STATIC_LIBSTDCXX

### DIFF
--- a/scripts/build/debug/300-gdb.sh
+++ b/scripts/build/debug/300-gdb.sh
@@ -237,6 +237,7 @@ do_gdb_backend()
         ldflags+=" -static"
     fi
     if [ "${static_libstdcxx}" = "y" ]; then
+        ldflags+=" -static-libgcc"
         ldflags+=" -static-libstdc++"
     fi
 

--- a/scripts/build/debug/300-gdb.sh
+++ b/scripts/build/debug/300-gdb.sh
@@ -146,7 +146,7 @@ do_debug_gdb_build()
             cflags="${CT_ALL_TARGET_CFLAGS}" \
             ldflags="${CT_ALL_TARGET_LDFLAGS}" \
             static="${CT_GDB_NATIVE_STATIC}" \
-            static_libstdc="${CT_GDB_NATIVE_STATIC_LIBSTDC}" \
+            static_libstdcxx="${CT_GDB_NATIVE_STATIC_LIBSTDCXX}" \
             prefix=/usr \
             destdir="${CT_DEBUGROOT_DIR}" \
             "${native_extra_config[@]}"
@@ -236,7 +236,7 @@ do_gdb_backend()
         cflags+=" -static"
         ldflags+=" -static"
     fi
-    if [ "${static_libstdc}" = "y" ]; then
+    if [ "${static_libstdcxx}" = "y" ]; then
         ldflags+=" -static-libstdc++"
     fi
 


### PR DESCRIPTION
This series fixes the incorrect reference to the `CT_GDB_NATIVE_STATIC_LIBSTDCXX` configuration and semantically aligns it with the equivalent GCC symbol (`CT_CC_GCC_STATIC_LIBSTDCXX`).

CI run here (ignore the "cancelled" failures):
https://github.com/stephanosio/zephyr-crosstool-ng/actions/runs/115500663