### PR TITLE
Allow glibc 2.12 - 2.20 to work with GCC 10+

### DIFF
--- a/packages/glibc/2.12.1/0044-new-tools.patch
+++ b/packages/glibc/2.12.1/0044-new-tools.patch
@@ -10,7 +10,7 @@
    case $ac_prog_version in
      '') ac_prog_version="v. ?.??, bad"; ac_verc_fail=yes;;
 -    3.4* | 4.[0-9]* )
-+    3.4* | [4-9].* )
++    3.4* | [4-9].* | [1-9][0-9]* )
         ac_prog_version="$ac_prog_version, ok"; ac_verc_fail=no;;
      *) ac_prog_version="$ac_prog_version, bad"; ac_verc_fail=yes;;
  
@@ -48,7 +48,7 @@
  AC_CHECK_TOOL_PREFIX
  AC_CHECK_PROG_VER(CC, ${ac_tool_prefix}gcc ${ac_tool_prefix}cc, -v,
 -  [version \([egcygnustpi-]*[0-9.]*\)], [3.4* | 4.[0-9]* ],
-+  [version \([egcygnustpi-]*[0-9.]*\)], [3.4* | [4-9].* ],
++  [version \([egcygnustpi-]*[0-9.]*\)], [3.4* | [4-9].* | [1-9][0-9].* ],
    critic_missing="$critic_missing gcc")
  AC_CHECK_PROG_VER(MAKE, gnumake gmake make, --version,
    [GNU Make[^0-9]*\([0-9][0-9.]*\)],

--- a/packages/glibc/2.12.2/0007-new-tools.patch
+++ b/packages/glibc/2.12.2/0007-new-tools.patch
@@ -10,7 +10,7 @@
    case $ac_prog_version in
      '') ac_prog_version="v. ?.??, bad"; ac_verc_fail=yes;;
 -    3.4* | 4.[0-9]* )
-+    3.4* | [4-9].* )
++    3.4* | [4-9].* | [1-9][0-9]* )
         ac_prog_version="$ac_prog_version, ok"; ac_verc_fail=no;;
      *) ac_prog_version="$ac_prog_version, bad"; ac_verc_fail=yes;;
  
@@ -48,7 +48,7 @@
  AC_CHECK_TOOL_PREFIX
  AC_CHECK_PROG_VER(CC, ${ac_tool_prefix}gcc ${ac_tool_prefix}cc, -v,
 -  [version \([egcygnustpi-]*[0-9.]*\)], [3.4* | 4.[0-9]* ],
-+  [version \([egcygnustpi-]*[0-9.]*\)], [3.4* | [4-9].* ],
++  [version \([egcygnustpi-]*[0-9.]*\)], [3.4* | [4-9].* | [1-9][0-9].* ],
    critic_missing="$critic_missing gcc")
  AC_CHECK_PROG_VER(MAKE, gnumake gmake make, --version,
    [GNU Make[^0-9]*\([0-9][0-9.]*\)],

--- a/packages/glibc/2.13/0043-new-tools.patch
+++ b/packages/glibc/2.13/0043-new-tools.patch
@@ -10,7 +10,7 @@
    case $ac_prog_version in
      '') ac_prog_version="v. ?.??, bad"; ac_verc_fail=yes;;
 -    3.4* | 4.[0-9]* )
-+    3.4* | [4-9].* )
++    3.4* | [4-9].* | [1-9][0-9]* )
         ac_prog_version="$ac_prog_version, ok"; ac_verc_fail=no;;
      *) ac_prog_version="$ac_prog_version, bad"; ac_verc_fail=yes;;
  
@@ -48,7 +48,7 @@
  AC_CHECK_TOOL_PREFIX
  AC_CHECK_PROG_VER(CC, ${ac_tool_prefix}gcc ${ac_tool_prefix}cc, -v,
 -  [version \([egcygnustpi-]*[0-9.]*\)], [3.4* | 4.[0-9]* ],
-+  [version \([egcygnustpi-]*[0-9.]*\)], [3.4* | [4-9].* ],
++  [version \([egcygnustpi-]*[0-9.]*\)], [3.4* | [4-9].* | [1-9][0-9].* ],
    critic_missing="$critic_missing gcc")
  AC_CHECK_PROG_VER(MAKE, gnumake gmake make, --version,
    [GNU Make[^0-9]*\([0-9][0-9.]*\)],

--- a/packages/glibc/2.14.1/0043-new-tools.patch
+++ b/packages/glibc/2.14.1/0043-new-tools.patch
@@ -10,7 +10,7 @@
    case $ac_prog_version in
      '') ac_prog_version="v. ?.??, bad"; ac_verc_fail=yes;;
 -    3.4* | 4.[0-9]* )
-+    3.4* | [4-9].* )
++    3.4* | [4-9].* | [1-9][0-9]* )
         ac_prog_version="$ac_prog_version, ok"; ac_verc_fail=no;;
      *) ac_prog_version="$ac_prog_version, bad"; ac_verc_fail=yes;;
  
