### PR TITLE
gcc: Fix canadian cross building on older hosts

### DIFF
--- a/scripts/build/cc/gcc.sh
+++ b/scripts/build/cc/gcc.sh
@@ -696,20 +696,8 @@ do_gcc_core_backend() {
         libgcc_rule="libgcc.mvars"
         core_targets=( gcc target-libgcc )
 
-        # On bare metal and canadian build the host-compiler is used when
-        # actually the build-system compiler is required. Choose the correct
-        # compilers for canadian build and use the defaults on other
-        # configurations.
-        if [ "${CT_BARE_METAL},${CT_CANADIAN}" = "y,y" ]; then
-            repair_cc="CC_FOR_BUILD=${CT_BUILD}-gcc \
-                       CXX_FOR_BUILD=${CT_BUILD}-g++ \
-                       GCC_FOR_TARGET=${CT_TARGET}-${CT_CC}"
-        else
-            repair_cc=""
-        fi
+        CT_DoExecLog ALL make ${CT_JOBSFLAGS} -C gcc ${libgcc_rule}
 
-        CT_DoExecLog ALL make ${CT_JOBSFLAGS} -C gcc ${libgcc_rule} \
-                              ${repair_cc}
         sed -r -i -e 's@-lc@@g' gcc/${libgcc_rule}
     else # build_libgcc
         core_targets=( gcc )


### PR DESCRIPTION
GCC 11+ requires compiler being used to support C++11 standard [1].
And while GCC starting from 6.x has C++11 support enabled by default [2], older versions need to be forced to implement it with "-std=gnu++11" and luckily GCC's build-system takes care of that:

 1. For `${host}` compiler - [1]
 2. For `${build}` compiler - [3, 4]

In a nutshell the configure script tries a couple of options and the one which helps to build a test source gets appended to `CXX` (not `CXXFLAGS`!), so on say CentOS 7.x with GCC 4.8.5 during cross-compilation of GCC `CXX=x86_64-build_pc-linux-gnu-g++ -std=gnu++11`. And all is good.

But in case of canadian cross due to [5] we for some reason (read-on) force set `CXX_FOR_BUILD` with just a compiler name, effectively overriding all the magic done by GCC's internals described above.

This leads to a compilation failures like that:
```
[ALL  ]    In file included from /usr/include/c++/4.8.2/type_traits:35:0,
[ALL  ]                     from .../HOST-x86_64-apple-darwin14/arc-gcc11-elf/src/gcc/gcc/system.h:244,
[ALL  ]                     from .../HOST-x86_64-apple-darwin14/arc-gcc11-elf/src/gcc/gcc/gengtype.c:26:
[ERROR]    /usr/include/c++/4.8.2/bits/c++0x_warning.h:32:2: error: #error This file requires compiler and library support for the ISO C++ 2011 standard. This support is currently experimental, and must be enabled with the -std=c++11 or -std=gnu++11 compiler options.
[ALL  ]     #error This file requires compiler and library support for the   ^
```

My guess that [5] was done because back in the day indeed we used to have `--build=${CT_BUILD} --host=${CT_HOST}` in `do_cc_core()`. But now after [6] this is no longer necessary as we use `--build=${CT_BUILD} --host=${CT_BUILD}` and all is safe and clean. So yet another old quirk goes away - hooray!

[1] https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=5329b59a2e13dabbe2038af0fe2e3cf5fc7f98ed
[2] https://gcc.gnu.org/gcc-6/changes.html
[3] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96612
[4] https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=7ffcf5d61174dda1f39a623e15f7e5d6b98bbafc
[5] https://github.com/crosstool-ng/crosstool-ng/commit/9c6c090d7b6f5a03213b8ac6bd33a5cb812ec4c4
[6] https://github.com/crosstool-ng/crosstool-ng/commit/08161250ed65a9b91d680a305d01acd8052f937f