### PR TITLE
gdb: Don't mess with gdbserver config permissions

### DIFF
--- a/scripts/build/debug/300-gdb.sh
+++ b/scripts/build/debug/300-gdb.sh
@@ -8,11 +8,6 @@ do_debug_gdb_get()
 do_debug_gdb_extract()
 {
     CT_ExtractPatch GDB
-
-    # Workaround for bad versions, where the configure
-    # script for gdbserver is not executable...
-    # Bah, GNU folks strike again... :-(
-    chmod a+x "${CT_SRC_DIR}/gdb/gdb/gdbserver/configure"
 }
 
 do_debug_gdb_build()


### PR DESCRIPTION
Note, this is more of precautious "fix", though I'd say pretty meaningful: why touching something we're not going to really use.

Now, w/o that fix it's not possible to build even host/target GDB out of GDB v10.x sources. To get gdbserver built in v10.x we'll
need to do much more (see https://sourceware.org/git/?p=binutils-gdb.git;a=commit;h=919adfe8409211c726c1d05b47ca59890ee648f1) as source structure was changed (gdbserver was "promoted" to the top-level, see https://github.com/abrodkin/crosstool-ng/commit/2f9b431228c58fe98704a72390672942935ac8e3).

Yet host or target GDB could be nicely built of v10.x sources just with that one-liner fix.