### PR TITLE
testing/docker: Add meson and ninja to containers

### DIFF
--- a/testing/docker/fedora35/Dockerfile
+++ b/testing/docker/fedora35/Dockerfile
@@ -4,7 +4,8 @@ ARG CTNG_GID=1000
 RUN groupadd -g $CTNG_GID ctng
 RUN useradd -d /home/ctng -m -g $CTNG_GID -u $CTNG_UID -s /bin/bash ctng
 RUN yum install -y autoconf gperf bison file flex texinfo help2man gcc-c++ libtool make patch \
-    ncurses-devel python3-devel perl-Thread-Queue bzip2 git wget which xz unzip rsync diffutils
+    ncurses-devel python3-devel perl-Thread-Queue bzip2 git wget which xz unzip rsync diffutils \
+    meson ninja-build
 RUN wget -O /sbin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_x86_64
 RUN chmod a+x /sbin/dumb-init
 RUN echo 'export PATH=/opt/ctng/bin:$PATH' >> /etc/profile

--- a/testing/docker/mint20-amd64/Dockerfile
+++ b/testing/docker/mint20-amd64/Dockerfile
@@ -5,7 +5,7 @@ RUN groupadd -g $CTNG_GID ctng
 RUN useradd -d /home/ctng -m -g $CTNG_GID -u $CTNG_UID -s /bin/bash ctng
 RUN apt-get update
 RUN apt-get install -y gcc gperf bison flex texinfo help2man make libncurses5-dev \
-    python3-dev autoconf automake libtool libtool-bin gawk wget rsync
+    python3-dev autoconf automake libtool libtool-bin gawk wget rsync meson ninja-build
 RUN wget -O /sbin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_x86_64
 RUN chmod a+x /sbin/dumb-init
 RUN echo 'export PATH=/opt/ctng/bin:$PATH' >> /etc/profile

--- a/testing/docker/ubuntu18.04/Dockerfile
+++ b/testing/docker/ubuntu18.04/Dockerfile
@@ -6,7 +6,7 @@ RUN useradd -d /home/ctng -m -g $CTNG_GID -u $CTNG_UID -s /bin/bash ctng
 RUN apt-get update
 RUN apt-get install -y gcc g++ gperf bison flex texinfo help2man make libncurses5-dev \
     python3-dev autoconf automake libtool libtool-bin gawk wget bzip2 xz-utils unzip \
-    patch libstdc++6 rsync
+    patch libstdc++6 rsync meson ninja-build
 RUN wget -O /sbin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_x86_64
 RUN chmod a+x /sbin/dumb-init
 RUN echo 'export PATH=/opt/ctng/bin:$PATH' >> /etc/profile

--- a/testing/docker/ubuntu21.10/Dockerfile
+++ b/testing/docker/ubuntu21.10/Dockerfile
@@ -12,7 +12,7 @@ RUN { echo 'tzdata tzdata/Areas select Etc'; echo 'tzdata tzdata/Zones/Etc selec
 RUN apt-get update
 RUN apt-get install -y gcc g++ gperf bison flex texinfo help2man make libncurses5-dev \
     python3-dev autoconf automake libtool libtool-bin gawk wget bzip2 xz-utils unzip \
-    patch libstdc++6 rsync git
+    patch libstdc++6 rsync git meson ninja-build
 RUN wget -O /sbin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_x86_64
 RUN chmod a+x /sbin/dumb-init
 RUN echo 'export PATH=/opt/ctng/bin:$PATH' >> /etc/profile


### PR DESCRIPTION
meson and ninja are needed to build picolibc.

Signed-off-by: Chris Packham <judge.packham@gmail.com>