### PR TITLE
[scripts/functions]: Fix quoting issue in comparison

### DIFF
--- a/scripts/functions
+++ b/scripts/functions
@@ -727,7 +727,7 @@ CT_DoGetFile()
     rm -f "${tmp}"
 
     # Replace a special value of '-1' with empty string
-    if [ ${CT_CONNECT_TIMEOUT} != -1 ]; then
+    if [ "${CT_CONNECT_TIMEOUT}" != -1 ]; then
         T="${CT_CONNECT_TIMEOUT}"
     fi
 


### PR DESCRIPTION
On my Ubuntu machine (with `dash` version `0.5.10` and `bash` version `5.0.17`), I would get errors such as the following:

```
crosstool-ng/scripts/functions: line 730: [: !=: unary operator expected
```

This is generally because a variable is not set, and expands to an empty string causing the test operator to mis-parse the expression.  To fix this, I have added quotes around the variable.