@@ -48,7 +48,7 @@
  AC_CHECK_TOOL_PREFIX
  AC_CHECK_PROG_VER(CC, ${ac_tool_prefix}gcc ${ac_tool_prefix}cc, -v,
 -  [version \([egcygnustpi-]*[0-9.]*\)], [3.4* | 4.[0-9]* ],
-+  [version \([egcygnustpi-]*[0-9.]*\)], [3.4* | [4-9].* ],
++  [version \([egcygnustpi-]*[0-9.]*\)], [3.4* | [4-9].* | [1-9][0-9].* ],
    critic_missing="$critic_missing gcc")
  AC_CHECK_PROG_VER(MAKE, gnumake gmake make, --version,
    [GNU Make[^0-9]*\([0-9][0-9.]*\)],

--- a/packages/glibc/2.15/0044-new-tools.patch
+++ b/packages/glibc/2.15/0044-new-tools.patch
@@ -10,7 +10,7 @@
    case $ac_prog_version in
      '') ac_prog_version="v. ?.??, bad"; ac_verc_fail=yes;;
 -    3.4* | 4.[0-9]* )
-+    3.4* | [4-9].* )
++    3.4* | [4-9].* | [1-9][0-9]* )
         ac_prog_version="$ac_prog_version, ok"; ac_verc_fail=no;;
      *) ac_prog_version="$ac_prog_version, bad"; ac_verc_fail=yes;;
  
@@ -48,7 +48,7 @@
  AC_CHECK_TOOL_PREFIX
  AC_CHECK_PROG_VER(CC, ${ac_tool_prefix}gcc ${ac_tool_prefix}cc, -v,
 -  [version \([egcygnustpi-]*[0-9.]*\)], [3.4* | 4.[0-9]* ],
-+  [version \([egcygnustpi-]*[0-9.]*\)], [3.4* | [4-9].* ],
++  [version \([egcygnustpi-]*[0-9.]*\)], [3.4* | [4-9].* | [1-9][0-9].* ],
    critic_missing="$critic_missing gcc")
  AC_CHECK_PROG_VER(MAKE, gnumake gmake make, --version,
    [GNU Make[^0-9]*\([0-9][0-9.]*\)],

--- a/packages/glibc/2.16.0/0042-fix-GCC-10-detection.patch
+++ b/packages/glibc/2.16.0/0042-fix-GCC-10-detection.patch
@@ -1,0 +1,25 @@
+From 01e89232ac76b66e2bba2ec84d7f86e86f04ae64 Mon Sep 17 00:00:00 2001
+From: Jakub Labenski <kuba@parasoft.com>
+Date: Fri, 5 Jun 2020 09:11:40 +0200
+Subject: [PATCH] Fix GCC 10+ detection
+
+---
+ configure | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure b/configure
+index aa7869ff17..2a513eae65 100755
+--- a/configure
++++ b/configure
+@@ -4782,7 +4782,7 @@ $as_echo_n "checking version of $CC... " >&6; }
+   ac_prog_version=`$CC -v 2>&1 | sed -n 's/^.*version \([egcygnustpi-]*[0-9.]*\).*$/\1/p'`
+   case $ac_prog_version in
+     '') ac_prog_version="v. ?.??, bad"; ac_verc_fail=yes;;
+-    4.[3-9].* | 4.[1-9][0-9].* | [5-9].* )
++    4.[3-9].* | 4.[1-9][0-9].* | [5-9].* | [1-9][0-9].* )
+        ac_prog_version="$ac_prog_version, ok"; ac_verc_fail=no;;
+     *) ac_prog_version="$ac_prog_version, bad"; ac_verc_fail=yes;;
+ 
+-- 
+2.25.1
+

--- a/packages/glibc/2.17/0018-fix-GCC-10-detection.patch
+++ b/packages/glibc/2.17/0018-fix-GCC-10-detection.patch
@@ -1,0 +1,25 @@
+From 760445cabb52d131b88fd81a1c1385f6b6eb1bec Mon Sep 17 00:00:00 2001
+From: Jakub Labenski <kuba@parasoft.com>
+Date: Fri, 5 Jun 2020 09:11:40 +0200
+Subject: [PATCH] Fix GCC 10+ detection
+
+---
+ configure | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure b/configure
+index 8799b7de78..0f99f04bfc 100755
+--- a/configure
++++ b/configure
+@@ -4909,7 +4909,7 @@ $as_echo_n "checking version of $CC... " >&6; }
+   ac_prog_version=`$CC -v 2>&1 | sed -n 's/^.*version \([egcygnustpi-]*[0-9.]*\).*$/\1/p'`
+   case $ac_prog_version in
+     '') ac_prog_version="v. ?.??, bad"; ac_verc_fail=yes;;
+-    4.[3-9].* | 4.[1-9][0-9].* | [5-9].* )
++    4.[3-9].* | 4.[1-9][0-9].* | [5-9].* | [1-9][0-9].* )
+        ac_prog_version="$ac_prog_version, ok"; ac_verc_fail=no;;
+     *) ac_prog_version="$ac_prog_version, bad"; ac_verc_fail=yes;;
+ 
+-- 
+2.25.1
+

