### PR TITLE
glibc: rework GLIBC_ENABLE_WERROR

### DIFF
--- a/config/libc/glibc.in
+++ b/config/libc/glibc.in
@@ -401,11 +401,12 @@ config GLIBC_SSP
 # GCC11-related fixes were available in glibc 2.34
 config GLIBC_ENABLE_WERROR
     bool "Enable -Werror during the build"
-    default y if GCC_7_or_older
-    default y if GCC_8_or_later && !GCC_9_or_later && GLIBC_2_27_or_later
-    default y if GCC_9_or_later && !GCC_10_or_later && GLIBC_2_29_or_later
-    default y if GCC_10_or_later && !GCC_11_or_later && GLIBC_2_31_or_later
-    default y if GCC_11_or_later && GLIBC_2_34_or_later
+    depends on GCC_7_or_older || \
+        (GCC_8_or_later && !GCC_9_or_later && GLIBC_2_27_or_later) || \
+        (GCC_9_or_later && !GCC_10_or_later && GLIBC_2_29_or_later) || \
+        (GCC_10_or_later && !GCC_11_or_later && GLIBC_2_31_or_later) || \
+        (GCC_11_or_later && GLIBC_2_34_or_later)
+    default y
     help
       By default, glibc enables strict warning checks during the build.
       However, older version of glibc may not build with newer versions


### PR DESCRIPTION
Use `depends on` conditions to enable/disable building glibc with
-Werror. Using `depends on` instead of `default if` means that when the
GCC/GLIBC selection changes GLIBC_ENABLE_WERROR will automatically
become n.

Fixes #1729, fixes #1712
Signed-off-by: Chris Packham <judge.packham@gmail.com>