### PR TITLE
binutils-2.37: add more patches from upstream release branch

### DIFF
--- a/packages/binutils/2.37/0011-bfd-close-the-file-descriptor-if-there-is-no-archive-fd.patch
+++ b/packages/binutils/2.37/0011-bfd-close-the-file-descriptor-if-there-is-no-archive-fd.patch
@@ -1,0 +1,232 @@
+From 1c611b40e6bfc8029bff7696814330b5bc0ee5c0 Mon Sep 17 00:00:00 2001
+From: "H.J. Lu" <hjl.tools@gmail.com>
+Date: Mon, 26 Jul 2021 05:59:55 -0700
+Subject: [PATCH] bfd: Close the file descriptor if there is no archive fd
+
+Close the file descriptor if there is no archive plugin file descriptor
+to avoid running out of file descriptors on thin archives with many
+archive members.
+
+bfd/
+
+	PR ld/28138
+	* plugin.c (bfd_plugin_close_file_descriptor): Close the file
+	descriptor there is no archive plugin file descriptor.
+
+ld/
+
+	PR ld/28138
+	* testsuite/ld-plugin/lto.exp: Run tmpdir/pr28138 only for
+	native build.
+
+	PR ld/28138
+	* testsuite/ld-plugin/lto.exp: Run ld/28138 tests.
+	* testsuite/ld-plugin/pr28138.c: New file.
+	* testsuite/ld-plugin/pr28138-1.c: Likewise.
+	* testsuite/ld-plugin/pr28138-2.c: Likewise.
+	* testsuite/ld-plugin/pr28138-3.c: Likewise.
+	* testsuite/ld-plugin/pr28138-4.c: Likewise.
+	* testsuite/ld-plugin/pr28138-5.c: Likewise.
+	* testsuite/ld-plugin/pr28138-6.c: Likewise.
+	* testsuite/ld-plugin/pr28138-7.c: Likewise.
+
+(cherry picked from commit 5a98fb7513b559e20dfebdbaa2a471afda3b4742)
+(cherry picked from commit 7dc37e1e1209c80e0bab784df6b6bac335e836f2)
+---
+ bfd/plugin.c                       |  8 +++++++
+ ld/testsuite/ld-plugin/lto.exp     | 34 ++++++++++++++++++++++++++++++
+ ld/testsuite/ld-plugin/pr28138-1.c |  6 ++++++
+ ld/testsuite/ld-plugin/pr28138-2.c |  6 ++++++
+ ld/testsuite/ld-plugin/pr28138-3.c |  6 ++++++
+ ld/testsuite/ld-plugin/pr28138-4.c |  6 ++++++
+ ld/testsuite/ld-plugin/pr28138-5.c |  6 ++++++
+ ld/testsuite/ld-plugin/pr28138-6.c |  6 ++++++
+ ld/testsuite/ld-plugin/pr28138-7.c |  6 ++++++
+ ld/testsuite/ld-plugin/pr28138.c   | 20 ++++++++++++++++++
+ 10 files changed, 104 insertions(+)
+ create mode 100644 ld/testsuite/ld-plugin/pr28138-1.c
+ create mode 100644 ld/testsuite/ld-plugin/pr28138-2.c
+ create mode 100644 ld/testsuite/ld-plugin/pr28138-3.c
+ create mode 100644 ld/testsuite/ld-plugin/pr28138-4.c
+ create mode 100644 ld/testsuite/ld-plugin/pr28138-5.c
+ create mode 100644 ld/testsuite/ld-plugin/pr28138-6.c
+ create mode 100644 ld/testsuite/ld-plugin/pr28138-7.c
+ create mode 100644 ld/testsuite/ld-plugin/pr28138.c
+
+diff --git a/bfd/plugin.c b/bfd/plugin.c
+index 6cfa2b66470..3bab8febe88 100644
+--- a/bfd/plugin.c
++++ b/bfd/plugin.c
+@@ -291,6 +291,14 @@ bfd_plugin_close_file_descriptor (bfd *abfd, int fd)
+ 	     && !bfd_is_thin_archive (abfd->my_archive))
+ 	abfd = abfd->my_archive;
+ 
++      /* Close the file descriptor if there is no archive plugin file
++	 descriptor.  */
++      if (abfd->archive_plugin_fd == -1)
++	{
++	  close (fd);
++	  return;
++	}
++
+       abfd->archive_plugin_fd_open_count--;
+       /* Dup the archive plugin file descriptor for later use, which
+ 	 will be closed by _bfd_archive_close_and_cleanup.  */
+diff --git a/ld/testsuite/ld-plugin/lto.exp b/ld/testsuite/ld-plugin/lto.exp
+index def69e43ab3..999d911ce6a 100644
+--- a/ld/testsuite/ld-plugin/lto.exp
++++ b/ld/testsuite/ld-plugin/lto.exp
+@@ -687,6 +687,40 @@ if { [is_elf_format] && [check_lto_shared_available] } {
+     }
+ }
+ 
++run_cc_link_tests [list \
++    [list \
++	"Build pr28138.a" \
++	"-T" "" \
++	{pr28138-1.c pr28138-2.c pr28138-3.c pr28138-4.c pr28138-5.c \
++	 pr28138-6.c pr28138-7.c} {} "pr28138.a" \
++    ] \
++    [list \
++	"Build pr28138.o" \
++	"" "" \
++	{pr28138.c} {} \
++    ] \
++]
++
++set exec_output [run_host_cmd "sh" \
++			      "-c \"ulimit -n 20; \
++			      $CC -Btmpdir/ld -o tmpdir/pr28138 \
++			      tmpdir/pr28138.o tmpdir/pr28138.a\""]
++set exec_output [prune_warnings $exec_output]
++if [string match "" $exec_output] then {
++    if { [isnative] } {
++	set exec_output [run_host_cmd "tmpdir/pr28138" ""]
++	if [string match "PASS" $exec_output] then {
++	    pass "PR ld/28138"
++	} else {
++	    fail "PR ld/28138"
++	}
++    } else {
++	pass "PR ld/28138"
++    }
++} else {
++    fail "PR ld/28138"
++}
++
+ set testname "Build liblto-11.a"
+ remote_file host delete "tmpdir/liblto-11.a"
+ set catch_output [run_host_cmd "$ar" "rc $plug_opt tmpdir/liblto-11.a tmpdir/lto-11a.o tmpdir/lto-11b.o tmpdir/lto-11c.o"]
+diff --git a/ld/testsuite/ld-plugin/pr28138-1.c b/ld/testsuite/ld-plugin/pr28138-1.c
+new file mode 100644
+index 00000000000..51d119e1642
+--- /dev/null
++++ b/ld/testsuite/ld-plugin/pr28138-1.c
+@@ -0,0 +1,6 @@
++extern int a0(void);
++int
++a1(void)
++{
++  return 1 + a0();
++}
+diff --git a/ld/testsuite/ld-plugin/pr28138-2.c b/ld/testsuite/ld-plugin/pr28138-2.c
+new file mode 100644
+index 00000000000..1120cd797e9
+--- /dev/null
++++ b/ld/testsuite/ld-plugin/pr28138-2.c
+@@ -0,0 +1,6 @@
++extern int a1(void);
++int
++a2(void)
++{
++  return 1 + a1();
++}
+diff --git a/ld/testsuite/ld-plugin/pr28138-3.c b/ld/testsuite/ld-plugin/pr28138-3.c
+new file mode 100644
+index 00000000000..ec464947ee6
+--- /dev/null
++++ b/ld/testsuite/ld-plugin/pr28138-3.c
+@@ -0,0 +1,6 @@
++extern int a2(void);
++int
++a3(void)
++{
++  return 1 + a2();
++}
+diff --git a/ld/testsuite/ld-plugin/pr28138-4.c b/ld/testsuite/ld-plugin/pr28138-4.c
+new file mode 100644
+index 00000000000..475701b2c5c
+--- /dev/null
++++ b/ld/testsuite/ld-plugin/pr28138-4.c
+@@ -0,0 +1,6 @@
++extern int a3(void);
++int
++a4(void)
++{
++  return 1 + a3();
++}
+diff --git a/ld/testsuite/ld-plugin/pr28138-5.c b/ld/testsuite/ld-plugin/pr28138-5.c
+new file mode 100644
+index 00000000000..e24f86c363e
+--- /dev/null
++++ b/ld/testsuite/ld-plugin/pr28138-5.c
+@@ -0,0 +1,6 @@
++extern int a4(void);
++int
++a5(void)
++{
++  return 1 + a4();
++}
+diff --git a/ld/testsuite/ld-plugin/pr28138-6.c b/ld/testsuite/ld-plugin/pr28138-6.c
+new file mode 100644
+index 00000000000..b5b938bdb21
+--- /dev/null
++++ b/ld/testsuite/ld-plugin/pr28138-6.c
+@@ -0,0 +1,6 @@
++extern int a5(void);
++int
++a6(void)
++{
++  return 1 + a5();
++}
+diff --git a/ld/testsuite/ld-plugin/pr28138-7.c b/ld/testsuite/ld-plugin/pr28138-7.c
+new file mode 100644
+index 00000000000..4ef75bf0f0c
+--- /dev/null
++++ b/ld/testsuite/ld-plugin/pr28138-7.c
+@@ -0,0 +1,6 @@
++extern int a6(void);
++int
++a7(void)
++{
++  return 1 + a6();
++}
+diff --git a/ld/testsuite/ld-plugin/pr28138.c b/ld/testsuite/ld-plugin/pr28138.c
+new file mode 100644
+index 00000000000..68252c9f382
+--- /dev/null
++++ b/ld/testsuite/ld-plugin/pr28138.c
+@@ -0,0 +1,20 @@
++#include <stdio.h>
++
++extern int a7(void);
++
++int
++a0(void)
++{
++  return 0;
++}
++
++int
++main()
++{
++  if (a7() == 7)
++    {
++      printf ("PASS\n");
++      return 0;
++    }
++  return 1;
++}
+-- 
+2.27.0
+

