### PR TITLE
kconfig: Use ncurses location determined by ./configure

### DIFF
--- a/kconfig/lxdialog/dialog.h
+++ b/kconfig/lxdialog/dialog.h
@@ -16,7 +16,7 @@
 #ifdef __sun__
 #define CURS_MACROS
 #endif
-#include <ncurses.h>
+#include CURSES_LOC
 
 /*
  * Colors in ncurses 1.9.9e do not work properly since foreground and

--- a/kconfig/nconf.h
+++ b/kconfig/nconf.h
@@ -13,8 +13,8 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <ncurses.h>
-#include <menu.h>
+#include CURSES_LOC
+#include MENU_LOC
 #include <panel.h>
 #include <form.h>
 


### PR DESCRIPTION
Prior to commit bbc4db13 ("kconfig: Sync with upstream v4.18") we used
the macro CURSES_LOC to tell us where curses.h was installed. Restore
this behaviour so that we can deal with some of the odd places curses.h
ends up.

Fixes #1403

Signed-off-by: Chris Packham <judge.packham@gmail.com>