### PR TITLE
CI: build sh-unknown-elf instead of sh-multilib-linux-gnu

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -74,7 +74,7 @@ jobs:
           "riscv32-unknown-elf",
           "riscv64-unknown-elf",
           "s390-unknown-linux-gnu",
-          "sh-multilib-linux-gnu",
+          "sh-unknown-elf",
           "sparc-unknown-linux-gnu",
           "x86_64-unknown-linux-gnu",
           "x86_64-multilib-linux-uclibc",


### PR DESCRIPTION
sh-multilib-linux-gnu ends up building 8 different libcs. This seems to
be problematic for the github hosted runners as it appears to run them
out of disk space (anecdotally this seems to have gotten worse with the
switch from ubuntu-18.04 to ubuntu-20.04).

Build sh-unknown-elf instead to make sure we cover of the sh
architecture to some degree.

Signed-off-by: Chris Packham <judge.packham@gmail.com>