### PR TITLE
contrib: Add contrib/gen-chksum.sh

### DIFF
--- a/contrib/gen-chksum.sh
+++ b/contrib/gen-chksum.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Helper script to generate package chksum from a given tarball.
+
+die()
+{
+  echo "ERROR: $@"
+  exit 1
+}
+
+[ $# != 1 ] && die "Usage: $0 <package.tar.gz>"
+
+for s in md5 sha1 sha256 sha512
+do
+  echo "${s} `basename ${1}` `${s}sum ${1} | cut -f1 -d' '`"
+done


### PR DESCRIPTION
When updating a single package, it does not make sense to touch the
configuration for all packages:
  $ ./maintainer/manage-packages.sh -D

Instead of this, provide a script to update the checksum for a single
tarball only:

  $ ./contrib/gen-chksum.sh gnuprumcu-0.6.0.tar.gz > packages/gnuprumcu/0.6.0/chksum

Signed-off-by: Dimitar Dimitrov <dimitar@dinux.eu>