### PR TITLE
gcc: add gcc libstdcxx-verbose option

### DIFF
--- a/config/cc/gcc.in
+++ b/config/cc/gcc.in
@@ -280,6 +280,23 @@ config CC_GCC_LIBMPX
     help
       Enable GCC support for Intel Memory Protection Extensions (MPX).
 
+config CC_GCC_LIBSTDCXX_VERBOSE
+    tristate
+    default n if BARE_METAL
+    default m if !BARE_METAL
+    prompt "Verbose libstdc++"
+    depends on GCC_4_8_or_later
+    depends on CC_LANG_CXX
+    help
+      Write descriptive error messages on certain events.
+      
+      Those messages cause the library to depend on the demangler and
+      standard I/O facilities, which will pull in alot of dependencies
+      on static builds.
+      On embedded systems this is often not wanted, and the std io
+      facilities might not work at all.
+
+
 #-----------------------------------------------------------------------------
 
 comment "Misc. obscure options."

--- a/scripts/build/cc/gcc.sh
+++ b/scripts/build/cc/gcc.sh
@@ -375,6 +375,11 @@ do_gcc_core_backend() {
         extra_config+=(--disable-libquadmath-support)
     fi
 
+    case "${CT_CC_GCC_LIBSTDCXX_VERBOSE}" in
+        y)  extra_config+=("--enable-libstdcxx-verbose");;
+        "") extra_config+=("--disable-libstdcxx-verbose");;
+    esac
+
     if [ "${build_libstdcxx}" = "no" ]; then
         extra_config+=(--disable-libstdcxx)
     fi
@@ -1010,6 +1015,11 @@ do_gcc_backend() {
         fi
     fi
 
+    case "${CT_CC_GCC_LIBSTDCXX_VERBOSE}" in
+        y)  extra_config+=("--enable-libstdcxx-verbose");;
+        "") extra_config+=("--disable-libstdcxx-verbose");;
+    esac
+    
     if [ "${build_libstdcxx}" = "no" ]; then
         extra_config+=(--disable-libstdcxx)
     fi


### PR DESCRIPTION
Rather important option for arm cortex toolchains supporting c++,
avoids pulling in all printf/iostream code by default.
