### PR TITLE
CI: Add mingw32 samples

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -111,6 +111,7 @@ jobs:
           "arm-unknown-linux-musleabi",
           "armv6-nommu-linux-uclibcgnueabi",
           "avr",
+          "i686-w64-mingw32",
           "mips-unknown-elf",
           "mips-unknown-linux-gnu",
           "mips64-unknown-linux-gnu",
@@ -123,6 +124,7 @@ jobs:
           "sparc-unknown-linux-gnu",
           "x86_64-unknown-linux-gnu",
           "x86_64-multilib-linux-uclibc",
+          "x86_64-w64-mingw32",
           "xtensa-fsf-linux-uclibc"
         ]
         exclude:


### PR DESCRIPTION
Add i686-w64-mingw32 and x86_64-w64-mingw32 to the targets built for CI.

Signed-off-by: Chris Packham <judge.packham@gmail.com>