### PR TITLE
binutils: Add MinGW build fix from 2.37 branch

### DIFF
--- a/packages/binutils/2.37/0010-change-uint-to-unsigned.patch
+++ b/packages/binutils/2.37/0010-change-uint-to-unsigned.patch
@@ -1,0 +1,56 @@
+From 999566402e3d7c69032bbf47e28b44fc0926fe62 Mon Sep 17 00:00:00 2001
+From: Christopher Wellons <wellons@nullprogram.com>
+Date: Sun, 18 Jul 2021 16:57:19 -0400
+Subject: [PATCH] Change "uint" to "unsigned"
+
+This fixes a defect introduced in 25162c795. The "uint" type has not
+been explicitly defined here on mingw, causing compilation to fail.
+
+On linux we have this in /usr/include/sys/types.h
+
+/* Old compatibility names for C types.  */
+typedef unsigned long int ulong;
+typedef unsigned short int ushort;
+typedef unsigned int uint;
+
+So it's easy to see how such bugs can creep in.
+
+	* rust-demangle.c (struct rust_demangler): Change type of
+	"recursion" to unsigned.
+	(RUST_NO_RECURSION_LIMIT): Similarly in cast.
+---
+ libiberty/ChangeLog       | 6 ++++++
+ libiberty/rust-demangle.c | 4 ++--
+ 2 files changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/libiberty/ChangeLog b/libiberty/ChangeLog
+index 8e39fd28eba8..3f749455f05d 100644
+--- a/libiberty/ChangeLog
++++ b/libiberty/ChangeLog
+@@ -1,3 +1,9 @@
++2021-07-19  Christopher Wellons  <wellons@nullprogram.com>
++
++	* rust-demangle.c (struct rust_demangler): Change type of
++	"recursion" to unsigned.
++	(RUST_NO_RECURSION_LIMIT): Similarly in cast.
++
+ 2021-07-15  Nick Clifton  <nickc@redhat.com>
+ 
+ 	PR 99935
+diff --git a/libiberty/rust-demangle.c b/libiberty/rust-demangle.c
+index df09b7b8fddb..ac1eb8eb02c6 100644
+--- a/libiberty/rust-demangle.c
++++ b/libiberty/rust-demangle.c
+@@ -75,10 +75,10 @@ struct rust_demangler
+   int version;
+ 
+   /* Recursion depth.  */
+-  uint recursion;
++  unsigned recursion;
+   /* Maximum number of times demangle_path may be called recursively.  */
+ #define RUST_MAX_RECURSION_COUNT  1024
+-#define RUST_NO_RECURSION_LIMIT   ((uint) -1)
++#define RUST_NO_RECURSION_LIMIT   ((unsigned) -1)
+ 
+   uint64_t bound_lifetime_depth;
+ };


### PR DESCRIPTION
This fixes a defect introduced in 25162c7. The "uint" type has not
been explicitly defined here on mingw, causing compilation to fail.

Signed-off-by: Artem Panfilov <artemp@synopsys.com>