### PR TITLE
Fix dist-create-release after kconfig update

### DIFF
--- a/kconfig/Makefile.am
+++ b/kconfig/Makefile.am
@@ -7,7 +7,7 @@ pkglibexec_PROGRAMS    = conf nconf mconf
 
 EXTRA_DIST		= parser.y lexer.l \
 				  expr.h list.h lkc.h lkc_proto.h nconf.h lxdialog/dialog.h \
-				  confdata.c expr.c kconf_id.c menu.c symbol.c util.c
+				  menu.c
 
 CLEANFILES		= lexer.lex.c parser.tab.c parser.tab.h
 BUILT_SOURCES		= lexer.lex.c parser.tab.c
@@ -17,17 +17,20 @@ AM_YFLAGS		= -t -l
 AM_CPPFLAGS		= -include config.h -DCONFIG_=\"CT_\"
 AM_LIBTOOLFLAGS	= --tag CC
 
-conf_SOURCES    = conf.c confdata.c expr.c symbol.c preprocess.c util.c lexer.lex.c parser.tab.c
+conf_SOURCES    = conf.c confdata.c expr.c symbol.c preprocess.c util.c
+nodist_conf_SOURCES = parser.tab.c lexer.lex.c
 conf_LDADD      = $(LIBINTL)
 
-nconf_SOURCES	= nconf.c nconf.gui.c confdata.c expr.c symbol.c preprocess.c util.c lexer.lex.c parser.tab.c
+nconf_SOURCES	= nconf.c nconf.gui.c confdata.c expr.c symbol.c preprocess.c util.c
+nodist_nconf_SOURCES = parser.tab.c lexer.lex.c
 nconf_CFLAGS	= $(CURSES_CFLAGS)
 nconf_LDADD     = $(MENU_LIBS) $(PANEL_LIBS) $(CURSES_LIBS) $(LIBINTL)
 
-mconf_SOURCES	= mconf.c confdata.c expr.c symbol.c preprocess.c util.c lexer.lex.c parser.tab.c \
+mconf_SOURCES	= mconf.c confdata.c expr.c symbol.c preprocess.c util.c \
 				  lxdialog/checklist.c lxdialog/inputbox.c \
 				  lxdialog/menubox.c lxdialog/textbox.c lxdialog/util.c \
 				  lxdialog/yesno.c
+nodist_mconf_SOURCES = parser.tab.c lexer.lex.c
 mconf_LDADD     = $(CURSES_LIBS) $(LIBINTL)
 
 # automake's support for yacc/lex/gperf is too idiosyncratic. It doesn't


### PR DESCRIPTION
After commits 21095fab6 and acce58834, 'make dist-create-release' fails.

1. kconf_id.c is gone but it is still listed in EXTRA_DIST.

2. Only the files not listed in xxx_SOURCES need to be placed in
EXTRA_LIST. confdata.c, expr.c and others were previously not compiled
separately, they were #include'd from parser.y. Now they are listed in
xxx_SOURCES and should be removed from EXTRA_DIST. Note that menu.c is
still #include'd through parser.y, so it is kept.

3. parser.tab.c and lexer.lex.c should not be included in the
distribution tarball; they were previously omitted by virtue of not
being listed in xxx_SOURCES directly. Without it, `make distcheck`
fails.

Signed-off-by: Alexey Neyman <aneyman@lynx.com>