### PR TITLE
cc/gcc: Add options for zstd usage

### DIFF
--- a/config/cc/gcc.in
+++ b/config/cc/gcc.in
@@ -179,6 +179,25 @@ config CC_GCC_USE_LTO
     help
       Enable the Link Time Optimisations.
 
+config CC_GCC_LTO_ZSTD
+    tristate
+    prompt "Support LTO compression with zstd"
+    default m
+    depends on CC_GCC_USE_LTO
+    depends on GCC_10_or_later
+    depends on ! STATIC_TOOLCHAIN
+    help
+      Support zstd compression for LTO object files. This will require
+      libzstd to be installed when using the toolchain
+
+       Option  | ZSTD use           | Associated ./configure switch
+      ---------+--------------------+--------------------------------
+         Y     | forcibly used      | --with-zstd
+         M     | auto               | (none, ./configure decides)
+         N     | forcibly not used  | --without-zstd
+
+      If unsure, say 'M'
+
 #-----------------------------------------------------------------------------
 comment "Settings for libraries running on target"
 

--- a/scripts/build/cc/gcc.sh
+++ b/scripts/build/cc/gcc.sh
@@ -1130,6 +1130,11 @@ do_gcc_backend() {
     else
         extra_config+=("--disable-lto")
     fi
+    case "${CT_CC_GCC_LTO_ZSTD}" in
+        y) extra_config+=("--with-zstd");;
+        m) ;;
+        *) extra_config+=("--without-zstd");;
+    esac
 
     if [ ${#host_libstdcxx_flags[@]} -ne 0 ]; then
         extra_config+=("--with-host-libstdcxx=${host_libstdcxx_flags[*]}")


### PR DESCRIPTION
GCC can support using zstd compression for LTO object files. By default
GCC's configure will enable this if libzstd is installed on the machine
building the toolchain. This may be undesirable if the toolchain is to
be used on a different machine. Add an option to control zstd usage and
set the default to the same as the current behaviour (i.e. auto).

Fixes #1579

Signed-off-by: Chris Packham <judge.packham@gmail.com>