### PR TITLE
Enable D language support

### DIFF
--- a/config/cc.in
+++ b/config/cc.in
@@ -17,6 +17,9 @@ config CC_SUPPORT_JAVA
 config CC_SUPPORT_ADA
     bool
 
+config CC_SUPPORT_D
+    bool
+
 config CC_SUPPORT_OBJC
     bool
 
@@ -69,6 +72,17 @@ config CC_LANG_ADA
     depends on EXPERIMENTAL
     help
       Enable building an Ada compiler.
+
+      Only select this if you know that your specific version of the
+      compiler supports this language.
+
+config CC_LANG_D
+    bool
+    prompt "D (EXPERIMENTAL)"
+    depends on CC_SUPPORT_D
+    depends on EXPERIMENTAL
+    help
+      Enable building a D compiler.
 
       Only select this if you know that your specific version of the
       compiler supports this language.

--- a/config/cc/gcc.in
+++ b/config/cc/gcc.in
@@ -4,6 +4,7 @@
 ## select CC_SUPPORT_FORTRAN
 ## select CC_SUPPORT_JAVA if !GCC_7_or_later && OBSOLETE
 ## select CC_SUPPORT_ADA
+## select CC_SUPPORT_D
 ## select CC_SUPPORT_OBJC
 ## select CC_SUPPORT_OBJCXX
 ## select CC_SUPPORT_GOLANG

--- a/scripts/build/cc/gcc.sh
+++ b/scripts/build/cc/gcc.sh
@@ -43,6 +43,7 @@ cc_gcc_lang_list() {
     [ "${CT_CC_LANG_CXX}" = "y"      ] && lang_list+=",c++"
     [ "${CT_CC_LANG_FORTRAN}" = "y"  ] && lang_list+=",fortran"
     [ "${CT_CC_LANG_ADA}" = "y"      ] && lang_list+=",ada"
+    [ "${CT_CC_LANG_D}" = "y"      ] && lang_list+=",d"
     [ "${CT_CC_LANG_JAVA}" = "y"     ] && lang_list+=",java"
     [ "${CT_CC_LANG_OBJC}" = "y"     ] && lang_list+=",objc"
     [ "${CT_CC_LANG_OBJCXX}" = "y"   ] && lang_list+=",obj-c++"


### PR DESCRIPTION
Enable D support as an experimental feature.
GDC becomes a build dependency when enabled.

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>