### PR TITLE
Make `ct-ng oldconfig` work again after kconfig updating

### DIFF
--- a/ct-ng.in
+++ b/ct-ng.in
@@ -129,7 +129,7 @@ menuconfig nconfig: check-config
 oldconfig: .config check-config
 	@$(CT_ECHO) "  CONF  $@"
 	@$(bash) $(CT_LIB_DIR)/scripts/version-check.sh .config
-	$(SILENT)$(CONF) --silent$@ $(KCONFIG_TOP)
+	$(SILENT)$(CONF) --syncconfig $(KCONFIG_TOP)
 
 olddefconfig: .config check-config
 	@$(CT_ECHO) "  CONF  $@"


### PR DESCRIPTION
When I do `./ct-ng oldconfig` (mater branch) I'm getting 

```
  CONF  oldconfig
crosstool-NG/kconfig/conf: unrecognized option '--silentoldconfig'
See README for usage info
make: *** [oldconfig] Error 1
ct-ng:130: recipe for target 'oldconfig' failed
```
I found that the cause is https://github.com/crosstool-ng/crosstool-ng/commit/689dc60f212db105243b60290480f29475578e0d

I propose this fix.