### PR TITLE
gcc: Make CC_GCC_TM_CLONE_REGISTRY tristate

### DIFF
--- a/config/cc/gcc.in
+++ b/config/cc/gcc.in
@@ -280,11 +280,18 @@ config CC_CXA_ATEXIT
       you might want to try disabling this option.
 
 config CC_GCC_TM_CLONE_REGISTRY
-    bool
+    tristate
     prompt "Use TM clone registry"
     depends on GCC_10_or_later
+    default m
     help
       Enable GCC transactional memory clone registry in libgcc.
+
+       Option  | tm-clone-registry  | Associated ./configure switch
+      ---------+--------------------+--------------------------------
+         Y     | forcibly used      | --enable-tm-clone-registry
+         M     | auto               | (none, ./configure decides)
+         N     | forcibly not used  | --disable-tm-clone-registry
 
 config CC_GCC_DISABLE_PCH
     bool

--- a/scripts/build/cc/gcc.sh
+++ b/scripts/build/cc/gcc.sh
@@ -397,11 +397,11 @@ do_gcc_core_backend() {
         extra_config+=("--disable-__cxa_atexit")
     fi
 
-    if [ "${CT_CC_GCC_TM_CLONE_REGISTRY}" = "y" ]; then
-        extra_config+=("--enable-tm-clone-registry")
-    else
-        extra_config+=("--disable-tm-clone-registry")
-    fi
+    case "${CT_CC_GCC_TM_CLONE_REGISTRY}" in
+        y) extra_config+=("--enable-tm-clone-registry");;
+        m) ;;
+        "") extra_config+=("--disable-tm-clone-registry");;
+    esac
 
     if [ -n "${CT_CC_GCC_ENABLE_CXX_FLAGS}" \
             -a "${mode}" = "baremetal" ]; then
@@ -1021,11 +1021,11 @@ do_gcc_backend() {
         extra_config+=("--disable-__cxa_atexit")
     fi
 
-    if [ "${CT_CC_GCC_TM_CLONE_REGISTRY}" = "y" ]; then
-        extra_config+=("--enable-tm-clone-registry")
-    else
-        extra_config+=("--disable-tm-clone-registry")
-    fi
+    case "${CT_CC_GCC_TM_CLONE_REGISTRY}" in
+        y) extra_config+=("--enable-tm-clone-registry");;
+        m) ;;
+        "") extra_config+=("--disable-tm-clone-registry");;
+    esac
 
     if [ -n "${CT_CC_GCC_ENABLE_CXX_FLAGS}" ]; then
         extra_config+=("--enable-cxx-flags=${CT_CC_GCC_ENABLE_CXX_FLAGS}")


### PR DESCRIPTION
Explicitly passing --disable-tm-clone-registry causes gcc to create a
crtbegin.o with a zero-sized .init_array/.fini_array. This in turn
causes ld to complain.

Make CC_GCC_TM_CLONE_REGISTRY a tristate so if it's not explicitly
enabled we can let ./configure decide.

Fixes #1531

Fixes: 1e21a302 ("gcc: Add CT_CC_GCC_TM_CLONE_REGISTRY config")
Signed-off-by: Chris Packham <judge.packham@gmail.com>