### PR TITLE
zlib-1.2.11: Add a patch to cross-compile for macos

### DIFF
--- a/packages/zlib/1.2.11/0003-crossbuild-macos-libtool.patch
+++ b/packages/zlib/1.2.11/0003-crossbuild-macos-libtool.patch
@@ -1,0 +1,34 @@
+commit 1f6bc557ec5c90eced96ae81ff1d443ee5770993
+Author: Heiko Lewin <heiko.lewin@worldiety.de>
+Date:   Fri May 22 03:32:33 2020 +0200
+
+    configure: use LIBTOOL variable for Darwin builds
+
+diff --git a/configure b/configure
+index e974d1f..0c88bf9 100755
+--- a/configure
++++ b/configure
+@@ -66,6 +66,12 @@ if "${CROSS_PREFIX}nm" --version >/dev/null 2>/dev/null || test $? -lt 126; then
+ else
+     NM=${NM-"nm"}
+ fi
++if "${CROSS_PREFIX}libtool" --version >/dev/null 2>/dev/null || test $? -lt 126; then
++    LIBTOOL=${LIBTOOL-"${CROSS_PREFIX}libtool"}
++    test -n "${CROSS_PREFIX}" && echo Using ${LIBTOOL} | tee -a configure.log
++else
++    LIBTOOL=${LIBTOOL-"libtool"}
++fi
+ 
+ # set defaults before processing command line options
+ LDCONFIG=${LDCONFIG-"ldconfig"}
+@@ -241,8 +247,8 @@ if test "$gcc" -eq 1 && ($cc -c $test.c) >> configure.log 2>&1; then
+              SHAREDLIBV=libz.$VER$shared_ext
+              SHAREDLIBM=libz.$VER1$shared_ext
+              LDSHARED=${LDSHARED-"$cc -dynamiclib -install_name $libdir/$SHAREDLIBM -compatibility_version $VER1 -current_version $VER3"}
+-             if libtool -V 2>&1 | grep Apple > /dev/null; then
+-                 AR="libtool"
++             if ${LIBTOOL} -V 2>&1 | grep Apple > /dev/null; then
++                 AR="${LIBTOOL}"
+              else
+                  AR="/usr/bin/libtool"
+              fi

--- a/scripts/crosstool-NG.sh
+++ b/scripts/crosstool-NG.sh
@@ -437,7 +437,7 @@ if [ -z "${CT_RESTART}" ]; then
             t="${!r}-"
         fi
 
-        for tool in ar as dlltool gcc g++ gcj gnatbind gnatmake ld nm objcopy objdump ranlib strip windres; do
+        for tool in ar as dlltool gcc g++ gcj gnatbind gnatmake ld libtool nm objcopy objdump ranlib strip windres; do
             # First try with prefix + suffix
             # Then try with prefix only
             # Then try with suffix only, but only for BUILD, and HOST iff REAL_BUILD == REAL_HOST


### PR DESCRIPTION
A fix for cross-build for macos

