### PR TITLE
Clarify tree layout of local patches directory

### DIFF
--- a/config/global/extract.in
+++ b/config/global/extract.in
@@ -107,5 +107,7 @@ config LOCAL_PATCH_DIR
     help
       Enter the custom patch directory here.
       
-      Note that you must ensure that the directory containing your custom
-      patches is arranged the same way the official directory is.
+      Note that you must ensure that tree layout of the directory containing
+      your custom patches match the bundled patches one. For example, if you
+      have custom GCC patches for <gcc-version>, place them under
+      $LOCAL_PATCH_DIR/gcc/<gcc-version>.


### PR DESCRIPTION
Currently the help for LOCAL_PATCH_DIR did not specify the tree layout
of custom patches directory. This commit adds such explanation.

For example, the bundled patches for GCC are placed under
packages/gcc/<gcc-version>, thus custom (local) GCC patches should be
placed under $LOCAL_PATCH_DIR/gcc/<gcc-version>.

Signed-off-by: Bagas Sanjaya <bagasdotme@gmail.com>