### PR TITLE
libgmp: Fix cross-canadian build for macOS

### DIFF
--- a/scripts/build/companion_libs/100-gmp.sh
+++ b/scripts/build/companion_libs/100-gmp.sh
@@ -87,6 +87,15 @@ do_gmp_backend() {
         extra_config+=("--enable-mpbsd")
     fi
 
+    # To avoind “illegal text-relocation” linking error against
+    # the static library, see:
+    #     https://github.com/Homebrew/homebrew-core/pull/25470
+    case "${host}" in
+        *darwin*)
+            extra_config+=("--with-pic")
+            ;;
+    esac
+
     # FIXME: GMP's configure script doesn't respect the host parameter
     # when not cross-compiling, ie when build == host.
     CT_DoExecLog CFG                                \


### PR DESCRIPTION
Currently when building cross-canadian toolchain for macOS the folowing error happens when GCC is configured:
```
ld: illegal text-relocation to '___gmp_binvert_limb_table' in
... /.build/... /buildtools/complibs-host/lib/libgmp.a(mp_minv_tab.o) from '___gmpn_divexact_1' in
... /.build/... /buildtools/complibs-host/lib/libgmp.a(dive_1.o)
collect2: error: ld returned 1 exit status
```

Apparently this might be solved with GMP configured with `--with-pic`, even though we're talking about static library here.

That solution was found here: https://github.com/Homebrew/homebrew-core/pull/25470