### PR TITLE
CI: Download bison, m4 and make

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -79,6 +79,10 @@ jobs:
                 sed -i -e '/CT_LOG_PROGRESS_BAR/s/y$/n/' .config; \
                 sed -i -e '/CT_LOCAL_TARBALLS_DIR/s/HOME/CT_TOP_DIR/' .config; \
                 sed -i -e '/CT_PREFIX_DIR/s/HOME/CT_TOP_DIR/' .config; \
+                sed -i -e 's/^.*CT_COMP_TOOLS_BISON.*$/CT_COMP_TOOLS_BISON=y/' .config; \
+                sed -i -e 's/^.*CT_COMP_TOOLS_M4.*$/CT_COMP_TOOLS_M4=y/' .config; \
+                sed -i -e 's/^.*CT_COMP_TOOLS_MAKE.*$/CT_COMP_TOOLS_MAKE=y/' .config; \
+                ct-ng olddefconfig; \
                 ct-ng source; \
           done
           tar -cvf src.tar src


### PR DESCRIPTION
Various configurations end up using these companion tools (particularly
those with GNU libc). Ensure we download these tools at the start of the
build.

Signed-off-by: Chris Packham <judge.packham@gmail.com>