### PR TITLE
populate: Include dependencies of PIE executables

### DIFF
--- a/scripts/populate.in
+++ b/scripts/populate.in
@@ -281,9 +281,9 @@ CT_TMP_DIR="${TMPDIR:-/tmp}/populate-${rand}-${$}"
 trap "rm -rf ${CT_TMP_DIR}" EXIT
 
 # List all ELF (executables|shared objects)...
-find . -type f -exec file {} \;                                             \
-|"${grep}" -E ': ELF [[:digit:]]+-bit (L|M)SB +(executable|shared object),' \
-|cut -d ":" -f 1                                                            \
+find . -type f -exec file {} \;                                                            \
+|"${grep}" -E ': ELF [[:digit:]]+-bit (L|M)SB +(executable|pie executable|shared object),' \
+|cut -d ":" -f 1                                                                           \
 >"${CT_TMP_DIR}/files.list"
 
 # ... and use that list to find missing dependencies


### PR DESCRIPTION
Modern versions of the `file` utility give different output for position
dependent and position independent executables. The populate tool should
consider both types.

Versions of file prior to February 2018 (e.g. Debian Stretch) would report PIE executables as `executable`. Versions between February 2018 and February 2020 (e.g. Debian Buster) would identify them as `shared object`. Modern versions (e.g. Debian Bullseye) idenentify PIE executables as `pie executable`.

Signed-off-by: Johan Levin <johan13@gmail.com>