### PR TITLE
Patches: search package patches in the top package directory

### DIFF
--- a/scripts/functions
+++ b/scripts/functions
@@ -2233,6 +2233,7 @@ CT_DoExtractPatch()
     local archive ext
     local -a patch_dirs
     local bundled_patch_dir
+    local bundled_common_patch_dir
     local local_patch_dir
     local overlay
 
@@ -2307,13 +2308,14 @@ CT_DoExtractPatch()
             CT_DoExecLog ALL touch "${src_dir}/.${basename}.patching"
 
             bundled_patch_dir="${CT_LIB_DIR}/packages/${pkg_dir}"
+            bundled_common_patch_dir="${CT_LIB_DIR}/packages/${pkg_name}"
             local_patch_dir="${CT_LOCAL_PATCH_DIR}/${pkg_dir}"
 
             case "${patch_order}" in
-                bundled)        patch_dirs=("${bundled_patch_dir}");;
+                bundled)        patch_dirs=("${bundled_patch_dir}" "${bundled_common_patch_dir}");;
                 local)          patch_dirs=("${local_patch_dir}");;
-                bundled,local)  patch_dirs=("${bundled_patch_dir}" "${local_patch_dir}");;
-                local,bundled)  patch_dirs=("${local_patch_dir}" "${bundled_patch_dir}");;
+                bundled,local)  patch_dirs=("${bundled_patch_dir}" "${bundled_common_patch_dir}" "${local_patch_dir}");;
+                local,bundled)  patch_dirs=("${local_patch_dir}" "${bundled_patch_dir}" "${bundled_common_patch_dir}");;
                 none)           patch_dirs=;;
             esac
 


### PR DESCRIPTION
Before patches for specific package were searched in packages/${pkg_name}/${version}. This means that with usage of custom
version, patches wont be applied. This commit makes ct-ng search bundled patches also in packages/${pkg_name} directory. That means that we can put some patches in this directory, that will be applied to any version of this component.

This change is useful for development purposes when you build toolchain from custom sources and you need some patches to be applied, so you can put required patches in the top package directory. 