### PR TITLE
gcc: Bring in fix for libsanitizer on mips64

### DIFF
--- a/packages/gcc/11.3.0/0010-libsanitizer-mips64-Set-struct_kernel_stat_sz-to-mat.patch
+++ b/packages/gcc/11.3.0/0010-libsanitizer-mips64-Set-struct_kernel_stat_sz-to-mat.patch
@@ -1,0 +1,31 @@
+From ac6e15a2776e8fffdbd108213e8690c9f30a7380 Mon Sep 17 00:00:00 2001
+From: Chris Packham <chris.packham@alliedtelesis.co.nz>
+Date: Mon, 16 May 2022 20:55:36 +1200
+Subject: [PATCH] libsanitizer: mips64: Set struct_kernel_stat_sz to match the
+ kernel
+
+The kernel's struct stat is 104 bytes when compiling for
+_MIPS_SIM_ABI64. Set struct_kernel_stat_sz to match.
+
+Signed-off-by: Chris Packham <chris.packham@alliedtelesis.co.nz>
+Link: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105614
+---
+ libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.h b/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.h
+index 83861105a509..326419a5d613 100644
+--- a/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.h
++++ b/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.h
+@@ -83,7 +83,7 @@ const unsigned struct_kernel_stat64_sz = 104;
+ #elif defined(__mips__)
+ const unsigned struct_kernel_stat_sz = SANITIZER_ANDROID
+                                            ? FIRST_32_SECOND_64(104, 128)
+-                                           : FIRST_32_SECOND_64(144, 216);
++                                           : FIRST_32_SECOND_64(144, 104);
+ const unsigned struct_kernel_stat64_sz = 104;
+ #elif defined(__s390__) && !defined(__s390x__)
+ const unsigned struct_kernel_stat_sz = 64;
+-- 
+2.36.1
+


### PR DESCRIPTION
The kernel's struct stat is 104 bytes when compiling for
_MIPS_SIM_ABI64. Set struct_kernel_stat_sz to match.

Fixes #1733

Signed-off-by: Chris Packham <judge.packham@gmail.com>