### PR TITLE
glibc: Don't build with -Werror for powerpc64+glibc-2.32

### DIFF
--- a/config/libc/glibc.in
+++ b/config/libc/glibc.in
@@ -400,6 +400,7 @@ config GLIBC_SSP
 # GCC8-related fixes were only available in glibc 2.27.
 config GLIBC_ENABLE_WERROR
     bool "Enable -Werror during the build"
+    depends on !(ARCH_POWERPC && ARCH_64 && GLIBC_V_2_32)
     default y if GCC_7_or_older
     default y if GCC_8_or_later && GLIBC_2_27_or_later
     help

--- a/packages/glibc/package.desc
+++ b/packages/glibc/package.desc
@@ -3,6 +3,6 @@ repository='git git://sourceware.org/git/glibc.git'
 mirrors='$(CT_Mirrors GNU glibc)'
 # Cannot use MAJOR.MINOR as the relevant part because of 2.12: 2.12.2 was the most recent
 # bugfix release, but it didn't have glibc-ports released alongside it.
-milestones='2.14 2.17 2.20 2.23 2.24 2.25 2.26 2.27 2.28 2.29 2.30'
+milestones='2.14 2.17 2.20 2.23 2.24 2.25 2.26 2.27 2.28 2.29 2.30 2.32'
 archive_formats='.tar.xz .tar.bz2 .tar.gz'
 signature_format='packed/.sig'


### PR DESCRIPTION
When building powerpc64+glibc-2.32 we see the following error:

[ALL  ]      In file included from ../sysdeps/powerpc/powerpc32/power4/multiarch/wordcopy-ppc32.c:26,
[ALL  ]                       from ../sysdeps/powerpc/powerpc64/multiarch/wordcopy-ppc64.c:18:
[ALL  ]      ../string/wordcopy.c: In function '_wordcopy_fwd_aligned':
[ERROR]      ../string/wordcopy.c:98:26: error: 'a1' may be used uninitialized in this function [-Werror=maybe-uninitialized]
[ALL  ]         98 |       ((op_t *) dstp)[0] = a1;
[ALL  ]            |       ~~~~~~~~~~~~~~~~~~~^~~~
[ALL  ]      In file included from ../sysdeps/powerpc/powerpc64/power4/../../powerpc32/power4/memcopy.h:38,
[ALL  ]                       from ../sysdeps/powerpc/powerpc64/power4/memcopy.h:1,
[ALL  ]                       from ../string/wordcopy.c:23,
[ALL  ]                       from ../sysdeps/powerpc/powerpc32/power4/multiarch/wordcopy-ppc32.c:26,
[ALL  ]                       from ../sysdeps/powerpc/powerpc64/multiarch/wordcopy-ppc64.c:18:
[ALL  ]      ../string/wordcopy.c: In function '_wordcopy_fwd_dest_aligned':
[ERROR]      ../sysdeps/generic/memcopy.h:72:61: error: 'a3' may be used uninitialized in this function [-Werror=maybe-uninitialized]
[ALL  ]         72 | #define MERGE(w0, sh_1, w1, sh_2) (((w0) << (sh_1)) | ((w1) >> (sh_2)))
[ALL  ]            |                                                             ^~

This seems to only trigger for powerpc64. Other architectures build
cleanly. For now avoid specifying -Werror for powerpc64+glibc-2.32.

Signed-off-by: Chris Packham <judge.packham@gmail.com>