### PR TITLE
newlib-nano: Use run-time calculated paths in top-level nano.specs

### DIFF
--- a/scripts/build/companion_libs/350-newlib_nano.sh
+++ b/scripts/build/companion_libs/350-newlib_nano.sh
@@ -199,13 +199,13 @@ ENABLE_TARGET_OPTSPACE:target-optspace
 %rename cc1plus	newlib_nano_cc1plus
 
 *cpp:
--isystem ${CT_PREFIX_DIR}/newlib-nano/${CT_TARGET}/include %(newlib_nano_cpp)
+-isystem %:getenv(GCC_EXEC_PREFIX ../../newlib-nano/${CT_TARGET}/include) %(newlib_nano_cpp)
 
 *cc1plus:
--idirafter ${CT_PREFIX_DIR}/newlib-nano/${CT_TARGET}/include %(newlib_nano_cc1plus)  
+-idirafter %:getenv(GCC_EXEC_PREFIX ../../newlib-nano/${CT_TARGET}/include) %(newlib_nano_cc1plus)
 
 *link:
--L${CT_PREFIX_DIR}/newlib-nano/${CT_TARGET}/lib/%M -L${CT_PREFIX_DIR}/newlib-nano/${CT_TARGET}/lib
+-L%:getenv(GCC_EXEC_PREFIX ../../newlib-nano/${CT_TARGET}/lib/%M) -L%:getenv(GCC_EXEC_PREFIX ../../newlib-nano/${CT_TARGET}/lib)
 
 EOF
 


### PR DESCRIPTION
In currently generated top-level `nano.specs` we resolve paths during toolchain building and then use those pre-defined
full paths once the toolchain got built.

That's OK until the toolchain is used right where it was built, otherwise paths used in the top-level `nano.specs` become irrelevant and linker fails to find "nano" libs reverting to non-"nano" libs in the default location.

See https://github.com/crosstool-ng/crosstool-ng/issues/1491.