### PR TITLE
cloog: remove gnu mirror

### DIFF
--- a/packages/cloog/package.desc
+++ b/packages/cloog/package.desc
@@ -1,5 +1,5 @@
 pkg_label='CLooG'
 repository='git git://repo.or.cz/cloog.git'
-mirrors='http://www.bastoul.net/cloog/pages/download ftp://gcc.gnu.org/pub/gcc/infrastructure'
+mirrors='http://www.bastoul.net/cloog/pages/download'
 milestones='0.18.1 0.18.4'
 archive_formats='.tar.gz'


### PR DESCRIPTION
The GNU mirror doesn't contain cloog-18.4. Remove it.

Signed-off-by: Chris Packham <judge.packham@gmail.com>