### PR TITLE
gcc: Don't mess with --with-host-libstdcxx if recent GCC (6+) is used

### DIFF
--- a/scripts/build/cc/gcc.sh
+++ b/scripts/build/cc/gcc.sh
@@ -436,9 +436,11 @@ do_gcc_core_backend() {
     # with the same block in do_gcc_backend, below.
     if [ "${build_staticlinked}" = "yes" ]; then
         core_LDFLAGS+=("-static")
-        host_libstdcxx_flags+=("-static-libgcc")
-        host_libstdcxx_flags+=("-Wl,-Bstatic,-lstdc++")
-        host_libstdcxx_flags+=("-lm")
+        if [ "${CT_GCC_older_than_6}" = "y" ]; then
+            host_libstdcxx_flags+=("-static-libgcc")
+            host_libstdcxx_flags+=("-Wl,-Bstatic,-lstdc++")
+            host_libstdcxx_flags+=("-lm")
+        fi
         # Companion libraries are build static (eg !shared), so
         # the libstdc++ is not pulled automatically, although it
         # is needed. Shoe-horn it in our LDFLAGS
@@ -446,7 +448,7 @@ do_gcc_core_backend() {
         core_LDFLAGS+=("-lstdc++")
         core_LDFLAGS+=("-lm")
     else
-        if [ "${CT_CC_GCC_STATIC_LIBSTDCXX}" = "y" ]; then
+        if [ "${CT_CC_GCC_STATIC_LIBSTDCXX}" = "y" -a "${CT_GCC_older_than_6}" = "y" ]; then
             # this is from CodeSourcery arm-2010q1-202-arm-none-linux-gnueabi.src.tar.bz2
             # build script
             # INFO: if the host gcc is gcc-4.5 then presumably we could use -static-libstdc++,
@@ -1084,9 +1086,11 @@ do_gcc_backend() {
     # with the same block in do_gcc_core_backend, above.
     if [ "${CT_STATIC_TOOLCHAIN}" = "y" ]; then
         final_LDFLAGS+=("-static")
-        host_libstdcxx_flags+=("-static-libgcc")
-        host_libstdcxx_flags+=("-Wl,-Bstatic,-lstdc++")
-        host_libstdcxx_flags+=("-lm")
+        if [ "${CT_GCC_older_than_6}" = "y" ]; then
+            host_libstdcxx_flags+=("-static-libgcc")
+            host_libstdcxx_flags+=("-Wl,-Bstatic,-lstdc++")
+            host_libstdcxx_flags+=("-lm")
+        fi
         # Companion libraries are build static (eg !shared), so
         # the libstdc++ is not pulled automatically, although it
         # is needed. Shoe-horn it in our LDFLAGS
@@ -1094,7 +1098,7 @@ do_gcc_backend() {
         final_LDFLAGS+=("-lstdc++")
         final_LDFLAGS+=("-lm")
     else
-        if [ "${CT_CC_GCC_STATIC_LIBSTDCXX}" = "y" ]; then
+        if [ "${CT_CC_GCC_STATIC_LIBSTDCXX}" = "y" -a "${CT_GCC_older_than_6}" = "y" ]; then
             # this is from CodeSourcery arm-2010q1-202-arm-none-linux-gnueabi.src.tar.bz2
             # build script
             # INFO: if the host gcc is gcc-4.5 then presumably we could use -static-libstdc++,


### PR DESCRIPTION
`--with-host-libstdcxx` option was removed in GCC 6.x, see https://gcc.gnu.org/git/?p=gcc.git&a=commit;h=5dc85f7ec719a79ecfbcdd8563b07e5f0f365e65 because of https://gcc.gnu.org/bugzilla/show_bug.cgi?id=67092.
So it makes no sense to use it with later GCC versions.

Frankly I don't like that implementation with yet another set of "if XXX", but since we still support GCC down to 4.8.5 what else we may do?

Well, technically we may keep using things as they are now, because surprisingly GCC's configure script doesn't mind accepting meaningless options, but as a person who's looking at differences between various builds and drill-down to peculiarities of various config options, I'd prefer to not pollute configure with garbage.

But for all the rest... well, it works now and maybe nobody else cares.