### PR TITLE
glibc: Enable -Werror for more combinations of GCC/GLIBC

### DIFF
--- a/config/libc/glibc.in
+++ b/config/libc/glibc.in
@@ -403,11 +403,17 @@ config GLIBC_SSP
     default "strong" if GLIBC_SSP_STRONG
 
 # All supported versions of glibc build cleanly with GCC7 and earlier.
-# GCC8-related fixes were only available in glibc 2.27.
+# GCC8-related fixes were only available in glibc 2.27
+# GCC9-related fixes were available in glibc 2.29
+# GCC10-related fixes were available in glibc 2.31
+# GCC11-related fixes were available in glibc 2.34
 config GLIBC_ENABLE_WERROR
     bool "Enable -Werror during the build"
     default y if GCC_7_or_older
-    default y if GCC_8_or_later && GLIBC_2_27_or_later
+    default y if GCC_8_or_later && !GCC_9_or_later && GLIBC_2_27_or_later
+    default y if GCC_9_or_later && !GCC_10_or_later && GLIBC_2_29_or_later
+    default y if GCC_10_or_later && !GCC_11_or_later && GLIBC_2_31_or_later
+    default y if GCC_11_or_later && GLIBC_2_34_or_later
     help
       By default, glibc enables strict warning checks during the build.
       However, older version of glibc may not build with newer versions

--- a/packages/glibc/package.desc
+++ b/packages/glibc/package.desc
@@ -3,6 +3,6 @@ repository='git git://sourceware.org/git/glibc.git'
 mirrors='$(CT_Mirrors GNU glibc)'
 # Cannot use MAJOR.MINOR as the relevant part because of 2.12: 2.12.2 was the most recent
 # bugfix release, but it didn't have glibc-ports released alongside it.
-milestones='2.14 2.17 2.20 2.23 2.24 2.25 2.26 2.27 2.28 2.29 2.30 2.32'
+milestones='2.14 2.17 2.20 2.23 2.24 2.25 2.26 2.27 2.28 2.29 2.30 2.31 2.32 2.34'
 archive_formats='.tar.xz .tar.bz2 .tar.gz'
 signature_format='packed/.sig'


### PR DESCRIPTION
Newer GCC versions trigger warnings on older GLIBC versions. GLIBC 2.29
is warning free with GCC9. GLIBC 2.31 is warning free with GCC10. GLIBC
2.34 is warning free with GCC11.

Add milestones for 2.31 and 2.34 and use those to set the default value
for GLIBC_ENABLE_WERROR based on the GCC version.

Signed-off-by: Chris Packham <judge.packham@gmail.com>