### PR TITLE
Add option to build toolchain tarball

### DIFF
--- a/config/global/paths.in
+++ b/config/global/paths.in
@@ -137,3 +137,31 @@ config STRIP_TARGET_TOOLCHAIN_EXECUTABLES
       An install-strip make target is provided that installs stripped
       executables, and may install libraries with unneeded or debugging
       sections stripped. 
+
+config TARBALL_RESULT
+    bool
+    depends on EXPERIMENTAL
+    prompt "Create binary toolchain tarball"
+    default n
+    help
+      Create tarball of the final binary toolchain.
+
+if TARBALL_RESULT
+
+config TARBALL_RESULT_DIR
+    string
+    depends on TARBALL_RESULT
+    prompt "Output directory"
+    default "${CT_TOP_DIR}"
+    help
+      Directory where tarball will be created.
+
+config TARBALL_RESULT_FILENAME
+    string
+    depends on TARBALL_RESULT
+    prompt "Output filename"
+    default "toolchain${CT_TOOLCHAIN_PKGVERSION:+-${CT_TOOLCHAIN_PKGVERSION}}-${CT_HOST:+HOST-${CT_HOST}-}${CT_TARGET}"
+    help
+      Filename for toolchain tarball, without extension.
+
+endif


### PR DESCRIPTION
Add TARBALL_RESULT option that will produce a tarball of the final
toolchain to make it easier to deploy the toolchain to other machines.

The implementation uses `find | sort` instead of `tar --sort` because
this was introduced in GNU Tar v1.28, which is not available in some LTS
Linux distributions. This is  a variation of the command recommended
here: https://wiki.debian.org/ReproducibleBuilds/FileOrderInTarballs

Closes #1262

Signed-off-by: Chris Packham <judge.packham@gmail.com>