### PR TITLE
gdb: Enable TUI for full target/native GDB

### DIFF
--- a/scripts/build/debug/300-gdb.sh
+++ b/scripts/build/debug/300-gdb.sh
@@ -129,10 +129,9 @@ do_debug_gdb_build()
 
         export ac_cv_func_strncmp_works=yes
 
-        # TBD do we need all these? Eg why do we disable TUI if we build curses for target?
+        # TBD do we need all these?
         native_extra_config+=(
             --without-uiout
-            --disable-tui
             --disable-gdbtk
             --without-x
             --disable-sim
@@ -201,10 +200,9 @@ do_debug_gdb_build()
 
         export ac_cv_func_strncmp_works=yes
 
-        # TBD do we need all these? Eg why do we disable TUI if we build curses for target?
+        # TBD do we need all these?
         native_extra_config+=(
             --without-uiout
-            --disable-tui
             --disable-gdbtk
             --without-x
             --disable-sim


### PR DESCRIPTION
Since we have curses built for target anyway now, why don't allow users to use very convenient pseudo-GUI operating mode?
And while at it, there's no use of TUI in naturally headless `gdbserver`.