### PR TITLE
CI: Replace add-path command

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -67,7 +67,7 @@ jobs:
       - name: "prereq"
         run: |
           sudo apt-get install -y gperf help2man libtool-bin
-          echo "::add-path::$GITHUB_WORKSPACE/.local/bin"
+          echo "$GITHUB_WORKSPACE/.local/bin" >> $GITHUB_PATH
       - name: "build ${{ matrix.sample }}"
         run: |
           mkdir -p src


### PR DESCRIPTION
The add-path and set-env commands are being deprecated[1]. Replace the
one instance of add-path in the CI workflow with the recommended
alternative[2].

[1] - https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
[2] - https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#adding-a-system-path

Signed-off-by: Chris Packham <judge.packham@gmail.com>