### PR TITLE
Fixes for libstdcxx-verbose option tristate

### DIFF
--- a/config/cc/gcc.in
+++ b/config/cc/gcc.in
@@ -286,7 +286,6 @@ config CC_GCC_LIBSTDCXX_VERBOSE
     default n if BARE_METAL
     default m if !BARE_METAL
     prompt "Verbose libstdc++"
-    depends on GCC_4_8_or_later
     depends on CC_LANG_CXX
     help
       Write descriptive error messages on certain events.

--- a/scripts/build/cc/gcc.sh
+++ b/scripts/build/cc/gcc.sh
@@ -380,6 +380,7 @@ do_gcc_core_backend() {
 
     case "${CT_CC_GCC_LIBSTDCXX_VERBOSE}" in
         y)  extra_config+=("--enable-libstdcxx-verbose");;
+        m)  ;;
         "") extra_config+=("--disable-libstdcxx-verbose");;
     esac
 
@@ -1020,6 +1021,7 @@ do_gcc_backend() {
 
     case "${CT_CC_GCC_LIBSTDCXX_VERBOSE}" in
         y)  extra_config+=("--enable-libstdcxx-verbose");;
+        m)  ;;
         "") extra_config+=("--disable-libstdcxx-verbose");;
     esac
     


### PR DESCRIPTION
Make it proper "tristate" by not specifying the
option.

The config GCC_4_8_or_later was removed with
cc6b7fad46f5cb3d84, so dont use it.