### PR TITLE
glibc: Reinstate support for the bundled ports

### DIFF
--- a/config/libc/glibc.in
+++ b/config/libc/glibc.in
@@ -113,6 +113,15 @@ config GLIBC_HAS_PORTS_ADDON_EXTERNAL
 config GLIBC_HAS_LIBIDN_ADDON
     def_bool y
 
+# Some architectures require the ports addon. List them one by one here:
+# This list must be carefully in sync with the architectures names
+# we can find in config/arch/*
+config GLIBC_USE_PORTS_ADDON
+    def_bool y
+    depends on ARCH_ALPHA || ARCH_ARM || ARCH_M68K || ARCH_MIPS || ARCH_POWERPC
+    depends on GLIBC_HAS_PORTS_ADDON
+    depends on !GLIBC_USE_ORACLE
+
 config GLIBC_USE_NPTL_ADDON
     def_bool y
     depends on THREADS_NATIVE && GLIBC_HAS_NPTL_ADDON

--- a/scripts/build/libc/glibc.sh
+++ b/scripts/build/libc/glibc.sh
@@ -294,6 +294,9 @@ glibc_add_ons_list()
     local sep="$1"
     local addons_list
 
+    if [ "${CT_GLIBC_USE_PORTS_ADDON}" = "y" ]; then
+        addons_list="${addons_list}${sep}ports"
+    fi
     if [ "${CT_GLIBC_USE_NPTL_ADDON}" = "y" ]; then
         addons_list="${addons_list}${sep}nptl"
     fi


### PR DESCRIPTION
Commit 6d5227b6 ("Remove obsolete glibc 2.12.1") removed supports for
the separate glibc-ports but also removed GLIBC_USE_PORTS_ADDON. Glibc
versions up to 2.20 bundled support from some architectures in the ports
directory so GLIBC_USE_PORTS_ADDON is required to support these older
glibc versions.

Fixes #1736
Signed-off-by: Chris Packham <judge.packham@gmail.com>