--- a/packages/binutils/2.37/0012-pr28391-strip-objcopy-preserve-dates-a-cannot-set-time.patch
+++ b/packages/binutils/2.37/0012-pr28391-strip-objcopy-preserve-dates-a-cannot-set-time.patch
@@ -1,0 +1,51 @@
+From 6b02746a0e29b1007efd4feb137e2da3e681fc68 Mon Sep 17 00:00:00 2001
+From: Gleb Fotengauer-Malinovskiy <glebfm@altlinux.org>
+Date: Tue, 28 Sep 2021 20:11:26 +0930
+Subject: [PATCH] PR28391, strip/objcopy --preserve-dates *.a: cannot set time
+
+After commit 985e0264516 copy_archive function began to pass invalid
+values to the utimensat(2) function when it tries to preserve
+timestamps in ar archives.  This happens because the bfd_stat_arch_elt
+implementation for ar archives fills only the st_mtim.tv_sec part of
+the st_mtim timespec structure, but leaves the st_mtim.tv_nsec part
+and the whole st_atim timespec untouched leaving them uninitialized
+
+	PR 28391
+	* ar.c (extract_file): Clear buf for preserve_dates.
+	* objcopy.c (copy_archive): Likewise.
+
+(cherry picked from commit 0d62064867c74286360e821b75ef6799bedc4b34)
+---
+ binutils/ar.c      | 3 +++
+ binutils/objcopy.c | 1 +
+ 2 files changed, 4 insertions(+)
+
+diff --git a/binutils/ar.c b/binutils/ar.c
+index 5d6976c7027..8885585ef75 100644
+--- a/binutils/ar.c
++++ b/binutils/ar.c
+@@ -1180,6 +1180,9 @@ extract_file (bfd *abfd)
+   bfd_size_type size;
+   struct stat buf;
+ 
++  if (preserve_dates)
++    memset (&buf, 0, sizeof (buf));
++
+   if (bfd_stat_arch_elt (abfd, &buf) != 0)
+     /* xgettext:c-format */
+     fatal (_("internal stat error on %s"), bfd_get_filename (abfd));
+diff --git a/binutils/objcopy.c b/binutils/objcopy.c
+index a6c2e0dcc26..fd7557fe433 100644
+--- a/binutils/objcopy.c
++++ b/binutils/objcopy.c
+@@ -3600,6 +3600,7 @@ copy_archive (bfd *ibfd, bfd *obfd, const char *output_target,
+ 
+       if (preserve_dates)
+ 	{
++	  memset (&buf, 0, sizeof (buf));
+ 	  stat_status = bfd_stat_arch_elt (this_element, &buf);
+ 
+ 	  if (stat_status != 0)
+-- 
+2.27.0
+

--- a/packages/binutils/2.37/0013-ld-pru-fix-resource_table-output-section-alignment.patch
+++ b/packages/binutils/2.37/0013-ld-pru-fix-resource_table-output-section-alignment.patch
@@ -1,0 +1,60 @@
+From a9c3934f6cb4407c5aaae82ada3b859d8ca9df83 Mon Sep 17 00:00:00 2001
+From: Dimitar Dimitrov <dimitar@dinux.eu>
+Date: Mon, 27 Sep 2021 22:43:24 +0300
+Subject: [PATCH] ld: pru: Fix resource_table output section alignment
+
+My commit 261980de18b added alignment for the resource table symbol.
+But it is wrong.  The Linux remoteproc driver loads and interprets the
+contents of the .resource_table ELF section, not of a table symbol.
+
+Without this patch, if the linker happens to output padding for symbol
+alignment, then the resource table contents as viewed by the kernel
+loader would "shift" and look corrupted.
+
+ld/ChangeLog:
+
+	* scripttempl/pru.sc  (.resource_table): Align the output
+	section, not the first symbol.
+
+Signed-off-by: Dimitar Dimitrov <dimitar@dinux.eu>
+(cherry picked from commit 5109a7bd9b87bdad530f2ebf97036e6087b4504d)
+---
+ ld/ChangeLog          | 5 +++++
+ ld/scripttempl/pru.sc | 7 +++----
+ 2 files changed, 8 insertions(+), 4 deletions(-)
+
+diff --git a/ld/ChangeLog b/ld/ChangeLog
+index 5048b5b6a17..ee3259a06de 100644
+--- a/ld/ChangeLog
++++ b/ld/ChangeLog
+@@ -1,3 +1,8 @@
++2021-09-30  Dimitar Dimitrov  <dimitar@dinux.eu>
++
++	* scripttempl/pru.sc (.resource_table): Align the output
++	section, not the first symbol.
++
+ 2021-07-18  Nick Clifton  <nickc@redhat.com>
+ 
+ 	* 2.37 release.
+diff --git a/ld/scripttempl/pru.sc b/ld/scripttempl/pru.sc
+index b2c941b7911..97d8be0a0a4 100644
+--- a/ld/scripttempl/pru.sc
++++ b/ld/scripttempl/pru.sc
+@@ -151,11 +151,10 @@ SECTIONS
+     ${RELOCATING+ PROVIDE (_data_end = .) ; }
+   } ${RELOCATING+ > dmem }
+ 
+-  .resource_table ${RELOCATING-0} :
++  /* Linux remoteproc loader requires the resource_table section
++     start address to be aligned to 8 bytes.  */
++  .resource_table ${RELOCATING-0} ${RELOCATING+ ALIGN(8)} :
+   {
+-    /* Linux remoteproc loader requires the resource table address
+-       to be aligned to 8 bytes.  */
+-    ${RELOCATING+. = ALIGN(8);}
+     KEEP (*(.resource_table))
+   } ${RELOCATING+ > dmem}
+ 
+-- 
+2.27.0
+

--- a/packages/binutils/2.37/0014-pr28422-build_id-use-after-free.patch
+++ b/packages/binutils/2.37/0014-pr28422-build_id-use-after-free.patch
@@ -1,0 +1,31 @@
+From c20c7adbeaa3af18a58ba1e20e6c33e7186356e3 Mon Sep 17 00:00:00 2001
+From: Alan Modra <amodra@gmail.com>
+Date: Wed, 6 Oct 2021 18:28:47 +1030
+Subject: [PATCH] PR28422, build_id use-after-free
+
+This fixes a bug in commit 5d9bbb73c1df.  All fields preserved from a
+bfd in struct bfd_preserve need to be cleared in bfd_reinit.
+
+	PR 28422
+	* format.c (bfd_reinit): Clear build_id.
+
+(cherry picked from commit 6d661cdc5be46e890ed9255e749806f46a88e26c)
+---
+ bfd/format.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/bfd/format.c b/bfd/format.c
+index 5d08d1d642c..408c984690e 100644
+--- a/bfd/format.c
++++ b/bfd/format.c
+@@ -151,6 +151,7 @@ bfd_reinit (bfd *abfd, unsigned int section_id, bfd_cleanup cleanup)
+   abfd->tdata.any = NULL;
+   abfd->arch_info = &bfd_default_arch_struct;
+   abfd->flags &= BFD_FLAGS_SAVED;
++  abfd->build_id = NULL;
+   bfd_section_list_clear (abfd);
+ }
+ 
+-- 
+2.27.0
+

