### PR TITLE
glibc: --enable-obsolete-rpc has been removed as of 2.32

### DIFF
--- a/config/libc/glibc.in
+++ b/config/libc/glibc.in
@@ -145,9 +145,10 @@ config GLIBC_NO_SPARC_V8
 # in 2.16, adding an option to enable that code. Crosstool-NG backports that code
 # to 2.14/2.15, but there is no harm in throwing this option even if that patch
 # is not applied.
+# The option and the code has finally been removed in 2.32
 config GLIBC_HAS_OBSOLETE_RPC
     def_bool y
-    depends on GLIBC_2_14_or_later
+    depends on GLIBC_2_14_or_later && !CT_GLIBC_2_32_or_later
 
 config GLIBC_EXTRA_CONFIG_ARRAY
     string


### PR DESCRIPTION
Make --enable-obsolete-rpc conditional on !CT_GLIBC_2_32_or_later as
it's been removed from that version on.

Signed-off-by: Chris Packham <judge.packham@gmail.com>