### PR TITLE
Remove unused variables in bootstrap

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -399,7 +399,7 @@ cmp_versions()
 {
     local v1="${1}"
     local v2="${2}"
-    local e1=0 e2=0 u1 u2 d1=0 d2=0
+    local e1=0 e2=0 d1=0 d2=0
 
     # Case-insensitive comparison
     v1="${v1^^}"
@@ -640,7 +640,6 @@ enter_version()
 enter_milestone()
 {
     local ms="${1}"
-    local cmp
 
     info[ms]=${ms}
     if [ -n "${info[ver]}" ]; then


### PR DESCRIPTION
cmp, u1, u2 seem not to be used at all.