### PR TITLE
ltrace: Add patch to fix compile error for mips

### DIFF
--- a/packages/ltrace/0.7.3/0008-mips-printf-format.patch
+++ b/packages/ltrace/0.7.3/0008-mips-printf-format.patch
@@ -1,0 +1,14 @@
+diff -Naur ltrace-0.7.3-orig/sysdeps/linux-gnu/mips/plt.c ltrace-0.7.3/sysdeps/linux-gnu/mips/plt.c
+--- ltrace-0.7.3-orig/sysdeps/linux-gnu/mips/plt.c	2013-09-17 11:04:28.000000000 +1200
++++ ltrace-0.7.3/sysdeps/linux-gnu/mips/plt.c	2021-04-14 22:05:45.950413823 +1200
+@@ -356,8 +356,8 @@
+ 
+ 	name = strdup(a_name);
+ 	if (name == NULL) {
+-		fprintf(stderr, "%s: failed %s(%#llx): %s\n", __func__,
+-			name, addr, strerror(errno));
++		fprintf(stderr, "%s: failed (%#llx): %s\n", __func__,
++			addr, strerror(errno));
+ 		goto fail;
+ 	}
+ 


### PR DESCRIPTION
Newer versions of GCC complain:

  plt.c: In function 'arch_elf_add_plt_entry':
  plt.c:359:3: error: '%s' directive argument is null [-Werror=format-overflow=]
    359 |   fprintf(stderr, "%s: failed %s(%#llx): %sn", __func__,
        | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    360 |    name, addr, strerror(errno));
        |    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  cc1: all warnings being treated as errors

add a patch to avoid this error.

Signed-off-by: Chris Packham <judge.packham@gmail.com>