### PR TITLE
gcc: Build static libgcc in core_pass1

### DIFF
--- a/config/cc.in
+++ b/config/cc.in
@@ -2,11 +2,6 @@
 
 menu "C compiler"
 
-config CC_CORE_PASSES_NEEDED
-    bool
-    select CC_CORE_PASS_1_NEEDED
-    select CC_CORE_PASS_2_NEEDED
-
 config CC_CORE_PASS_1_NEEDED
     bool
 

--- a/config/libc/glibc.in
+++ b/config/libc/glibc.in
@@ -407,9 +407,6 @@ config GLIBC_SSP
 # GCC8-related fixes were only available in glibc 2.27.
 config GLIBC_ENABLE_WERROR
     bool "Enable -Werror during the build"
-    default n if GLIBC_2_32_or_later && ARCH_POWERPC && ARCH_64
-    default n if GLIBC_2_32_or_later && ARCH_SPARC
-    default n if GLIBC_2_32_or_later && GCC_11_or_later
     default y if GCC_7_or_older
     default y if GCC_8_or_later && GLIBC_2_27_or_later
     help

--- a/config/libc/glibc.in
+++ b/config/libc/glibc.in
@@ -3,7 +3,7 @@
 
 ## depends on ! WINDOWS && ! BARE_METAL && ARCH_USE_MMU
 ## select LIBC_SUPPORT_THREADS_NATIVE
-## select CC_CORE_PASSES_NEEDED
+## select CC_CORE_PASS_1_NEEDED
 # TBD: select GETTEXT for build only, not for host
 ## select GETTEXT_NEEDED
 ## select BINUTILS_FORCE_LD_BFD_DEFAULT

--- a/config/libc/moxiebox.in
+++ b/config/libc/moxiebox.in
@@ -10,8 +10,7 @@
 ## select LIBC_SUPPORT_THREADS_NONE
 ## select COMP_TOOLS_AUTOCONF if !CONFIGURE_has_autoconf_2_65_or_newer || !CONFIGURE_has_autoreconf_2_64_or_newer
 ## select COMP_TOOLS_AUTOMAKE if !CONFIGURE_has_automake_1_15_or_newer
-## select CC_CORE_PASSES_NEEDED if CANADIAN
-## select CC_CORE_PASS_2_NEEDED if ! CANADIAN
+## select CC_CORE_PASS_1_NEEDED
 ## select LIBELF_NEEDED
 ##
 ## help Secure execution runtime for Moxie architecture.

--- a/config/libc/musl.in
+++ b/config/libc/musl.in
@@ -3,7 +3,7 @@
 ## depends on ! WINDOWS && ! BARE_METAL
 ## depends on EXPERIMENTAL
 ## select LIBC_SUPPORT_THREADS_NATIVE
-## select CC_CORE_PASSES_NEEDED
+## select CC_CORE_PASS_1_NEEDED
 
 ## help Musl is a new standard library to power a new generation of Linux-based
 ## help devices. musl is lightweight, fast, simple, free, and strives to be

--- a/config/libc/newlib.in
+++ b/config/libc/newlib.in
@@ -2,8 +2,7 @@
 
 ## depends on BARE_METAL
 ## select LIBC_SUPPORT_THREADS_NONE
-## select CC_CORE_PASSES_NEEDED if CANADIAN
-## select CC_CORE_PASS_2_NEEDED if ! CANADIAN
+## select CC_CORE_PASS_1_NEEDED
 
 ## help Newlib is a C library intended for use on embedded systems. It is a
 ## help conglomeration of several library parts, all under free software

--- a/config/libc/uClibc.in
+++ b/config/libc/uClibc.in
@@ -5,7 +5,7 @@
 ## select LIBC_SUPPORT_THREADS_LT
 ## select LIBC_SUPPORT_THREADS_NONE
 ## select LIBC_SUPPORT_THREADS_NATIVE if UCLIBC_0_9_33_2_or_later
-## select CC_CORE_PASSES_NEEDED
+## select CC_CORE_PASS_1_NEEDED
 ##
 ## help The de-facto standard for embeded linux systems.
 ## help

--- a/scripts/build/cc/gcc.sh
+++ b/scripts/build/cc/gcc.sh
@@ -202,6 +202,8 @@ do_cc_core_pass_1() {
     core_opts+=( "ldflags=${CT_LDFLAGS_FOR_BUILD}" )
     core_opts+=( "lang_list=c" )
     core_opts+=( "build_step=core1" )
+    core_opts+=( "mode=static" )
+    core_opts+=( "build_libgcc=yes" )
 
     CT_DoStep INFO "Installing pass-1 core C gcc compiler"
     CT_mkdir_pushd "${CT_BUILD_DIR}/build-cc-gcc-core-pass-1"


### PR DESCRIPTION
Per https://github.com/crosstool-ng/crosstool-ng/issues/808 build static
libgcc in the first pass which lets us skip the second one.

Very lightly tested at this point. Creating PR to make use of CI builds.