### PR TITLE
Fix build of older Glibc using GCC >=10

### DIFF
--- a/config/libc/glibc.in
+++ b/config/libc/glibc.in
@@ -181,6 +181,7 @@ config GLIBC_CONFIGPARMS
 config GLIBC_EXTRA_CFLAGS
     string
     prompt "extra target CFLAGS"
+    default "-Wno-missing-attributes -Wno-array-bounds -Wno-array-parameter -Wno-stringop-overflow -Wno-maybe-uninitialized" if GLIBC_2_29_or_older && GCC_11_or_later
     default ""
     help
       Extra target CFLAGS to use when building.
@@ -415,5 +416,11 @@ config GLIBC_ENABLE_WERROR
       release (because newer compilers typically have better diagnostics).
 
 endif
+
+config GLIBC_ENABLE_COMMON_FLAG
+    bool "Enable -fcommon flag for older version of glibc when using GCC >=10"
+    default y if GLIBC_2_29_or_older && GCC_10_or_later
+    default n if GLIBC_2_30_or_later || GCC_9_or_older
+
 
 endif # KERNEL_LINUX

--- a/config/libc/glibc.in
+++ b/config/libc/glibc.in
@@ -421,6 +421,8 @@ config GLIBC_ENABLE_COMMON_FLAG
     bool "Enable -fcommon flag for older version of glibc when using GCC >=10"
     default y if GLIBC_2_29_or_older && GCC_10_or_later
     default n if GLIBC_2_30_or_later || GCC_9_or_older
-
+    help
+      Starting from GCC 10, the default behavior is changed to -fno-common.
+      That leads to linking errors in GLibc versions older than 2.30.
 
 endif # KERNEL_LINUX

--- a/scripts/build/libc/glibc.sh
+++ b/scripts/build/libc/glibc.sh
@@ -201,6 +201,10 @@ glibc_backend_once()
     # glibc can't be built without -O2 (reference needed!)
     glibc_cflags+=" -g -O2"
 
+    if [ "${CT_GLIBC_ENABLE_COMMON_FLAG}" = "y" ]; then
+        glibc_cflags+=" -fcommon"
+    fi
+
     case "${CT_GLIBC_ENABLE_FORTIFIED_BUILD}" in
         y)  ;;
         *)  glibc_cflags+=" -U_FORTIFY_SOURCE";;


### PR DESCRIPTION
Issue #1535

GCC 10 changed the default to -fno-common, which leads to a linking error in GLibc older than 2.30.

This change adds -fcommon cflag for the target GLibc versions <=2.29 and GCC >=10.

This change also adds additional cflags for the target GLibc to disable
new GCC11 checks that lead to compilation errors.

Signed-off-by: Nik Konyuchenko <spaun2002mobile@gmail.com>