### PR TITLE
scripts/build/companion_libs: Fix missing directory with newlib-nano

### DIFF
--- a/scripts/build/companion_libs/350-newlib_nano.sh
+++ b/scripts/build/companion_libs/350-newlib_nano.sh
@@ -264,6 +264,8 @@ newlib_nano_copy_multilibs()
         eval "${arg// /\\ }"
     done
 
+    CT_DoExecLog ALL mkdir -p "${CT_PREFIX_DIR}/${CT_TARGET}/lib/${multi_dir}"
+
     for lib_a in "${nano_lib_dir}/${CT_TARGET}/lib/${multi_dir}/"*.a; do
        if [ -f ${lib_a} ] && [ ! -L ${lib_a} ]; then
           _f=$(basename "${lib_a}")


### PR DESCRIPTION
With 'CT_NEWLIB_NANO_INSTALL_IN_TARGET=y', this build failure occurs:
````
[...]
[INFO ]  Installing Newlib Nano library
[EXTRA]    Configuring Newlib Nano library
[EXTRA]    Building Newlib Nano C library
[EXTRA]    Installing Newlib Nano C library
[INFO ]  Installing Newlib Nano library: done in 110.66s (at 29:04)
[INFO ]  =================================================================
[INFO ]  Installing libstdc++ newlib-nano
[EXTRA]    Configuring libstdc++ for newlib-nano
[EXTRA]    Building libstdc++ newlib-nano library
[EXTRA]    Installing libstdc++ newlib-nano library
[EXTRA]    Housekeeping for core gcc compiler
[EXTRA]       '' --> lib (gcc)   lib (os)
[EXTRA]       ' -mthumb' --> lib/thumb (gcc)   lib/thumb (os)
[EXTRA]       ' -marm -mfpu=auto -march=armv5te+fp -mfloat-abi=hard' --> lib/arm/autofp/v5te/fpu (gcc)   lib/arm/autofp/v5te/fpu (os)
[EXTRA]       ' -mthumb -mfpu=auto -march=armv7+fp -mfloat-abi=hard' --> lib/thumb/autofp/v7/fpu (gcc)   lib/thumb/autofp/v7/fpu (os)
[INFO ]  Installing libstdc++ newlib-nano: done in 457.12s (at 36:42)
[ERROR]
[ERROR]  >>
[ERROR]  >>  Build failed in step '(top-level)'
[ERROR]  >>
[ERROR]  >>  Error happened in: CT_DoExecLog[scripts/functions@376]
[ERROR]  >>        called from: newlib_nano_copy_multilibs[scripts/build/companion_libs/350-newlib_nano.sh@270]
[ERROR]  >>        called from: CT_IterateMultilibs[scripts/functions@1608]
[ERROR]  >>        called from: do_newlib_nano_for_target[scripts/build/companion_libs/350-newlib_nano.sh@254]
[ERROR]  >>        called from: do_companion_libs_for_target[scripts/build/companion_libs.sh@43]
[ERROR]  >>        called from: main[scripts/crosstool-NG.sh@697]
Current command:
   'cp' '-f' '/build/toolchain/arm-none-eabi/newlib-nano/arm-none-eabi/lib/thumb/libc.a' '/build/toolchain/arm-none-eabi/arm-none-eabi/lib/thumb/libc_nano.a'
exited with error code: 1
Please fix it up and finish by exiting the shell with one of these values:
    1  fixed, continue with next build command
    2  repeat this build command
    3  abort build
````

This commit calls 'mkdir -p' to create the destination path before
copying.

Signed-off-by: Derald D. Woods <woods.technical@gmail.com>