--- a/packages/binutils/2.37/0015-pr28459-readelf-issues-bogus-warning.patch
+++ b/packages/binutils/2.37/0015-pr28459-readelf-issues-bogus-warning.patch
@@ -1,0 +1,40 @@
+From 61b08178e4cafca911bf909f54f8c373f16f0a70 Mon Sep 17 00:00:00 2001
+From: Alan Modra <amodra@gmail.com>
+Date: Sun, 17 Oct 2021 17:34:46 +1030
+Subject: [PATCH] PR28459, readelf issues bogus warning
+
+I'd missed the fact that the .debug_rnglists dump doesn't exactly
+display the contents of the section.  Instead readelf rummages through
+.debug_info looking for DW_AT_ranges entries, then displays the
+entries in .debug_rnglists pointed at, sorted.  A simpler dump of the
+actual section contents might be more useful and robust, but it was
+likely done that way to detect overlap and holes.
+
+Anyway, the headers in .debug_rnglists besides the first are ignored,
+and limiting to the unit length of the first header fails if there is
+more than one unit.
+
+	PR 28459
+	* dwarf.c (display_debug_ranges): Don't constrain data to length
+	in header.
+
+(cherry picked from commit e7f024765a48fba4452535a5fc006a7e858730fd)
+---
+ binutils/dwarf.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/binutils/dwarf.c b/binutils/dwarf.c
+index 1e7f4db7b7c..e73078f496f 100644
+--- a/binutils/dwarf.c
++++ b/binutils/dwarf.c
+@@ -7727,7 +7727,6 @@ display_debug_ranges (struct dwarf_section *section,
+ 	      return 0;
+ 	    }
+ 	}
+-      finish = start + initial_length;
+ 
+       /* Get and check the version number.  */
+       SAFE_BYTE_GET_AND_INC (version, start, 2, finish);
+-- 
+2.27.0
+

