### PR TITLE
gcc: Fix compilation error in core C gcc compiler older than v5

### DIFF
--- a/scripts/build/cc/gcc.sh
+++ b/scripts/build/cc/gcc.sh
@@ -600,6 +600,12 @@ do_gcc_core_backend() {
         --enable-languages="${lang_list}"              \
         "${extra_user_config[@]}"
 
+    gcc_core_build_libcpp=all-build-libcpp
+    # disable target all-build-libcpp in gcc older verions
+    if [ "${CT_GCC_older_than_5}" = "y" ]; then
+        gcc_core_build_libcpp=""
+    fi
+
     if [ "${build_libgcc}" = "yes" ]; then
         # HACK: we need to override SHLIB_LC from gcc/config/t-slibgcc-elf-ver or
         # gcc/config/t-libunwind so -lc is removed from the link for
@@ -621,10 +627,10 @@ do_gcc_core_backend() {
             CT_DoExecLog CFG make ${CT_JOBSFLAGS} configure-libiberty
             CT_DoExecLog ALL make ${CT_JOBSFLAGS} -C libiberty libiberty.a
             CT_DoExecLog CFG make ${CT_JOBSFLAGS} configure-gcc configure-libcpp
-            CT_DoExecLog ALL make ${CT_JOBSFLAGS} all-libcpp all-build-libcpp
+            CT_DoExecLog ALL make ${CT_JOBSFLAGS} all-libcpp ${gcc_core_build_libcpp}
         else
             CT_DoExecLog CFG make ${CT_JOBSFLAGS} configure-gcc configure-libcpp configure-build-libiberty
-            CT_DoExecLog ALL make ${CT_JOBSFLAGS} all-libcpp all-build-libcpp all-build-libiberty
+            CT_DoExecLog ALL make ${CT_JOBSFLAGS} all-libcpp ${gcc_core_build_libcpp} all-build-libiberty
         fi
         # HACK: gcc-4.2 uses libdecnumber to build libgcc.mk, so build it here.
         if [ -d "${CT_SRC_DIR}/gcc/libdecnumber" ]; then


### PR DESCRIPTION
When core gcc older than v5 is compiled it shows the error message:

Build failed in step 'Installing core C gcc compiler'
      called in step '(top-level)'

Error happened in: CT_DoExecLog[scripts/functions@376]
      called from: do_gcc_core_backend[scripts/build/cc/gcc.sh@627]
      called from: do_cc_core[scripts/build/cc/gcc.sh@210]
      called from: main[scripts/crosstool-NG.sh@697]

configure: error: in
`.../build/build-cc-gcc-core/fixincludes':
configure: error: C compiler cannot create executables

This patch disable `all-build-libcpp' target when core gcc
older than v5 is configured.

Signed-off-by: Guillermo E. Martinez <guillermo.e.martinez@oracle.com>