### PR TITLE
gdb: Really decouple building of native/target GDB & gdbserver

### DIFF
--- a/scripts/build/debug/300-gdb.sh
+++ b/scripts/build/debug/300-gdb.sh
@@ -116,6 +116,12 @@ do_debug_gdb_build()
 
         native_extra_config+=("--program-prefix=")
 
+        # gdbserver gets enabled by default with gdb
+        # since gdbserver was prometed to top-level
+        if [ "${CT_GDB_GDBSERVER_TOPLEVEL}" = "y" ]; then
+            native_extra_config+=("--disable-gdbserver")
+        fi
+
         # GDB on Mingw depends on PDcurses, not ncurses
         if [ "${CT_MINGW32}" != "y" ]; then
             native_extra_config+=("--with-curses")
@@ -185,6 +191,8 @@ do_debug_gdb_build()
 
         if [ "${CT_GDB_GDBSERVER_TOPLEVEL}" != "y" ]; then
             subdir=gdb/gdbserver/
+        else
+            native_extra_config+=("--disable-gdb")
         fi
 
         CT_DoStep INFO "Installing gdb server"


### PR DESCRIPTION
Back in the day gdbserver was treated as a subproject of GDB and even was located in `gdb/gdbserver` and so to build `gdbserver` we had to go into `gdb/gdbserver` and there run configure. That way full GDB was out of the picture.

Now starting from GDB 10.1 where gdbserver was promoted to the top-level we're supposed to run top-level's configure script for all the tools provided by the unified binutils-gdb tree.

That said if we only want to build `gdbserver` (and that's what we want since we build one tool at a build step) we have to be explicit: `--enable-gdbserver --disable--gdb`.

Ah, and so far we used to build full native GDB when only wanted `gdbserver` if it was GDB v10.x ;)

Ironically full native/target GDB also enabled gdbserver by default so we need to also disable it explicitly with `--disable-gdbserver`.