--- a/packages/binutils/2.37/0016-pr28417-std-string-no-longer-allows-accepting-nullptr_t.patch
+++ b/packages/binutils/2.37/0016-pr28417-std-string-no-longer-allows-accepting-nullptr_t.patch
@@ -1,0 +1,45 @@
+From 0effb90eb7c9a50408d98ce174f1b4bc5562f017 Mon Sep 17 00:00:00 2001
+From: Alan Modra <amodra@gmail.com>
+Date: Wed, 20 Oct 2021 10:09:57 +1030
+Subject: [PATCH] PR28417, std::string no longer allows accepting nullptr_t
+
+	PR 28417
+	* incremental.cc (Sized_relobj_incr::do_section_name): Avoid
+	std:string undefined behaviour.
+	* options.h (Search_directory::Search_directory): Likewise.
+
+(cherry picked from commit 068a039b8bd7c7386bb0d88f0ae245b0fe4132e9)
+---
+ gold/incremental.cc | 2 +-
+ gold/options.h      | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/gold/incremental.cc b/gold/incremental.cc
+index 52941985e6f..327a1527a29 100644
+--- a/gold/incremental.cc
++++ b/gold/incremental.cc
+@@ -2286,7 +2286,7 @@ Sized_relobj_incr<size, big_endian>::do_section_name(unsigned int shndx) const
+   const Output_sections& out_sections(this->output_sections());
+   const Output_section* os = out_sections[shndx];
+   if (os == NULL)
+-    return NULL;
++    return std::string();
+   return os->name();
+ }
+ 
+diff --git a/gold/options.h b/gold/options.h
+index 757ebf18fec..47299a37834 100644
+--- a/gold/options.h
++++ b/gold/options.h
+@@ -611,7 +611,7 @@ class Search_directory
+   // We need a default constructor because we put this in a
+   // std::vector.
+   Search_directory()
+-    : name_(NULL), put_in_sysroot_(false), is_in_sysroot_(false)
++    : name_(), put_in_sysroot_(false), is_in_sysroot_(false)
+   { }
+ 
+   // This is the usual constructor.
+-- 
+2.27.0
+

