### PR TITLE
glibc: fix version 2.32 not setting correct version string

### DIFF
--- a/packages/glibc/2.32/0001-Set-version.h-RELEASE-to-stable-Bug-26700.patch
+++ b/packages/glibc/2.32/0001-Set-version.h-RELEASE-to-stable-Bug-26700.patch
@@ -1,0 +1,26 @@
+From 23482f788665df83edc8b542698f45fed45a2711 Mon Sep 17 00:00:00 2001
+From: Carlos O'Donell <carlos@redhat.com>
+Date: Fri, 2 Oct 2020 09:23:35 -0400
+Subject: [PATCH] Set version.h RELEASE to "stable" (Bug 26700)
+
+The RELEASE macro was accidentaly set to "release" instead of
+the expected "stable" by the release manager.  This is a mistake
+that leads to the build using "-g -O1" instead of "-g -O2" if
+configure was executed with "CFLAGS=" (CFLAGS set but empty).
+---
+ version.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/version.h b/version.h
+index 83cd196798..e6ca7a8857 100644
+--- a/version.h
++++ b/version.h
+@@ -1,4 +1,4 @@
+ /* This file just defines the current version number of libc.  */
+ 
+-#define RELEASE "release"
++#define RELEASE "stable"
+ #define VERSION "2.32"
+-- 
+2.25.1
+

--- a/scripts/build/libc/glibc.sh
+++ b/scripts/build/libc/glibc.sh
@@ -314,6 +314,8 @@ glibc_backend_once()
             ;;
     esac
 
+    # Make sure glibc build system respects our provided CFLAGS.
+    extra_make_args+=( default_cflags= )
     extra_make_args+=( "BUILD_CFLAGS=${build_cflags}" )
     extra_make_args+=( "BUILD_CPPFLAGS=${build_cppflags}" )
     extra_make_args+=( "BUILD_LDFLAGS=${build_ldflags}" )


### PR DESCRIPTION
Backport change from glibc upstream that defines RELEASE as stable
instead of release. This will at least cause the default_cflags to be
set to expected default values again.

Ref issue #1396, although the bigger issue of respecting crosstool-ng
CT_GLIBC_EXTRA_CFLAGS is most likely still not fixed.