### PR TITLE
xtensa: Remove obsoleted CT_ARCH_XTENSA_CUSTOM_NAME

### DIFF
--- a/config/arch/xtensa.in
+++ b/config/arch/xtensa.in
@@ -18,7 +18,7 @@
 ## help
 ## help    For a custom configuration, select the XTENSA_CUSTOM option and
 ## help    provide the name of the processor configuration through the
-## help    CT_ARCH_XTENSA_CUSTOM_NAME option.
+## help    CT_OVERLAY_NAME option.
 ## help
 ## help    The default option (ARCH_xtensa_fsf) uses a built-in configuration,
 ## help    which may or may not work for a particular Xtensa processor.


### PR DESCRIPTION
Just a minor fix, to be consistent in names and comments