--- a/packages/binutils/2.37/0017-pr28540-segmentation-fault-on-NULL-byte_get.patch
+++ b/packages/binutils/2.37/0017-pr28540-segmentation-fault-on-NULL-byte_get.patch
@@ -1,0 +1,30 @@
+From 96eb21265ebffbc28f767bed9a2b7650ecb9818d Mon Sep 17 00:00:00 2001
+From: Alan Modra <amodra@gmail.com>
+Date: Thu, 4 Nov 2021 14:11:02 +1030
+Subject: [PATCH] PR28540, segmentation fault on NULL byte_get
+
+	PR 28540
+	* objdump.c (dump_bfd): Don't attempt load_separate_debug_files
+	when byte_get is NULL.
+
+(cherry picked from commit f2f105f518413ea3e4c212f89585f9a8a5dddcdd)
+---
+ binutils/objdump.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/binutils/objdump.c b/binutils/objdump.c
+index a7b8303b992..50317b3d48f 100644
+--- a/binutils/objdump.c
++++ b/binutils/objdump.c
+@@ -4869,7 +4869,7 @@ dump_bfd (bfd *abfd, bool is_mainfile)
+      
+      The test on is_mainfile is there because the chain of separate debug
+      info files is a global variable shared by all invocations of dump_bfd.  */
+-  if (is_mainfile)
++  if (byte_get != NULL && is_mainfile)
+     {
+       load_separate_debug_files (abfd, bfd_get_filename (abfd));
+ 
+-- 
+2.27.0
+

--- a/packages/binutils/2.37/0018-gold-place-note-gnu-property-section-before-other-note-sections.patch
+++ b/packages/binutils/2.37/0018-gold-place-note-gnu-property-section-before-other-note-sections.patch
@@ -1,0 +1,57 @@
+From bd711d6329ebb9328a99bd4be501932082248e44 Mon Sep 17 00:00:00 2001
+From: "H.J. Lu" <hjl.tools@gmail.com>
+Date: Mon, 25 Oct 2021 08:42:24 -0700
+Subject: [PATCH] gold: Place .note.gnu.property section before other note
+ sections
+
+Place the .note.gnu.property section before all other note sections to
+avoid being placed between other note sections with different alignments.
+
+	PR gold/28494
+	* layout.cc (Layout::create_note): Set order to ORDER_PROPERTY_NOTE
+	for the .note.gnu.property section.
+	* layout.h (Output_section_order): Add ORDER_PROPERTY_NOTE.
+
+(cherry picked from commit f85dcfc3af9cf7c2859241253f1d37b1133abea2)
+---
+ gold/layout.cc | 3 ++-
+ gold/layout.h  | 9 +++++++--
+ 2 files changed, 9 insertions(+), 3 deletions(-)
+
+diff --git a/gold/layout.cc b/gold/layout.cc
+index a27cb071c75..38e9bceec7e 100644
+--- a/gold/layout.cc
++++ b/gold/layout.cc
+@@ -3245,7 +3245,8 @@ Layout::create_note(const char* name, int note_type,
+   if (allocate)
+     {
+       flags = elfcpp::SHF_ALLOC;
+-      order = ORDER_RO_NOTE;
++      order = (note_type == elfcpp::NT_GNU_PROPERTY_TYPE_0
++	       ?  ORDER_PROPERTY_NOTE : ORDER_RO_NOTE);
+     }
+   Output_section* os = this->choose_output_section(NULL, section_name,
+ 						   elfcpp::SHT_NOTE,
+diff --git a/gold/layout.h b/gold/layout.h
+index 0b378003679..05c31714e47 100644
+--- a/gold/layout.h
++++ b/gold/layout.h
+@@ -399,8 +399,13 @@ enum Output_section_order
+   // linker can pick it up quickly.
+   ORDER_INTERP,
+ 
+-  // Loadable read-only note sections come next so that the PT_NOTE
+-  // segment is on the first page of the executable.
++  // The .note.gnu.property section comes next so that the PT_NOTE
++  // segment is on the first page of the executable and it won't be
++  // placed between other note sections with different alignments.
++  ORDER_PROPERTY_NOTE,
++
++  // Loadable read-only note sections come after the .note.gnu.property
++  // section.
+   ORDER_RO_NOTE,
+ 
+   // Put read-only sections used by the dynamic linker early in the
+-- 
+2.27.0
+

--- a/packages/binutils/2.37/0019-waddress-warning-in-ldelf.c.patch
+++ b/packages/binutils/2.37/0019-waddress-warning-in-ldelf.c.patch
@@ -1,0 +1,36 @@
+From c912b88e003a43e10020f56675fbd7e180d255ab Mon Sep 17 00:00:00 2001
+From: Alan Modra <amodra@gmail.com>
+Date: Thu, 21 Oct 2021 19:18:34 +1030
+Subject: [PATCH] -Waddress warning in ldelf.c
+
+ldelf.c: In function 'ldelf_after_open':
+ldelf.c:1049:43: warning: the comparison will always evaluate as 'true' for the address of 'elf_header' will never be NULL [-Waddress]
+ 1049 |           && elf_tdata (abfd)->elf_header != NULL
+      |                                           ^~
+In file included from ldelf.c:37:
+../bfd/elf-bfd.h:1957:21: note: 'elf_header' declared here
+ 1957 |   Elf_Internal_Ehdr elf_header[1];      /* Actual data, but ref like ptr */
+
+	PR ld/28734
+	* ldelf.c (ldelf_after_open): Remove useless elf_header test.
+
+(cherry picked from commit ced10cb78d01652f9e1bb1d1e465327dfe1debaa)
+---
+ ld/ldelf.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/ld/ldelf.c b/ld/ldelf.c
+index 21e655bb55c..0c39eb6024f 100644
+--- a/ld/ldelf.c
++++ b/ld/ldelf.c
+@@ -1046,7 +1046,6 @@ ldelf_after_open (int use_libpath, int native, int is_linux, int is_freebsd,
+       if (abfd->xvec->flavour == bfd_target_elf_flavour
+ 	  && !bfd_input_just_syms (abfd)
+ 	  && elf_tdata (abfd) != NULL
+-	  && elf_tdata (abfd)->elf_header != NULL
+ 	  /* FIXME: Maybe check for other non-supportable types as well ?  */
+ 	  && (elf_tdata (abfd)->elf_header->e_type == ET_EXEC
+ 	      || (elf_tdata (abfd)->elf_header->e_type == ET_DYN
+-- 
+2.27.0
+


### PR DESCRIPTION
Fetch in various patches from binutils-2_37-branch upstream.

The most vital change is the
0012-pr28391-strip-objcopy-preserve-dates-a-cannot-set-time.patch which
allows building large upstream projects like Qt WebEngine without need
100k's of file descriptors open.

Signed-off-by: Hans-Christian Noren Egtvedt <hegtvedt@cisco.com>