```
...
[INFO ]  Installing zlib for host
[DEBUG]    Entering '/builds/idf/crosstool-NG/.build/HOST-x86_64-apple-darwin12/xtensa-esp32-elf/build/build-zlib-host-x86_64-host_apple-darwin12'
[EXTRA]    Configuring zlib
[DEBUG]    ==> Executing:  CFLAGS='-O2 -g -pipe -I/builds/idf/crosstool-NG/.build/HOST-x86_64-apple-darwin12/xtensa-esp32-elf/buildtools/complibs-host/include  -fno-common' LDFLAGS='-L/builds/idf/crosstool-NG/.build/HOST-x86_64-apple-darwin12/xtensa-esp32-elf/buildtools/complibs-host/lib  -framework CoreFoundation' CHOST='x86_64-host_apple-darwin12' '/bin/bash' '/builds/idf/crosstool-NG/.build/HOST-x86_64-apple-darwin12/xtensa-esp32-elf/src/zlib/configure' '--prefix=/builds/idf/crosstool-NG/.build/HOST-x86_64-apple-darwin12/xtensa-esp32-elf/buildtools/complibs-host' '--static'
[CFG  ]    Using x86_64-host_apple-darwin12-ar
[CFG  ]    Using x86_64-host_apple-darwin12-ranlib
[CFG  ]    Using x86_64-host_apple-darwin12-nm
[CFG  ]    Checking for x86_64-host_apple-darwin12-gcc...
[CFG  ]    Building static library libz.a version 1.2.11 with x86_64-host_apple-darwin12-gcc.
[CFG  ]    Checking for size_t... Yes.
[CFG  ]    Checking for off64_t... No.
[CFG  ]    Checking for fseeko... Yes.
[CFG  ]    Checking for strerror... Yes.
[CFG  ]    Checking for unistd.h... Yes.
[CFG  ]    Checking for stdarg.h... Yes.
[CFG  ]    Checking whether to use vs[n]printf() or s[n]printf()... using vs[n]printf().
[CFG  ]    Checking for vsnprintf() in stdio.h... Yes.
[CFG  ]    Checking for return value of vsnprintf()... Yes.
[CFG  ]    Checking for attribute(visibility) support... Yes.
[DEBUG]    ==> Return status 0
[EXTRA]    Building zlib
[DEBUG]    ==> Executing:  'make' '-j65' '-l'
[ALL  ]    make[1]: Entering directory '/builds/idf/crosstool-NG/.build/HOST-x86_64-apple-darwin12/xtensa-esp32-elf/build/build-zlib-host-x86_64-host_apple-darwin12'
[ALL  ]    x86_64-host_apple-darwin12-gcc -O2 -g -pipe -I/builds/idf/crosstool-NG/.build/HOST-x86_64-apple-darwin12/xtensa-esp32-elf/buildtools/complibs-host/include  -fno-common -DHAVE_HIDDEN -I. -I/builds/idf/crosstool-NG/.build/HOST-x86_64-apple-darwin12/xtensa-esp32-elf/src/zlib/ -c -o example.o /builds/idf/crosstool-NG/.build/HOST-x86_64-apple-darwin12/xtensa-esp32-elf/src/zlib/test/example.c
[ALL  ]    x86_64-host_apple-darwin12-gcc -O2 -g -pipe -I/builds/idf/crosstool-NG/.build/HOST-x86_64-apple-darwin12/xtensa-esp32-elf/buildtools/complibs-host/include  -fno-common -DHAVE_HIDDEN -include zconf.h -c -o adler32.o /builds/idf/crosstool-NG/.build/HOST-x86_64-apple-darwin12/xtensa-esp32-elf/src/zlib/adler32.c
[ALL  ]    x86_64-host_apple-darwin12-gcc -O2 -g -pipe -I/builds/idf/crosstool-NG/.build/HOST-x86_64-apple-darwin12/xtensa-esp32-elf/buildtools/complibs-host/include  -fno-common -DHAVE_HIDDEN -include zconf.h -c -o crc32.o /builds/idf/crosstool-NG/.build/HOST-x86_64-apple-darwin12/xtensa-esp32-elf/src/zlib/crc32.c
[ALL  ]    x86_64-host_apple-darwin12-gcc -O2 -g -pipe -I/builds/idf/crosstool-NG/.build/HOST-x86_64-apple-darwin12/xtensa-esp32-elf/buildtools/complibs-host/include  -fno-common -DHAVE_HIDDEN -include zconf.h -c -o deflate.o /builds/idf/crosstool-NG/.build/HOST-x86_64-apple-darwin12/xtensa-esp32-elf/src/zlib/deflate.c
[ALL  ]    x86_64-host_apple-darwin12-gcc -O2 -g -pipe -I/builds/idf/crosstool-NG/.build/HOST-x86_64-apple-darwin12/xtensa-esp32-elf/buildtools/complibs-host/include  -fno-common -DHAVE_HIDDEN -include zconf.h -c -o infback.o /builds/idf/crosstool-NG/.build/HOST-x86_64-apple-darwin12/xtensa-esp32-elf/src/zlib/infback.c
[ALL  ]    x86_64-host_apple-darwin12-gcc -O2 -g -pipe -I/builds/idf/crosstool-NG/.build/HOST-x86_64-apple-darwin12/xtensa-esp32-elf/buildtools/complibs-host/include  -fno-common -DHAVE_HIDDEN -include zconf.h -c -o inffast.o /builds/idf/crosstool-NG/.build/HOST-x86_64-apple-darwin12/xtensa-esp32-elf/src/zlib/inffast.c
[ALL  ]    x86_64-host_apple-darwin12-gcc -O2 -g -pipe -I/builds/idf/crosstool-NG/.build/HOST-x86_64-apple-darwin12/xtensa-esp32-elf/buildtools/complibs-host/include  -fno-common -DHAVE_HIDDEN -include zconf.h -c -o inflate.o /builds/idf/crosstool-NG/.build/HOST-x86_64-apple-darwin12/xtensa-esp32-elf/src/zlib/inflate.c
[ALL  ]    x86_64-host_apple-darwin12-gcc -O2 -g -pipe -I/builds/idf/crosstool-NG/.build/HOST-x86_64-apple-darwin12/xtensa-esp32-elf/buildtools/complibs-host/include  -fno-common -DHAVE_HIDDEN -include zconf.h -c -o inftrees.o /builds/idf/crosstool-NG/.build/HOST-x86_64-apple-darwin12/xtensa-esp32-elf/src/zlib/inftrees.c
[ALL  ]    x86_64-host_apple-darwin12-gcc -O2 -g -pipe -I/builds/idf/crosstool-NG/.build/HOST-x86_64-apple-darwin12/xtensa-esp32-elf/buildtools/complibs-host/include  -fno-common -DHAVE_HIDDEN -include zconf.h -c -o trees.o /builds/idf/crosstool-NG/.build/HOST-x86_64-apple-darwin12/xtensa-esp32-elf/src/zlib/trees.c
[ALL  ]    x86_64-host_apple-darwin12-gcc -O2 -g -pipe -I/builds/idf/crosstool-NG/.build/HOST-x86_64-apple-darwin12/xtensa-esp32-elf/buildtools/complibs-host/include  -fno-common -DHAVE_HIDDEN -include zconf.h -c -o zutil.o /builds/idf/crosstool-NG/.build/HOST-x86_64-apple-darwin12/xtensa-esp32-elf/src/zlib/zutil.c
[ALL  ]    x86_64-host_apple-darwin12-gcc -O2 -g -pipe -I/builds/idf/crosstool-NG/.build/HOST-x86_64-apple-darwin12/xtensa-esp32-elf/buildtools/complibs-host/include  -fno-common -DHAVE_HIDDEN -include zconf.h -c -o compress.o /builds/idf/crosstool-NG/.build/HOST-x86_64-apple-darwin12/xtensa-esp32-elf/src/zlib/compress.c
[ALL  ]    x86_64-host_apple-darwin12-gcc -O2 -g -pipe -I/builds/idf/crosstool-NG/.build/HOST-x86_64-apple-darwin12/xtensa-esp32-elf/buildtools/complibs-host/include  -fno-common -DHAVE_HIDDEN -include zconf.h -c -o uncompr.o /builds/idf/crosstool-NG/.build/HOST-x86_64-apple-darwin12/xtensa-esp32-elf/src/zlib/uncompr.c
[ALL  ]    x86_64-host_apple-darwin12-gcc -O2 -g -pipe -I/builds/idf/crosstool-NG/.build/HOST-x86_64-apple-darwin12/xtensa-esp32-elf/buildtools/complibs-host/include  -fno-common -DHAVE_HIDDEN -include zconf.h -c -o gzclose.o /builds/idf/crosstool-NG/.build/HOST-x86_64-apple-darwin12/xtensa-esp32-elf/src/zlib/gzclose.c
[ALL  ]    x86_64-host_apple-darwin12-gcc -O2 -g -pipe -I/builds/idf/crosstool-NG/.build/HOST-x86_64-apple-darwin12/xtensa-esp32-elf/buildtools/complibs-host/include  -fno-common -DHAVE_HIDDEN -include zconf.h -c -o gzlib.o /builds/idf/crosstool-NG/.build/HOST-x86_64-apple-darwin12/xtensa-esp32-elf/src/zlib/gzlib.c
[ALL  ]    x86_64-host_apple-darwin12-gcc -O2 -g -pipe -I/builds/idf/crosstool-NG/.build/HOST-x86_64-apple-darwin12/xtensa-esp32-elf/buildtools/complibs-host/include  -fno-common -DHAVE_HIDDEN -include zconf.h -c -o gzread.o /builds/idf/crosstool-NG/.build/HOST-x86_64-apple-darwin12/xtensa-esp32-elf/src/zlib/gzread.c
[ALL  ]    x86_64-host_apple-darwin12-gcc -O2 -g -pipe -I/builds/idf/crosstool-NG/.build/HOST-x86_64-apple-darwin12/xtensa-esp32-elf/buildtools/complibs-host/include  -fno-common -DHAVE_HIDDEN -include zconf.h -c -o gzwrite.o /builds/idf/crosstool-NG/.build/HOST-x86_64-apple-darwin12/xtensa-esp32-elf/src/zlib/gzwrite.c
[ALL  ]    x86_64-host_apple-darwin12-gcc -O2 -g -pipe -I/builds/idf/crosstool-NG/.build/HOST-x86_64-apple-darwin12/xtensa-esp32-elf/buildtools/complibs-host/include  -fno-common -DHAVE_HIDDEN -I. -I/builds/idf/crosstool-NG/.build/HOST-x86_64-apple-darwin12/xtensa-esp32-elf/src/zlib/ -c -o minigzip.o /builds/idf/crosstool-NG/.build/HOST-x86_64-apple-darwin12/xtensa-esp32-elf/src/zlib/test/minigzip.c
[ALL  ]    /usr/bin/libtool -o libz.a adler32.o crc32.o deflate.o infback.o inffast.o inflate.o inftrees.o trees.o zutil.o compress.o uncompr.o gzclose.o gzlib.o gzread.o gzwrite.o 
[ALL  ]    libtool: unrecognized option `-o'
[ALL  ]    libtool: Try `libtool --help' for more information.
[ALL  ]    Makefile:131: recipe for target 'libz.a' failed
[ERROR]    make[1]: *** [libz.a] Error 1
[ALL  ]    make[1]: Leaving directory '/builds/idf/crosstool-NG/.build/HOST-x86_64-apple-darwin12/xtensa-esp32-elf/build/build-zlib-host-x86_64-host_apple-darwin12'
[ERROR]  
[ERROR]  >>
[ERROR]  >>  Build failed in step 'Installing zlib for host'
[ERROR]  >>        called in step '(top-level)'
[ERROR]  >>
[ERROR]  >>  Error happened in: CT_DoExecLog[scripts/functions@376]
[ERROR]  >>        called from: do_zlib_backend[scripts/build/companion_libs/050-zlib.sh@116]
[ERROR]  >>        called from: do_zlib_for_host[scripts/build/companion_libs/050-zlib.sh@58]
[ERROR]  >>        called from: do_companion_libs_for_host[scripts/build/companion_libs.sh@36]
[ERROR]  >>        called from: main[scripts/crosstool-NG.sh@695]
...
```

Pay attention for mangled tuple `CHOST='x86_64-host_apple-darwin12'` (not `x86_64-apple-darwin12`)

ref https://github.com/madler/zlib/pull/496