### PR TITLE
CI: Use github actions for continous integration

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -5,7 +5,35 @@ on:
   pull_request:
 
 jobs:
-  build:
+  crosstool:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "clone"
+        uses: actions/checkout@v2
+      - name: "prereq"
+        run: |
+          sudo apt-get install -y gperf help2man libtool-bin
+      - name: "build ct-ng"
+        run: |
+          ./bootstrap
+          ./configure --prefix=$PWD/.local/
+          make
+          make install
+          tar -cf ct-ng.tar .local/
+      - name: "upload ct-ng"
+        uses: actions/upload-artifact@v2
+        with:
+          name: crosstool
+          path: ct-ng.tar
+      - name: "upload config.log"
+        uses: actions/upload-artifact@v2
+        with:
+          name: config.log
+          path: config.log
+        if: ${{ always() }}
+
+  toolchains:
+    needs: crosstool
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -18,26 +46,21 @@ jobs:
           "x86_64-multilib-linux-uclibc"
         ]
     steps:
-      - name: "clone"
-        uses: actions/checkout@v2
+      - name: "download ct-ng"
+        uses: actions/download-artifact@v2
+        with:
+          name: crosstool
+      - name: "extract ct-ng"
+        run: |
+          tar -xf ct-ng.tar
       - name: "prereq"
         run: |
           sudo apt-get install -y gperf help2man libtool-bin
-      - name: "build ct-ng"
-        run: |
-          ./bootstrap
-          ./configure --enable-local
-          make
-      - name: "upload config.log"
-        uses: actions/upload-artifact@v2
-        with:
-          name: config.log
-          path: config.log
-        if: ${{ always() }}
+          echo "::add-path::$GITHUB_WORKSPACE/.local/bin"
       - name: "build ${{ matrix.sample }}"
         run: |
           mkdir -p src
-          ./ct-ng ${{ matrix.sample }}
+          ct-ng ${{ matrix.sample }}
           sed -i -e '/CT_LOG_PROGRESS_BAR/s/y$/n/' .config
           sed -i -e '/CT_LOCAL_TARBALLS_DIR/s/HOME/CT_TOP_DIR/' .config
           sed -i -e '/CT_PREFIX_DIR/s/HOME/CT_TOP_DIR/' .config
@@ -45,7 +68,7 @@ jobs:
           sed -i -e '/CT_LOG_LEVEL_MAX/d' .config
           echo 'CT_LOG_ALL=y' >>.config
           echo 'CT_LOG_LEVEL_MAX="ALL"' >>.config
-          ./ct-ng build
+          ct-ng build
       - name: "upload log"
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -28,6 +28,12 @@ jobs:
           ./bootstrap
           ./configure --enable-local
           make
+      - name: "upload config.log"
+        uses: actions/upload-artifact@v2
+        with:
+          name: config.log
+          path: config.log
+        if: ${{ always() }}
       - name: "build ${{ matrix.sample }}"
         run: |
           mkdir -p src
@@ -40,3 +46,11 @@ jobs:
           echo 'CT_LOG_ALL=y' >>.config
           echo 'CT_LOG_LEVEL_MAX="ALL"' >>.config
           ./ct-ng build
+      - name: "upload log"
+        uses: actions/upload-artifact@v2
+        with:
+          name: "${{ matrix.sample }}.log"
+          path: |
+            build.log
+            .config
+        if: ${{ always() }}

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -22,10 +22,7 @@ jobs:
         uses: actions/checkout@v2
       - name: "prereq"
         run: |
-          sudo apt-get install -y gcc g++ gperf bison flex texinfo help2man \
-                                  make libncurses5-dev python3-dev autoconf \
-                                  automake libtool libtool-bin gawk wget bzip2 \
-                                  xz-utils unzip patch libstdc++6 rsync
+          sudo apt-get install -y gperf help2man libtool-bin
       - name: "build ct-ng"
         run: |
           ./bootstrap

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        sample: [
+          "arm-unknown-linux-gnueabi",
+          "aarch64-unknown-linux-gnu",
+          "mips-unknown-elf",
+          "powerpc64-unknown-linux-gnu",
+          "powerpc-unknown-linux-gnu",
+          "x86_64-multilib-linux-uclibc"
+        ]
+    steps:
+      - name: "clone"
+        uses: actions/checkout@v2
+      - name: "prereq"
+        run: |
+          sudo apt-get install -y gcc g++ gperf bison flex texinfo help2man \
+                                  make libncurses5-dev python3-dev autoconf \
+                                  automake libtool libtool-bin gawk wget bzip2 \
+                                  xz-utils unzip patch libstdc++6 rsync
+      - name: "build ct-ng"
+        run: |
+          ./bootstrap
+          ./configure --enable-local
+          make
+      - name: "build ${{ matrix.sample }}"
+        run: |
+          mkdir -p src
+          ./ct-ng ${{ matrix.sample }}
+          sed -i -e '/CT_LOG_PROGRESS_BAR/s/y$/n/' .config
+          sed -i -e '/CT_LOCAL_TARBALLS_DIR/s/HOME/CT_TOP_DIR/' .config
+          sed -i -e '/CT_PREFIX_DIR/s/HOME/CT_TOP_DIR/' .config
+          sed -i -e '/CT_LOG_EXTRA/d' .config
+          sed -i -e '/CT_LOG_LEVEL_MAX/d' .config
+          echo 'CT_LOG_ALL=y' >>.config
+          echo 'CT_LOG_LEVEL_MAX="ALL"' >>.config
+          ./ct-ng build


### PR DESCRIPTION
This series creates a continuous integration configuration using github actions. I've arbitrarily chosen some samples to build. I'd like to expand this to at least one of each supported architecture and hopefully we can cover off each libc variant within that.

An example of this in action can be seen here https://github.com/cpackham/crosstool-ng/actions   