### PR TITLE
gcc: Additional build fix for building arm64 toolchain on M1 Mac's

### DIFF
--- a/packages/gcc/10.2.0/0022-aarch64-fix-conflicting-declarations.patch
+++ b/packages/gcc/10.2.0/0022-aarch64-fix-conflicting-declarations.patch
@@ -1,0 +1,33 @@
+From 3c1f316323f41ad02ee834278031a1cbcfdaa96b Mon Sep 17 00:00:00 2001
+From: Andreas Schwab <schwab@suse.de>
+Date: Mon, 4 May 2020 17:29:11 +0200
+Subject: [PATCH] aarch64: fix conflicting declarations
+
+aarch64_get_extension_string_for_isa_flags is declared in
+"aarch64-protos.h", use that instead of re-declaring it improperly.
+
+	* config/aarch64/driver-aarch64.c: Include "aarch64-protos.h".
+	(aarch64_get_extension_string_for_isa_flags): Don't declare.
+---
+ gcc/config/aarch64/driver-aarch64.c | 5 +----
+ 1 file changed, 1 insertion(+), 4 deletions(-)
+
+diff --git a/gcc/config/aarch64/driver-aarch64.c b/gcc/config/aarch64/driver-aarch64.c
+index 0ccd200e330..d1229e67680 100644
+--- a/gcc/config/aarch64/driver-aarch64.c
++++ b/gcc/config/aarch64/driver-aarch64.c
+@@ -24,10 +24,7 @@
+ #include "system.h"
+ #include "coretypes.h"
+ #include "tm.h"
+-
+-/* Defined in common/config/aarch64/aarch64-common.c.  */
+-std::string aarch64_get_extension_string_for_isa_flags (unsigned long,
+-							unsigned long);
++#include "aarch64-protos.h"
+ 
+ struct aarch64_arch_extension
+ {
+-- 
+2.28.0
+


### PR DESCRIPTION
If we are targetting an aarch64-none-elf toolchain we end up running
into a build issue in gcc/config/aarch64/driver-aarch64.c.  This is
fixed in upstream gcc so just backport the patch to gcc-10.2.0

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>