### PR TITLE
gcc: Make it aware of Newlib nano IO feature

### DIFF
--- a/scripts/build/cc/gcc.sh
+++ b/scripts/build/cc/gcc.sh
@@ -361,6 +361,11 @@ do_gcc_core_backend() {
     [ -n "${CT_PKGVERSION}" ] && extra_config+=("--with-pkgversion=${CT_PKGVERSION}")
     [ -n "${CT_TOOLCHAIN_BUGURL}" ] && extra_config+=("--with-bugurl=${CT_TOOLCHAIN_BUGURL}")
 
+    # Hint GCC we'll use a bit special version of Newlib
+    if [ "${CT_LIBC_NEWLIB_NANO_FORMATTED_IO}" = "y" ]; then
+        extra_config+=("--enable-newlib-nano-formatted-io")
+    fi
+
     if [ "${CT_CC_CXA_ATEXIT}" = "y" ]; then
         extra_config+=("--enable-__cxa_atexit")
     else


### PR DESCRIPTION
Even though GCC as a compiler has nothing to do with a C library being used it still makes sense to know about Newlib's compact implementation of IO functions:

 * For targets like MSP430 which require to have such a tuned Newlib if `-mtiny-printf` is passed to the GCC's command-line (see https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=02afb6a9321fbfb435452636cedc2cd43f0c4fd2).

 * For correct compilation of the following GCC's own DejaGnu tests (see https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=571bbd0d48d5872eacbd0b681fce6e1ae754520b):
     - gcc/testsuite/gcc.c-torture/execute/920501-8.c
     - gcc/testsuite/gcc.c-torture/execute/930513-1.c
     - gcc/testsuite/gcc.dg/torture/builtin-sprintf.c
     - gcc/testsuite/gcc.c-torture/execute/ieee/920810-1.x

So we add that missing cross-dependency now.