### PR TITLE
testing: docker: Use archlinux:latest instead of archlinux/base:latest

### DIFF
--- a/testing/docker/archlinux/Dockerfile
+++ b/testing/docker/archlinux/Dockerfile
@@ -1,4 +1,4 @@
-FROM archlinux/base:latest
+FROM archlinux:latest
 ARG CTNG_UID=1000
 ARG CTNG_GID=1000
 RUN pacman -Sy --noconfirm archlinux-keyring


### PR DESCRIPTION
The name of the docker images have changed on docker hub. Update the
name used to point to the official archlinux image.

Fixes #1522

Signed-off-by: Chris Packham <judge.packham@gmail.com>