### PR TITLE
Fix libstdc++ build options

### DIFF
--- a/config/comp_libs/newlib-nano.in
+++ b/config/comp_libs/newlib-nano.in
@@ -18,6 +18,14 @@ config NEWLIB_NANO_GCC_LIBSTDCXX
       This option compiles an additional target libstdc++ for use with
       newlib-nano.
 
+config NEWLIB_NANO_GCC_LIBSTDCXX_TARGET_CXXFLAGS
+    string
+    prompt "Target CXXFLAGS for libstdc++ newlib-nano variant"
+    default "-fno-exceptions"
+    help
+      Used to add extra CXXFLAGS when compiling the target libstdc++
+      newlib-nano library (e.g. -fno-exceptions).
+
 config NEWLIB_NANO_INSTALL_IN_TARGET
     bool
     prompt "Additionally install newlib-nano libs into TARGET dir"

--- a/scripts/build/cc/gcc.sh
+++ b/scripts/build/cc/gcc.sh
@@ -608,6 +608,9 @@ do_gcc_core_backend() {
         cflags_for_target="${cflags_for_target} -idirafter ${CT_HEADERS_DIR}"
     fi
 
+    # Assume '-O2' by default for building target libraries.
+    cflags_for_target="-g -O2 ${cflags_for_target}"
+
     # Use --with-local-prefix so older gccs don't look in /usr/local (http://gcc.gnu.org/PR10532).
     # Pass only user-specified CFLAGS/LDFLAGS in CFLAGS_FOR_TARGET/LDFLAGS_FOR_TARGET: during
     # the build of, for example, libatomic, GCC tried to compile multiple variants for runtime
@@ -936,6 +939,7 @@ do_gcc_backend() {
     local lang_list
     local cflags
     local cflags_for_build
+    local cflags_for_target
     local ldflags
     local build_manuals
     local exec_prefix
@@ -1200,8 +1204,9 @@ do_gcc_backend() {
 
     CT_DoLog DEBUG "Extra config passed: '${extra_config[*]}'"
 
-    # We may need to modify host/build CFLAGS separately below
+    # We may need to modify host/build/target CFLAGS separately below
     cflags_for_build="${cflags}"
+    cflags_for_target="${CT_TARGET_CFLAGS}"
 
     # Clang's default bracket-depth is 256, and building GCC
     # requires somewhere between 257 and 512.
@@ -1217,6 +1222,9 @@ do_gcc_backend() {
         fi
     fi
 
+    # Assume '-O2' by default for building target libraries.
+    cflags_for_target="-g -O2 ${cflags_for_target}"
+
     # NB: not using CT_ALL_TARGET_CFLAGS/CT_ALL_TARGET_LDFLAGS here!
     # See do_gcc_core_backend for explanation.
     CT_DoExecLog CFG                                   \
@@ -1226,8 +1234,8 @@ do_gcc_backend() {
     CXXFLAGS="${cflags}"                               \
     CXXFLAGS_FOR_BUILD="${cflags_for_build}"           \
     LDFLAGS="${final_LDFLAGS[*]}"                      \
-    CFLAGS_FOR_TARGET="${CT_TARGET_CFLAGS}"            \
-    CXXFLAGS_FOR_TARGET="${CT_TARGET_CFLAGS}"          \
+    CFLAGS_FOR_TARGET="${cflags_for_target}"           \
+    CXXFLAGS_FOR_TARGET="${cflags_for_target}"         \
     LDFLAGS_FOR_TARGET="${CT_TARGET_LDFLAGS}"          \
     ${CONFIG_SHELL}                                    \
     "${CT_SRC_DIR}/gcc/configure"                      \

--- a/scripts/build/cc/gcc.sh
+++ b/scripts/build/cc/gcc.sh
@@ -295,7 +295,8 @@ do_gcc_core_backend() {
     local enable_optspace
     local complibs
     local lang_list
-    local cflags cflags_for_build cflags_for_target
+    local cflags cflags_for_build cflags_for_target cxxflags_for_target
+    local extra_cxxflags_for_target
     local ldflags
     local build_step
     local log_txt
@@ -611,6 +612,16 @@ do_gcc_core_backend() {
     # Assume '-O2' by default for building target libraries.
     cflags_for_target="-g -O2 ${cflags_for_target}"
 
+    # Set target CXXFLAGS to CFLAGS if none is provided.
+    if [ -z "${cxxflags_for_target}" ]; then
+        cxxflags_for_target="${cflags_for_target}"
+    fi
+
+    # Append extra CXXFLAGS if provided.
+    if [ -n "${extra_cxxflags_for_target}" ]; then
+        cxxflags_for_target="${cxxflags_for_target} ${extra_cxxflags_for_target}"
+    fi
+
     # Use --with-local-prefix so older gccs don't look in /usr/local (http://gcc.gnu.org/PR10532).
     # Pass only user-specified CFLAGS/LDFLAGS in CFLAGS_FOR_TARGET/LDFLAGS_FOR_TARGET: during
     # the build of, for example, libatomic, GCC tried to compile multiple variants for runtime
@@ -624,7 +635,7 @@ do_gcc_core_backend() {
     CXXFLAGS_FOR_BUILD="${cflags_for_build}"           \
     LDFLAGS="${core_LDFLAGS[*]}"                       \
     CFLAGS_FOR_TARGET="${cflags_for_target}"           \
-    CXXFLAGS_FOR_TARGET="${cflags_for_target}"         \
+    CXXFLAGS_FOR_TARGET="${cxxflags_for_target}"       \
     LDFLAGS_FOR_TARGET="${CT_TARGET_LDFLAGS}"          \
     ${CONFIG_SHELL}                                    \
     "${CT_SRC_DIR}/gcc/configure"                      \
@@ -940,6 +951,8 @@ do_gcc_backend() {
     local cflags
     local cflags_for_build
     local cflags_for_target
+    local cxxflags_for_target
+    local extra_cxxflags_for_target
     local ldflags
     local build_manuals
     local exec_prefix
@@ -1225,6 +1238,16 @@ do_gcc_backend() {
     # Assume '-O2' by default for building target libraries.
     cflags_for_target="-g -O2 ${cflags_for_target}"
 
+    # Set target CXXFLAGS to CFLAGS if none is provided.
+    if [ -z "${cxxflags_for_target}" ]; then
+        cxxflags_for_target="${cflags_for_target}"
+    fi
+
+    # Append extra CXXFLAGS if provided.
+    if [ -n "${extra_cxxflags_for_target}" ]; then
+        cxxflags_for_target="${cxxflags_for_target} ${extra_cxxflags_for_target}"
+    fi
+
     # NB: not using CT_ALL_TARGET_CFLAGS/CT_ALL_TARGET_LDFLAGS here!
     # See do_gcc_core_backend for explanation.
     CT_DoExecLog CFG                                   \
@@ -1235,7 +1258,7 @@ do_gcc_backend() {
     CXXFLAGS_FOR_BUILD="${cflags_for_build}"           \
     LDFLAGS="${final_LDFLAGS[*]}"                      \
     CFLAGS_FOR_TARGET="${cflags_for_target}"           \
-    CXXFLAGS_FOR_TARGET="${cflags_for_target}"         \
+    CXXFLAGS_FOR_TARGET="${cxxflags_for_target}"       \
     LDFLAGS_FOR_TARGET="${CT_TARGET_LDFLAGS}"          \
     ${CONFIG_SHELL}                                    \
     "${CT_SRC_DIR}/gcc/configure"                      \

--- a/scripts/build/companion_libs/350-newlib_nano.sh
+++ b/scripts/build/companion_libs/350-newlib_nano.sh
@@ -67,6 +67,9 @@ do_cc_libstdcxx_newlib_nano()
 	if [ "${CT_LIBC_NEWLIB_NANO_ENABLE_TARGET_OPTSPACE}" = "y" ]; then
 	    final_opts+=( "enable_optspace=yes" )
 	fi
+        if [ -n "${CT_NEWLIB_NANO_GCC_LIBSTDCXX_TARGET_CXXFLAGS}" ]; then
+            final_opts+=( "extra_cxxflags_for_target=${CT_NEWLIB_NANO_GCC_LIBSTDCXX_TARGET_CXXFLAGS}" )
+        fi
 
         if [ "${CT_BARE_METAL}" = "y" ]; then
             final_opts+=( "mode=baremetal" )


### PR DESCRIPTION
This series consists of two important fixes for the libstdc++ build:
1. Fix incorrect optimisation flag when `CT_CC_GCC_ENABLE_TARGET_OPTSPACE=n`.
2. Allow specifying CXXFLAGS for libstdc++ nano build (and use `-fno-exceptions` as default).