### PR TITLE
arm: Disable context functions for Thumb

### DIFF
--- a/scripts/build/arch/arm.sh
+++ b/scripts/build/arch/arm.sh
@@ -70,6 +70,7 @@ CT_DoArchUClibcConfig() {
                 ;;
             thumb)
                 CT_KconfigEnableOption "COMPILE_IN_THUMB_MODE" "${cfg}"
+                CT_KconfigDisableOption "UCLIBC_HAS_CONTEXT_FUNCS" "${cfg}"
                 ;;
         esac
         # FIXME: CONFIG_ARM_OABI does not exist in neither uClibc/uClibc-ng


### PR DESCRIPTION
Similar to commit 57679b5e ("Disable context functions for Thumb") when
building for thumb we need to unset UCLIBC_HAS_CONTEXT_FUNCS.

Fixes #1397

Signed-off-by: Chris Packham <judge.packham@gmail.com>