### PR TITLE
Picolibc for more than just arm

### DIFF
--- a/scripts/build/arch/powerpc.sh
+++ b/scripts/build/arch/powerpc.sh
@@ -7,12 +7,12 @@ CT_DoArchTupleValues () {
     # Only override values when ABI is not the default
     case "${CT_ARCH_powerpc_ABI}" in
         eabi)
-            # EABI is only for bare-metal, so libc ∈ [none,newlib]
+            # EABI is only for bare-metal, so libc ∈ [none,newlib,picolibc]
             CT_TARGET_SYS="eabi"
             ;;
         spe)
             case "${CT_LIBC}" in
-                none|newlib)    CT_TARGET_SYS="elfspe";;
+                none|newlib|picolibc)    CT_TARGET_SYS="elfspe";;
                 *glibc)         CT_TARGET_SYS="gnuspe";;
                 uClibc)         CT_TARGET_SYS="uclibcgnuspe";;
             esac

--- a/scripts/build/libc/picolibc.sh
+++ b/scripts/build/libc/picolibc.sh
@@ -22,7 +22,7 @@ picolibc_main()
 
     CT_mkdir_pushd "${CT_BUILD_DIR}/build-libc"
 
-    CT_DoLog EXTRA "Configuring C library"
+    CT_DoLog EXTRA "Configuring Picolibc library"
 
     # Multilib is the default, so if it is not enabled, disable it.
     if [ "${CT_MULTILIB}" != "y" ]; then
@@ -81,10 +81,10 @@ as = '${CT_TARGET}-as'
 strip = '${CT_TARGET}-strip'
 
 [host_machine]
-system = 'none'
-cpu_family = 'arm'
-cpu = 'arm'
-endian = 'little'
+system = '${CT_TARGET_VENDOR}'
+cpu_family = '${CT_TARGET_ARCH}'
+cpu = '${CT_TARGET_ARCH}'
+endian = '${CT_ARCH_ENDIAN}'
 
 [properties]
 c_args = [ ${meson_cflags} '-nostdlib', '-fno-common', '-ftls-model=local-exec' ]

--- a/scripts/functions
+++ b/scripts/functions
@@ -1135,7 +1135,7 @@ CT_DoBuildTargetTuple()
         uClibc)      CT_TARGET_SYS=uclibc;;
         musl)        CT_TARGET_SYS=musl;;
         bionic)      CT_TARGET_SYS=android;;
-        none|newlib) CT_TARGET_SYS=elf;;
+        none|newlib|picolibc) CT_TARGET_SYS=elf;;
         *)
             # Keep empty for the libraries like mingw or avr-libc
             CT_TARGET_SYS=


### PR DESCRIPTION
I missed a couple of changes required to build crosstool-ng for targets other than 32-bit ARM. 

 1. Make non-arm architectures use the same CT_TARGET_SYS value as is used for newlib (generally 'elf').
 2. Use selected architecture values when configuring the meson cross-compile environment for picolibc.