### PR TITLE
ARC: No more fiddling with uClibc's CONFIG_ARC_HAS_ATOMICS

### DIFF
--- a/scripts/build/arch/arc.sh
+++ b/scripts/build/arch/arc.sh
@@ -13,23 +13,6 @@ CT_DoArchUClibcConfig()
     CT_DoArchUClibcSelectArch "${cfg}" "arc"
 }
 
-CT_DoArchUClibcCflags()
-{
-    local cfg="${1}"
-    local cflags="${2}"
-    local f
-
-    CT_KconfigDisableOption "CONFIG_ARC_HAS_ATOMICS" "${cfg}"
-
-    for f in ${cflags}; do
-        case "${f}" in
-            -matomic)
-                CT_KconfigEnableOption "CONFIG_ARC_HAS_ATOMICS" "${cfg}"
-                ;;
-        esac
-    done
-}
-
 # Multilib: Adjust configure arguments for GLIBC
 # Usage: CT_DoArchGlibcAdjustConfigure <configure-args-array-name> <cflags>
 #


### PR DESCRIPTION
Older ARC700 processors had atomic instructions (AKA llock/scond) as an option and so quite some "atomic" operations were not possible w/o OS support, which we implemented - see `arc_usr_cmpxchg()` in the Linux kernel.

And in uClibc, which was the only Linux libc back in the day of ARC700 era, it is well supported. Well, uClibc could be configured to support it. Which is done with `CONFIG_ARC_HAS_ATOMICS` Kconfig option.

But the problem is there's no check for ARC ISA version in uClibc when this option gets enabled. That leads to a funny situation when even for ARCv2 processors (ARC HS3x & HS4x) uClibc tries to utilize `arc_usr_cmpxchg()` syscall which is not supported for this newer ISA since ARCv2 processors have atomic instructions built-in all the time.

So what was happening here we didn't specify additional `-matomic` CFLAG unless we were targeting exactly those ancient ARC770 processors (ARC700 + MMUv3 + atomics) and so even for ARCv2 we forced uClibc to not use built-in atomics.

And even though there're ways to add a smarter solution here to handle that pretty rare by now case of ARC750 (ARC700 + MMUv2 - atomics), I suggest we just remove this part completely, leaving a possibility
to add needed option in uClibc-ng's configuration (I mean `packages/uClibc-ng/config`).