### PR TITLE
Move SRC_CUSTOM inside choice

### DIFF
--- a/maintainer/kconfig-versions.template
+++ b/maintainer/kconfig-versions.template
@@ -68,6 +68,12 @@ config @@fork|@@_SRC_DEVEL
       Default is the vendor repository at @@repository_url@@
 #!end-if
 
+config @@fork|@@_SRC_CUSTOM
+    bool "Custom location"
+    depends on EXPERIMENTAL
+    help
+      Custom directory or tarball.
+
 endchoice
 
 if @@fork|@@_SRC_DEVEL
@@ -162,12 +168,6 @@ config @@fork|@@_DEVEL_BOOTSTRAP
       with &&.
 
 endif
-
-config @@fork|@@_SRC_CUSTOM
-    bool "Custom location"
-    depends on EXPERIMENTAL
-    help
-      Custom directory or tarball.
 
 if @@fork|@@_SRC_CUSTOM
 


### PR DESCRIPTION
Prior to commit 30bffa96 SRC_CUSTOM was inside the choice with
SRC_RELEASE and SRC_DEVEL making the 3 options mutually exclusive.
Restore this behaviour keeping the "fix" to keep kconfig happy.

Fixes #1151
Fixes: 30bffa96 ("don't nest choices")
Signed-off-by: Chris Packham <judge.packham@gmail.com>