### PR TITLE
binutils: Disable libdebuginfod when producing a static toolchain

### DIFF
--- a/scripts/build/binutils/binutils.sh
+++ b/scripts/build/binutils/binutils.sh
@@ -171,6 +171,9 @@ do_binutils_backend() {
     extra_config+=("--disable-sim")
     extra_config+=("--disable-gdb")
 
+    # libdebuginfod in incompatible with static linking
+    [ "${CT_STATIC_TOOLCHAIN}" = "y" ] && extra_config+=("--without-debuginfod")
+
     [ "${CT_TOOLCHAIN_ENABLE_NLS}" != "y" ] && extra_config+=("--disable-nls")
 
     # Disable usage of glob for higher compatibility.


### PR DESCRIPTION
libdebuginfod is incompatible with static linking so pass
--without-debuginfod when CT_STATIC_TOOLCHAIN is selected.

Fixes #1683

Signed-off-by: Chris Packham <judge.packham@gmail.com>