### PR TITLE
gmp: Set CC_FOR_BUILD and CPP_FOR_BUILD

### DIFF
--- a/scripts/build/companion_libs/100-gmp.sh
+++ b/scripts/build/companion_libs/100-gmp.sh
@@ -118,9 +118,12 @@ do_gmp_backend() {
             ;;
     esac
 
-    # FIXME: GMP's configure script doesn't respect the host parameter
-    # when not cross-compiling, ie when build == host.
+    # GMP's configure script doesn't respect the host parameter
+    # when not cross-compiling, ie when build == host so set
+    # CC_FOR_BUILD and CPP_FOR_BUILD.
     CT_DoExecLog CFG                                \
+    CC_FOR_BUILD="${CT_BUILD}-gcc"                  \
+    CPP_FOR_BUILD="{CT_BUILD}-cpp"                  \
     CC="${host}-gcc"                                \
     CFLAGS="${cflags} -fexceptions"                 \
     LDFLAGS="${ldflags}"                            \


### PR DESCRIPTION
When GMP is being "cross" compiled for the same architecture (i.e. build
== host) it does not pick the right compiler. Set CC_FOR_BUILD and
CPP_FOR_BUILD to override the default compiler.

Fixes #1328
Signed-off-by: Chris Packham <judge.packham@gmail.com>