### PR TITLE
packages/ncurses: update ncurses mirror

### DIFF
--- a/packages/ncurses/package.desc
+++ b/packages/ncurses/package.desc
@@ -1,4 +1,4 @@
 # No public repository for ncurses
-mirrors='ftp://invisible-island.net/ncurses $(CT_Mirrors GNU ncurses)'
+mirrors='https://invisible-mirror.net/archives/ncurses $(CT_Mirrors GNU ncurses)'
 archive_formats='.tar.gz'
 signature_format='packed/.sig'


### PR DESCRIPTION
ftp://invisible-island.net/ncurses doesn't actually have the numbered
ncurses tarball. We've not noticed because we fall back to using the GNU
mirror which does. It's also ftp which is being deprecated.

Switch to https://invisible-mirror.net/archives/ncurses which has the
actual tarballs and provides a secure connection.

Signed-off-by: Chris Packham <judge.packham@gmail.com>