### PR TITLE
Fix deterministic binutils option

### DIFF
--- a/config/binutils/binutils.in
+++ b/config/binutils/binutils.in
@@ -140,8 +140,8 @@ config BINUTILS_RELRO
 
 config BINUTILS_DETERMINISTIC_ARCHIVES
     bool
-    prompt "Enable deterministic archives by default" if BINUTILS_2_23_or_later
-    default y if BINUTILS_2_23_or_later
+    prompt "Enable deterministic archives by default"
+    default y
     help
       Setting this option will enable deterministic mode by default (-D).
       ar and ranlib will use zero for UIDs, GIDs,


### PR DESCRIPTION
Versions before 2.26 got removed in fa992b41, together with
CT_BINUTILS_2_23_or_later.
Remove reference to this variable

Signed-off-by: Norbert Lange <nolange79@gmail.com>