### PR TITLE
gcc: Disable zstd for canadian builds

### DIFF
--- a/config/cc/gcc.in
+++ b/config/cc/gcc.in
@@ -177,10 +177,9 @@ config CC_GCC_USE_LTO
 config CC_GCC_LTO_ZSTD
     tristate
     prompt "Support LTO compression with zstd"
-    default m
+    default m if !CANADIAN && !STATIC_TOOLCHAIN
     depends on CC_GCC_USE_LTO
     depends on GCC_10_or_later
-    depends on ! STATIC_TOOLCHAIN
     help
       Support zstd compression for LTO object files. This will require
       libzstd to be installed when using the toolchain


### PR DESCRIPTION
We don't currently bundle zstd so when performing a canadian build we
need to tell GCC not to enable zstd support for lto otherwise it might
decide to enable it based on the package being installed on the build
machine.

Fixes #1718
Signed-off-by: Chris Packham <judge.packham@gmail.com>