### PR TITLE
binutils: Disable glob for better portability

### DIFF
--- a/scripts/build/binutils/binutils.sh
+++ b/scripts/build/binutils/binutils.sh
@@ -177,6 +177,10 @@ do_binutils_backend() {
 
     [ "${CT_TOOLCHAIN_ENABLE_NLS}" != "y" ] && extra_config+=("--disable-nls")
 
+    # Disable usage of glob for higher compatibility.
+    # Not strictly needed for anything but GDB anyways.
+    export ac_cv_func_glob=no
+
     CT_DoLog DEBUG "Extra config passed: '${extra_config[*]}'"
 
     CT_DoExecLog CFG                                            \


### PR DESCRIPTION
Since glibc 2.27 glob interface was changed [1]  and so "glob" & "glob64" symbols require glibc 2.27+.

For us that means if we build Binutils on a machine with glibc 2.27+ produced binaries won't be any longer usable on machines with older glibc.

As an example [2]: build on Ubuntu 18.04 (with glibc 2.27) and try to run on CentOS 7.x (with glibc 2.17), you'll see this:
```
$ ldd ld
ld: /lib64/libc.so.6: version `GLIBC_2.27' not found (required by ld)
```

Now given glob is not really used by Binutils itself (only needed by GDB) and we build Binutils & GDB separately let's make at least Binutils more portable.

In theory we may even try to do the same hack for GDB forcing it to use imported glob implementation. But since GDB is now built strictly by C++ compiler we'll get waaay to many incompatibilities due to multiple changes of C++ ABI in between GCC 7.5 of Ubuntu 18.04 and GCC 4.8.5 of CentOS 7.x, so there's no point to even try.

[1] https://sourceware.org/git/?p=glibc.git;a=commit;h=ccf970c7a77e86f4f5ef8ecc5e637114b1c0136a
[2] https://github.com/zephyrproject-rtos/sdk-ng/issues/280