### PR TITLE
Add patch to work round missing mips ld command line flags

### DIFF
--- a/packages/binutils/2.35.1/0011-mips-fix-missing-emulations.patch
+++ b/packages/binutils/2.35.1/0011-mips-fix-missing-emulations.patch
@@ -1,0 +1,13 @@
+--- a/ld/ldmain.c	2021-01-09 16:47:26.109063089 +0000
++++ b/ld/ldmain.c	2021-01-09 16:44:00.426128832 +0000
+@@ -700,6 +700,9 @@
+ 		   || strcmp (argv[i], "-mips5") == 0
+ 		   || strcmp (argv[i], "-mips32") == 0
+ 		   || strcmp (argv[i], "-mips32r2") == 0
++		   || strcmp (argv[i], "-mips32r3") == 0
++		   || strcmp (argv[i], "-mips32r4") == 0
++		   || strcmp (argv[i], "-mips32r5") == 0
+ 		   || strcmp (argv[i], "-mips32r6") == 0
+ 		   || strcmp (argv[i], "-mips64") == 0
+ 		   || strcmp (argv[i], "-mips64r2") == 0
+


### PR DESCRIPTION
Signed-off-by: Matt Jenkins <matt@majenko.co.uk>

The GCC compiler passes `-mips<level>` to `ld` erroneously.  `ld` has *some* code to ignore those flags, but misses some of the more modern ones. This simply adds those extra flags into `ld`. Of course, better would be to try and get these changes in to the `binutils` upstream, but here is easier to get a "quick fix" in place.