### PR TITLE
CI: add arm-unknown-linux-musleabi configuration

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -65,6 +65,7 @@ jobs:
           "arc-multilib-linux-uclibc",
           "arm-picolibc-eabi",
           "arm-unknown-linux-gnueabi",
+          "arm-unknown-linux-musleabi",
           "armv6-nommu-linux-uclibcgnueabi",
           "mips-unknown-elf",
           "mips64-unknown-linux-gnu",


### PR DESCRIPTION
Add a configuration that includes musl libc.

Signed-off-by: Chris Packham <judge.packham@gmail.com>