### PR TITLE
Add EXTRA_CXXFLAGS_FOR_BUILD option

### DIFF
--- a/config/global/build-behave.in
+++ b/config/global/build-behave.in
@@ -46,7 +46,17 @@ config EXTRA_CFLAGS_FOR_BUILD
 
       May be used to change the default features of the build
       compiler such as turning off the stack protector or fortify.
-      
+
+config EXTRA_CXXFLAGS_FOR_BUILD
+    string
+    prompt "Extra build compiler flags"
+    default ""
+    help
+      Extra flags to pass only to the build C++ compiler.
+
+      May be used to change the default features of the C++ build
+      compiler such as specifying the C++ standard to use.
+
 config EXTRA_LDFLAGS_FOR_BUILD
     string
     prompt "Extra build linker flags"

--- a/scripts/build/binutils/binutils.sh
+++ b/scripts/build/binutils/binutils.sh
@@ -186,10 +186,10 @@ do_binutils_backend() {
     CT_DoExecLog CFG                                            \
     CC_FOR_BUILD="${CT_BUILD}-gcc"                              \
     CFLAGS_FOR_BUILD="${CT_CFLAGS_FOR_BUILD}"                   \
-    CXXFLAGS_FOR_BUILD="${CT_CFLAGS_FOR_BUILD}"                 \
+    CXXFLAGS_FOR_BUILD="${CT_CFLAGS_FOR_BUILD} ${CT_CXXFLAGS_FOR_BUILD}" \
     LDFLAGS_FOR_BUILD="${CT_LDFLAGS_FOR_BUILD}"                 \
     CFLAGS="${cflags}"                                          \
-    CXXFLAGS="${cflags}"                                        \
+    CXXFLAGS="${cflags} ${CT_CXXFLAGS_FOR_BUILD}"               \
     LDFLAGS="${ldflags}"                                        \
     ${CONFIG_SHELL}                                             \
     "${CT_SRC_DIR}/binutils/configure"                          \

--- a/scripts/build/cc/gcc.sh
+++ b/scripts/build/cc/gcc.sh
@@ -295,7 +295,7 @@ do_gcc_core_backend() {
     local enable_optspace
     local complibs
     local lang_list
-    local cflags cflags_for_build cflags_for_target cxxflags_for_target
+    local cflags cflags_for_build cxxflags_for_build cflags_for_target cxxflags_for_target
     local extra_cxxflags_for_target
     local ldflags
     local build_step
@@ -587,6 +587,7 @@ do_gcc_core_backend() {
     # that ${cflags} may refer either to build or host CFLAGS; they are provided
     # by the caller.
     cflags_for_build="${CT_CFLAGS_FOR_BUILD}"
+    cxxflags_for_build="${CT_CXXFLAGS_FOR_BUILD}"
     cflags_for_target="${CT_TARGET_CFLAGS}"
 
     # Clang's default bracket-depth is 256, and building GCC
@@ -637,8 +638,8 @@ do_gcc_core_backend() {
     CC_FOR_BUILD="${CT_BUILD}-gcc"                     \
     CFLAGS="${cflags}"                                 \
     CFLAGS_FOR_BUILD="${cflags_for_build}"             \
-    CXXFLAGS="${cflags}"                               \
-    CXXFLAGS_FOR_BUILD="${cflags_for_build}"           \
+    CXXFLAGS="${cflags} ${cxxflags_for_build}"         \
+    CXXFLAGS_FOR_BUILD="${cflags_for_build} ${cxxflags_for_build}" \
     LDFLAGS="${core_LDFLAGS[*]}"                       \
     CFLAGS_FOR_TARGET="${cflags_for_target}"           \
     CXXFLAGS_FOR_TARGET="${cxxflags_for_target}"       \
@@ -956,6 +957,7 @@ do_gcc_backend() {
     local lang_list
     local cflags
     local cflags_for_build
+    local cxxflags_for_build
     local cflags_for_target
     local cxxflags_for_target
     local extra_cxxflags_for_target
@@ -1231,6 +1233,7 @@ do_gcc_backend() {
 
     # We may need to modify host/build/target CFLAGS separately below
     cflags_for_build="${cflags}"
+    cxxflags_for_build="${CT_CXXFLAGS_FOR_BUILD}"
     cflags_for_target="${CT_TARGET_CFLAGS}"
 
     # Clang's default bracket-depth is 256, and building GCC
@@ -1266,8 +1269,8 @@ do_gcc_backend() {
     CC_FOR_BUILD="${CT_BUILD}-gcc"                     \
     CFLAGS="${cflags}"                                 \
     CFLAGS_FOR_BUILD="${cflags_for_build}"             \
-    CXXFLAGS="${cflags}"                               \
-    CXXFLAGS_FOR_BUILD="${cflags_for_build}"           \
+    CXXFLAGS="${cflags} ${cxxflags_for_build}"         \
+    CXXFLAGS_FOR_BUILD="${cflags_for_build} ${cxxflags_for_build}" \
     LDFLAGS="${final_LDFLAGS[*]}"                      \
     CFLAGS_FOR_TARGET="${cflags_for_target}"           \
     CXXFLAGS_FOR_TARGET="${cxxflags_for_target}"       \

--- a/scripts/crosstool-NG.sh
+++ b/scripts/crosstool-NG.sh
@@ -530,6 +530,7 @@ if [ -z "${CT_RESTART}" ]; then
     # package's default optimisation flags
     CT_CFLAGS_FOR_BUILD="-O2 -g -I${CT_BUILDTOOLS_PREFIX_DIR}/include"
     CT_CFLAGS_FOR_BUILD+=" ${CT_EXTRA_CFLAGS_FOR_BUILD}"
+    CT_CXXFLAGS_FOR_BUILD="${CT_EXTRA_CXXFLAGS_FOR_BUILD}"
     CT_LDFLAGS_FOR_BUILD="-L${CT_BUILDTOOLS_PREFIX_DIR}/lib"
     CT_LDFLAGS_FOR_BUILD+=" ${CT_EXTRA_LDFLAGS_FOR_BUILD}"
 
@@ -552,6 +553,7 @@ if [ -z "${CT_RESTART}" ]; then
     esac
 
     CT_DoLog DEBUG "CFLAGS for build compiler: '${CT_CFLAGS_FOR_BUILD}'"
+    CT_DoLog DEBUG "CXXFLAGS for build compiler: '${CT_CXXFLAGS_FOR_BUILD}'"
     CT_DoLog DEBUG "LDFLAGS for build compiler: '${CT_LDFLAGS_FOR_BUILD}'"
 
     # Help host gcc


### PR DESCRIPTION
The new `EXTRA_CXXFLAGS_FOR_BUILD` option allows to add flags specifically for the build c++ compiler.

Fixes #1549