### PR TITLE
CI: install the latest GNU make on macOS

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -24,7 +24,7 @@ jobs:
         if: ${{ runner.os == 'macOS' }}
         run: |
           brew install autoconf automake bash binutils gawk gnu-sed \
-               gnu-tar help2man ncurses
+               gnu-tar help2man make ncurses
       - name: "build ct-ng"
         run: |
           if [ "$RUNNER_OS" == "macOS" ]; then
@@ -170,7 +170,7 @@ jobs:
         if: ${{ runner.os == 'macOS' }}
         run: |
           brew install autoconf automake bash binutils gawk gnu-sed \
-               gnu-tar help2man ncurses pkg-config
+               gnu-tar help2man make ncurses pkg-config
           echo "$GITHUB_WORKSPACE/.local/bin" >> $GITHUB_PATH
       - name: "build ${{ matrix.sample }} for ${{ matrix.host }}"
         run: |


### PR DESCRIPTION
The CI builds currently seem unhappy on macOS when we build make
ourselves. Install GNU make via brew so that we don't have to build it
ourselves.

Signed-off-by: Chris Packham <judge.packham@gmail.com>