### PR TITLE
scripts/functions: Add better support for annotanted git tags

### DIFF
--- a/scripts/functions
+++ b/scripts/functions
@@ -1951,8 +1951,14 @@ CT_GetVersion_git()
     local branch="${devel_branch:-master}"
 
     if [ -z "${devel_revision}" ]; then
-        local matches=`git ls-remote --exit-code "${devel_url}" --refs "${branch}" \
+        # First try to dereference an annotated tag.
+        local matches=`git ls-remote --exit-code "${devel_url}" --refs "${branch}^{}" \
             || echo "not found"`
+        # If we don't have an annotated tag, let's take the reference as is.
+        if [ "${matches}" = "not found" ]; then
+            matches=`git ls-remote --exit-code "${devel_url}" --refs "${branch}" \
+                || echo "not found"`
+        fi
         local best using ref
 
         # Cannot test $?, setting a trap on ERR prevents bash from returning the


### PR DESCRIPTION
Annotated git tags are git objects with their own ID.
They contain the commit ID where they point to.

When downloading from annotated tags, we currently get the following warning:
  "Revision being fetched changed to ${new_unique_id};"
The old unique_id is the ID of the annotated tag and the new unique_id
is the commit it points to.

Let's resolve this by first assuming to have an annotated tag and let
git ls-remote dereference it. If that fails (e.g. if it can't be
dereferenced because it is not an annotated tag), then let's proceed as
before and don't do any dereferencing.

Signed-off-by: Christoph Muellner <cmuellner@linux.com>