### PR TITLE
CT_Mirrors: make use of kernel cdn

### DIFF
--- a/scripts/functions
+++ b/scripts/functions
@@ -1800,7 +1800,6 @@ CT_Mirrors()
         echo "https://releases.linaro.org/archive/${yymm}/components/toolchain/${project}-linaro"
         ;;
     kernel.org)
-        # TBD move to linux.sh and dtc.sh?
         case "${project}" in
         linux)
             local version="${CT_LINUX_VERSION}"
@@ -1809,14 +1808,14 @@ CT_Mirrors()
                 # Ignore, this happens before .config is fully evaluated
                 ;;
             [345].*)
-                echo "http://www.kernel.org/pub/linux/kernel/v${version%%.*}.x"
+                echo "https://cdn.kernel.org/pub/linux/kernel/v${version%%.*}.x"
                 ;;
             2.6.*)
-                echo "http://www.kernel.org/pub/linux/kernel/v2.6"
+                echo "https://cdn.kernel.org/pub/linux/kernel/v2.6"
                 case "${version}" in
                 2.6.*.*)
-                    echo "http://www.kernel.org/pub/linux/kernel/v2.6/longterm"
-                    echo "http://www.kernel.org/pub/linux/kernel/v2.6/longterm/v${version%.*}"
+                    echo "https://cdn.kernel.org/pub/linux/kernel/v2.6/longterm"
+                    echo "https://cdn.kernel.org/pub/linux/kernel/v2.6/longterm/v${version%.*}"
                     ;;
                 esac
                 ;;
@@ -1826,7 +1825,7 @@ CT_Mirrors()
             esac
             ;;
         dtc)
-            echo "https://mirrors.edge.kernel.org/pub/software/utils/dtc"
+            echo "https://cdn.kernel.org/pub/software/utils/dtc"
             ;;
         *)
             echo "-unknown-"


### PR DESCRIPTION
cdn.kernel.org automatically redirects to a geographically close mirror.
Make use of this instead of www.kernel.org or mirrors.edge.kernel.org.
While were at it make sure we use https.

Signed-off-by: Chris Packham <judge.packham@gmail.com>