### PR TITLE
isl: Update mirror URL

### DIFF
--- a/packages/isl/package.desc
+++ b/packages/isl/package.desc
@@ -1,6 +1,6 @@
 repository='git git://repo.or.cz/isl.git'
 bootstrap='./autogen.sh'
-mirrors='http://isl.gforge.inria.fr'
+mirrors='https://libisl.sourceforge.io'
 relevantpattern='*.*|.'
 milestones='0.12 0.13 0.14 0.15 0.18'
 archive_formats='.tar.xz .tar.bz2 .tar.gz'


### PR DESCRIPTION
gforge.inria.fr has been shutdown. The isl project has moved hosting to
sourceforge.io. Update the mirror accordingly.

Signed-off-by: Chris Packham <judge.packham@gmail.com>