### PR TITLE
binutils: Bring in upstream fix for powerpc

### DIFF
--- a/packages/binutils/2.38/0008-binutils-2.38-vs.-ppc32-linux-kernel.patch
+++ b/packages/binutils/2.38/0008-binutils-2.38-vs.-ppc32-linux-kernel.patch
@@ -1,0 +1,52 @@
+From cebc89b9328eab994f6b0314c263f94e7949a553 Mon Sep 17 00:00:00 2001
+From: Alan Modra <amodra@gmail.com>
+Date: Mon, 21 Feb 2022 10:58:57 +1030
+Subject: [PATCH] binutils 2.38 vs. ppc32 linux kernel
+
+Commit b25f942e18d6 made .machine more strict.  Weaken it again.
+
+	* config/tc-ppc.c (ppc_machine): Treat an early .machine specially,
+	keeping sticky options to work around gcc bugs.
+---
+ gas/config/tc-ppc.c | 25 ++++++++++++++++++++++++-
+ 1 file changed, 24 insertions(+), 1 deletion(-)
+
+diff --git a/gas/config/tc-ppc.c b/gas/config/tc-ppc.c
+index 054f9c72161..89bc7d3f9b9 100644
+--- a/gas/config/tc-ppc.c
++++ b/gas/config/tc-ppc.c
+@@ -5965,7 +5965,30 @@ ppc_machine (int ignore ATTRIBUTE_UNUSED)
+ 	     options do not count as a new machine, instead they add
+ 	     to currently selected opcodes.  */
+ 	  ppc_cpu_t machine_sticky = 0;
+-	  new_cpu = ppc_parse_cpu (ppc_cpu, &machine_sticky, cpu_string);
++	  /* Unfortunately, some versions of gcc emit a .machine
++	     directive very near the start of the compiler's assembly
++	     output file.  This is bad because it overrides user -Wa
++	     cpu selection.  Worse, there are versions of gcc that
++	     emit the *wrong* cpu, not even respecting the -mcpu given
++	     to gcc.  See gcc pr101393.  And to compound the problem,
++	     as of 20220222 gcc doesn't pass the correct cpu option to
++	     gas on the command line.  See gcc pr59828.  Hack around
++	     this by keeping sticky options for an early .machine.  */
++	  asection *sec;
++	  for (sec = stdoutput->sections; sec != NULL; sec = sec->next)
++	    {
++	      segment_info_type *info = seg_info (sec);
++	      /* Are the frags for this section perturbed from their
++		 initial state?  Even .align will count here.  */
++	      if (info != NULL
++		  && (info->frchainP->frch_root != info->frchainP->frch_last
++		      || info->frchainP->frch_root->fr_type != rs_fill
++		      || info->frchainP->frch_root->fr_fix != 0))
++		break;
++	    }
++	  new_cpu = ppc_parse_cpu (ppc_cpu,
++				   sec == NULL ? &sticky : &machine_sticky,
++				   cpu_string);
+ 	  if (new_cpu != 0)
+ 	    ppc_cpu = new_cpu;
+ 	  else
+-- 
+2.35.1
+

