### PR TITLE
powerpc: Allow GCC 8.5 for SPE ABI

### DIFF
--- a/config/arch/powerpc.in
+++ b/config/arch/powerpc.in
@@ -43,7 +43,7 @@ config ARCH_powerpc_ABI_EABI
 config ARCH_powerpc_ABI_SPE
     bool
     prompt "SPE"
-    select GCC_REQUIRE_8_or_older
+    select GCC_REQUIRE_older_than_9
     select GLIBC_REQUIRE_2_29_or_older
     help
       Add support for the Signal Processing Engine.  This will set up


### PR DESCRIPTION
Support for the SPE ABI was removed in GCC 9. Update the select to
GCC_REQUIRE_older_than_9 so that GCC 8.5 can be selected.

Fixes #1349, fixes #1666

Signed-off-by: Chris Packham <judge.packham@gmail.com>