### PR TITLE
Disable libelf with bare metal

### DIFF
--- a/config/companion_libs/libelf.in
+++ b/config/companion_libs/libelf.in
@@ -1,5 +1,7 @@
 # libelf config file
 
+## depends on ! BARE_METAL
+
 choice
     bool
     prompt "libelf version"

--- a/config/debug/ltrace.in
+++ b/config/debug/ltrace.in
@@ -1,6 +1,7 @@
 # ltrace
 
 ## depends on ! BACKEND
+## depends on ! BARE_METAL
 ##
 ## select LIBELF_TARGET
 ##


### PR DESCRIPTION
Libelf can‘t configure in bare metal
Fixes #1555 