--- a/packages/gcc/10.3.0/0023-powerpc-Fix-asm-machine-directive-for-some-CPUs.patch
+++ b/packages/gcc/10.3.0/0023-powerpc-Fix-asm-machine-directive-for-some-CPUs.patch
@@ -1,0 +1,59 @@
+From d568abb25fc799123168aac840372b28bb81f85d Mon Sep 17 00:00:00 2001
+From: Sebastian Huber <sebastian.huber@embedded-brains.de>
+Date: Tue, 18 Jan 2022 12:44:53 +0100
+Subject: [PATCH] powerpc: Fix asm machine directive for some CPUs
+
+For some CPUs, the assembler machine directive cannot be determined by ISA
+flags.
+
+gcc/
+
+	PR target/104090
+	* config/rs6000/rs6000.c (rs6000_machine_from_flags): Use also
+	rs6000_cpu.
+---
+ gcc/config/rs6000/rs6000.c | 28 ++++++++++++++++++++++++++++
+ 1 file changed, 28 insertions(+)
+
+diff --git a/gcc/config/rs6000/rs6000.c b/gcc/config/rs6000/rs6000.c
+index 4b473e00be39..5404fb187556 100644
+--- a/gcc/config/rs6000/rs6000.c
++++ b/gcc/config/rs6000/rs6000.c
+@@ -5547,6 +5547,34 @@ const char *rs6000_machine;
+ const char *
+ rs6000_machine_from_flags (void)
+ {
++  /* For some CPUs, the machine cannot be determined by ISA flags.  We have to
++     check them first.  */
++  switch (rs6000_cpu)
++    {
++    case PROCESSOR_PPC8540:
++    case PROCESSOR_PPC8548:
++      return "e500";
++
++    case PROCESSOR_PPCE300C2:
++    case PROCESSOR_PPCE300C3:
++      return "e300";
++
++    case PROCESSOR_PPCE500MC:
++      return "e500mc";
++
++    case PROCESSOR_PPCE500MC64:
++      return "e500mc64";
++
++    case PROCESSOR_PPCE5500:
++      return "e5500";
++
++    case PROCESSOR_PPCE6500:
++      return "e6500";
++
++    default:
++      break;
++    }
++
+   HOST_WIDE_INT flags = rs6000_isa_flags;
+ 
+   /* Disable the flags that should never influence the .machine selection.  */
+-- 
+2.35.1
+

--- a/packages/gcc/11.2.0/0010-powerpc-Fix-asm-machine-directive-for-some-CPUs.patch
+++ b/packages/gcc/11.2.0/0010-powerpc-Fix-asm-machine-directive-for-some-CPUs.patch
@@ -1,0 +1,59 @@
+From 3cb53c10831be59d967d9dce8e7980fee4703500 Mon Sep 17 00:00:00 2001
+From: Sebastian Huber <sebastian.huber@embedded-brains.de>
+Date: Tue, 18 Jan 2022 12:44:53 +0100
+Subject: [PATCH] powerpc: Fix asm machine directive for some CPUs
+
+For some CPUs, the assembler machine directive cannot be determined by ISA
+flags.
+
+gcc/
+
+	PR target/104090
+	* config/rs6000/rs6000.c (rs6000_machine_from_flags): Use also
+	rs6000_cpu.
+---
+ gcc/config/rs6000/rs6000.c | 28 ++++++++++++++++++++++++++++
+ 1 file changed, 28 insertions(+)
+
+diff --git a/gcc/config/rs6000/rs6000.c b/gcc/config/rs6000/rs6000.c
+index c4f5c53932c7..9b1c3a8b5eae 100644
+--- a/gcc/config/rs6000/rs6000.c
++++ b/gcc/config/rs6000/rs6000.c
+@@ -5766,6 +5766,34 @@ const char *rs6000_machine;
+ const char *
+ rs6000_machine_from_flags (void)
+ {
++  /* For some CPUs, the machine cannot be determined by ISA flags.  We have to
++     check them first.  */
++  switch (rs6000_cpu)
++    {
++    case PROCESSOR_PPC8540:
++    case PROCESSOR_PPC8548:
++      return "e500";
++
++    case PROCESSOR_PPCE300C2:
++    case PROCESSOR_PPCE300C3:
++      return "e300";
++
++    case PROCESSOR_PPCE500MC:
++      return "e500mc";
++
++    case PROCESSOR_PPCE500MC64:
++      return "e500mc64";
++
++    case PROCESSOR_PPCE5500:
++      return "e5500";
++
++    case PROCESSOR_PPCE6500:
++      return "e6500";
++
++    default:
++      break;
++    }
++
+   HOST_WIDE_INT flags = rs6000_isa_flags;
+ 
+   /* Disable the flags that should never influence the .machine selection.  */
+-- 
+2.35.1
+


### PR DESCRIPTION
Some versions of GCC emit a .machine directive near the start of the
compiler's assembly output that overrides the CPU passed on the command
line. Bring in an upstream change for binutils that works around the
problem.

Signed-off-by: Chris Packham <judge.packham@gmail.com>