### PR TITLE
Don't unconditionally disable XLOCALE support.

### DIFF
--- a/scripts/build/libc/uClibc.sh
+++ b/scripts/build/libc/uClibc.sh
@@ -303,7 +303,6 @@ manage_uClibc_config()
             CT_KconfigEnableOption "UCLIBC_HAS_LOCALE" "${dst}"
             CT_KconfigDeleteOption "UCLIBC_PREGENERATED_LOCALE_DATA" "${dst}"
             CT_KconfigDeleteOption "UCLIBC_DOWNLOAD_PREGENERATED_LOCALE_DATA" "${dst}"
-            CT_KconfigDeleteOption "UCLIBC_HAS_XLOCALE" "${dst}"
     fi
 
     # WCHAR support


### PR DESCRIPTION
Using a custom config for uClibc-ng I wanted to enable XLOCALE but found out it is being unconditionally disabled regardless.

Signed-off-by: Lance Fredrickson <lancethepants@gmail.com>