### PR TITLE
Create unified diff when refreshing patch files in manage-packages.sh

### DIFF
--- a/maintainer/manage-packages.sh
+++ b/maintainer/manage-packages.sh
@@ -204,7 +204,7 @@ update_patches()
         # By now we know we have a non-empty set of patches
         CT_DoExecLog ALL quilt --quiltrc - import "${p}"
         CT_DoExecLog ALL quilt --quiltrc - push
-        CT_DoExecLog ALL quilt --quiltrc - refresh -p ab --no-timestamps --no-index --diffstat
+        CT_DoExecLog ALL quilt --quiltrc - refresh -p ab -u --no-timestamps --no-index --diffstat
     done
     # Now publish the patches back into the package's directory, renumbering them
     # in the process.


### PR DESCRIPTION
The unified diff patch format will contain slightly more information,
which is helpful when rebasing patches to new releases.

Signed-off-by: Hans-Christian Noren Egtvedt <hegtvedt@cisco.com>