### PR TITLE
glibc: mark 2.12.1 as obsolete

### DIFF
--- a/packages/glibc-ports/2.12.1/version.desc
+++ b/packages/glibc-ports/2.12.1/version.desc
@@ -1,1 +1,2 @@
 archive_formats='.tar.bz2 .tar.gz'
+obsolete='yes'

--- a/packages/glibc/2.12.1/version.desc
+++ b/packages/glibc/2.12.1/version.desc
@@ -1,1 +1,1 @@
-# Not obsolete (CentOS 6, EOL 11/2020)
+obsolete='yes'


### PR DESCRIPTION
CentOS6 has reached EOL so now glibc-2.12.1 can be marked as obsolete.
This also means the last glibc-ports version (and glibc-ports itself)
obsolete as well. These will be removed after the next release.

Signed-off-by: Chris Packham <judge.packham@gmail.com>