### PR TITLE
Fix depends generation with absolute paths

### DIFF
--- a/packages/gcc/10.2.0/0025-preprocessor-Make-quoting-PR-95253.patch
+++ b/packages/gcc/10.2.0/0025-preprocessor-Make-quoting-PR-95253.patch
@@ -1,0 +1,29 @@
+From 1ba71fabb78b18884e9f479f45a257bab50e8959 Mon Sep 17 00:00:00 2001
+From: Nathan Sidwell <nathan@acm.org>
+Date: Fri, 15 Jan 2021 06:47:13 -0800
+Subject: [PATCH] preprocessor: Make quoting : [PR 95253]
+
+Make doesn't need ':' quoting (in a filename).
+
+	PR preprocessor/95253
+	libcpp/
+	* mkdeps.c (munge): Do not escape ':'.
+---
+ libcpp/mkdeps.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/libcpp/mkdeps.c b/libcpp/mkdeps.c
+index 471e449a19d..1867e0089d7 100644
+--- a/libcpp/mkdeps.c
++++ b/libcpp/mkdeps.c
+@@ -162,7 +162,6 @@ munge (const char *str, const char *trail = nullptr)
+ 	      /* FALLTHROUGH  */
+ 
+ 	    case '#':
+-	    case ':':
+ 	      buf[dst++] = '\\';
+ 	      /* FALLTHROUGH  */
+ 
+-- 
+2.29.2.windows.2
+


### PR DESCRIPTION
Backport gcc commit: https://github.com/gcc-mirror/gcc/commit/1ba71fabb78b18884e9f479f45a257bab50e8959#diff-01d4a2754612370f4a498e10fb94692e0c7e4e9ea1e04fcf7d29c8037d81bb5b 

Here is how it fails without this commit: https://stackoverflow.com/questions/61729611/cmake-mingw-w64-strange-error-when-trying-to-build

The issue is because gcc echoed ':' sign in Windows file paths.