### PR TITLE
Support common local patch directory

### DIFF
--- a/scripts/functions
+++ b/scripts/functions
@@ -2240,6 +2240,7 @@ CT_DoExtractPatch()
     local bundled_patch_dir
     local bundled_common_patch_dir
     local local_patch_dir
+    local local_common_patch_dir
     local overlay
 
     # Inherit global value if requested
@@ -2315,12 +2316,13 @@ CT_DoExtractPatch()
             bundled_patch_dir="${CT_LIB_DIR}/packages/${pkg_dir}"
             bundled_common_patch_dir="${CT_LIB_DIR}/packages/${pkg_name}"
             local_patch_dir="${CT_LOCAL_PATCH_DIR}/${pkg_dir}"
+            local_common_patch_dir="${CT_LOCAL_PATCH_DIR}/${pkg_name}"
 
             case "${patch_order}" in
                 bundled)        patch_dirs=("${bundled_patch_dir}" "${bundled_common_patch_dir}");;
-                local)          patch_dirs=("${local_patch_dir}");;
-                bundled,local)  patch_dirs=("${bundled_patch_dir}" "${bundled_common_patch_dir}" "${local_patch_dir}");;
-                local,bundled)  patch_dirs=("${local_patch_dir}" "${bundled_patch_dir}" "${bundled_common_patch_dir}");;
+                local)          patch_dirs=("${local_patch_dir}" "${local_common_patch_dir}");;
+                bundled,local)  patch_dirs=("${bundled_patch_dir}" "${bundled_common_patch_dir}" "${local_patch_dir}" "${local_common_patch_dir}");;
+                local,bundled)  patch_dirs=("${local_patch_dir}" "${local_common_patch_dir}" "${bundled_patch_dir}" "${bundled_common_patch_dir}");;
                 none)           patch_dirs=;;
             esac
 


### PR DESCRIPTION
This commit updates the patching process such that the local patches
can be applied in a version-independent manner, as with the patches
provided by the crosstool-ng packages.

This is done by reading the patch files from
`${CT_LOCAL_PATCH_DIR}/(package_name)` rather than from
`${CT_LOCAL_PATCH_DIR}/(package_name)/(version)`.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>