### PR TITLE
configure.ac: bison is required for kconf

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -267,7 +267,7 @@ CTNG_PROG_VERSION([PYTHON],
     [^Python 3\.([4-9]|[1-9][0-9]+)\.],
     [python_3_4_or_newer])
 
-CTNG_PROG_VERSION([BISON],
+CTNG_PROG_VERSION_REQ_ANY([BISON],
     [bison >= 2.7],
     [bison],
     [bison],


### PR DESCRIPTION
Make the requirement for bison harder (but not strict). The system bison
will be used to build kconf. If the system bison is not GNU bison 2.7 or
later crosstool-ng will build GNU bison as a companion tool if necessary
(for glibc 2.29 or newer).

Fixes #1621
Signed-off-by: Chris Packham <judge.packham@gmail.com>