--- a/packages/glibc/2.18/0019-fix-GCC-10-detection.patch
+++ b/packages/glibc/2.18/0019-fix-GCC-10-detection.patch
@@ -1,0 +1,25 @@
+From 3b16131609b2edbf29194532c089079a8d2664b1 Mon Sep 17 00:00:00 2001
+From: Jakub Labenski <kuba@parasoft.com>
+Date: Fri, 5 Jun 2020 09:11:40 +0200
+Subject: [PATCH] Fix GCC 10+ detection
+
+---
+ configure | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure b/configure
+index 1ee4c42003..4e1d1fa8a0 100755
+--- a/configure
++++ b/configure
+@@ -4709,7 +4709,7 @@ $as_echo_n "checking version of $CC... " >&6; }
+   ac_prog_version=`$CC -v 2>&1 | sed -n 's/^.*version \([egcygnustpi-]*[0-9.]*\).*$/\1/p'`
+   case $ac_prog_version in
+     '') ac_prog_version="v. ?.??, bad"; ac_verc_fail=yes;;
+-    4.[4-9].* | 4.[1-9][0-9].* | [5-9].* )
++    4.[4-9].* | 4.[1-9][0-9].* | [5-9].* | [1-9][0-9].* )
+        ac_prog_version="$ac_prog_version, ok"; ac_verc_fail=no;;
+     *) ac_prog_version="$ac_prog_version, bad"; ac_verc_fail=yes;;
+ 
+-- 
+2.25.1
+

--- a/packages/glibc/2.19/0017-fix-GCC-10-detection.patch
+++ b/packages/glibc/2.19/0017-fix-GCC-10-detection.patch
@@ -1,0 +1,25 @@
+From 0db03b80d05d059c2f98cc9fc28cce90095d0876 Mon Sep 17 00:00:00 2001
+From: Jakub Labenski <kuba@parasoft.com>
+Date: Fri, 5 Jun 2020 09:11:40 +0200
+Subject: [PATCH] Fix GCC 10+ detection
+
+---
+ configure | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure b/configure
+index fc023d0c70..b201f71b4b 100755
+--- a/configure
++++ b/configure
+@@ -4710,7 +4710,7 @@ $as_echo_n "checking version of $CC... " >&6; }
+   ac_prog_version=`$CC -v 2>&1 | sed -n 's/^.*version \([egcygnustpi-]*[0-9.]*\).*$/\1/p'`
+   case $ac_prog_version in
+     '') ac_prog_version="v. ?.??, bad"; ac_verc_fail=yes;;
+-    4.[4-9].* | 4.[1-9][0-9].* | [5-9].* )
++    4.[4-9].* | 4.[1-9][0-9].* | [5-9].* | [1-9][0-9].* )
+        ac_prog_version="$ac_prog_version, ok"; ac_verc_fail=no;;
+     *) ac_prog_version="$ac_prog_version, bad"; ac_verc_fail=yes;;
+ 
+-- 
+2.25.1
+

--- a/packages/glibc/2.20/0017-fix-GCC-10-detection.patch
+++ b/packages/glibc/2.20/0017-fix-GCC-10-detection.patch
@@ -1,0 +1,25 @@
+From 0991846fc6d5d0ef3800391bd29f2759780a3041 Mon Sep 17 00:00:00 2001
+From: Jakub Labenski <kuba@parasoft.com>
+Date: Fri, 5 Jun 2020 09:11:40 +0200
+Subject: [PATCH] Fix GCC 10+ detection
+
+---
+ configure | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure b/configure
+index 86ba30774b..b22ad9cb07 100755
+--- a/configure
++++ b/configure
+@@ -4661,7 +4661,7 @@ $as_echo_n "checking version of $CC... " >&6; }
+   ac_prog_version=`$CC -v 2>&1 | sed -n 's/^.*version \([egcygnustpi-]*[0-9.]*\).*$/\1/p'`
+   case $ac_prog_version in
+     '') ac_prog_version="v. ?.??, bad"; ac_verc_fail=yes;;
+-    4.[4-9].* | 4.[1-9][0-9].* | [5-9].* )
++    4.[4-9].* | 4.[1-9][0-9].* | [5-9].* | [1-9][0-9].* )
+        ac_prog_version="$ac_prog_version, ok"; ac_verc_fail=no;;
+     *) ac_prog_version="$ac_prog_version, bad"; ac_verc_fail=yes;;
+ 
+-- 
+2.25.1
+


### PR DESCRIPTION
Glibc version 2.20 and older do not recognize GCC 10 properly. "1" from major version is ignored
and compiler is detected as too old. 

Patch fixes detection in version 2.12.1 and up to version 2.20. It was verified
with 2.12.2 (x86 and x86_64) and 2.19 (mips64el). 