### PR TITLE
Switch CT_CC_{CORE_}SYSROOT_ARG to arrays

### DIFF
--- a/scripts/build/cc/gcc.sh
+++ b/scripts/build/cc/gcc.sh
@@ -1227,7 +1227,7 @@ do_gcc_backend() {
         --target=${CT_TARGET}                          \
         --prefix="${prefix}"                           \
         --exec_prefix="${exec_prefix}"                 \
-        ${CT_CC_SYSROOT_ARG}                           \
+        "${CT_CC_SYSROOT_ARG[@]}"                      \
         "${extra_config[@]}"                           \
         --with-local-prefix="${CT_SYSROOT_DIR}"        \
         --enable-long-long                             \

--- a/scripts/crosstool-NG.sh
+++ b/scripts/crosstool-NG.sh
@@ -345,8 +345,8 @@ if [ -z "${CT_RESTART}" ]; then
         CT_HEADERS_DIR="${CT_SYSROOT_DIR}/usr/include"
         CT_SanitizeVarDir CT_SYSROOT_DIR CT_DEBUGROOT_DIR CT_HEADERS_DIR
         CT_BINUTILS_SYSROOT_ARG="--with-sysroot=${CT_SYSROOT_DIR}"
-        CT_CC_CORE_SYSROOT_ARG="--with-sysroot=${CT_SYSROOT_DIR}"
-        CT_CC_SYSROOT_ARG="--with-sysroot=${CT_SYSROOT_DIR}"
+        CT_CC_CORE_SYSROOT_ARG=("--with-sysroot=${CT_SYSROOT_DIR}")
+        CT_CC_SYSROOT_ARG=("--with-sysroot=${CT_SYSROOT_DIR}")
         # glibc's prefix must be exactly /usr, else --with-sysroot'd gcc will get
         # confused when $sysroot/usr/include is not present.
         # Note: --prefix=/usr is magic!
@@ -363,8 +363,8 @@ if [ -z "${CT_RESTART}" ]; then
         CT_BINUTILS_SYSROOT_ARG="--with-sysroot=${CT_SYSROOT_DIR}"
         # Use --with-headers, else final gcc will define disable_glibc while
         # building libgcc, and you'll have no profiling
-        CT_CC_CORE_SYSROOT_ARG="--without-headers"
-        CT_CC_SYSROOT_ARG="--with-headers=${CT_HEADERS_DIR}"
+        CT_CC_CORE_SYSROOT_ARG=("--without-headers")
+        CT_CC_SYSROOT_ARG=("--with-headers=${CT_HEADERS_DIR}")
     fi
     CT_DoExecLog ALL mkdir -p "${CT_SYSROOT_DIR}"
     CT_DoExecLog ALL mkdir -p "${CT_DEBUGROOT_DIR}"


### PR DESCRIPTION
CT_CC_{CORE_}SYSROOT_ARG is being used both as an array and string. Switch everything
to be used as an array for consistency.

Signed-off-by: Justin Chen <justinpopo6@gmail.com>