### PR TITLE
CI: Add fetch mingw sources

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -69,7 +69,8 @@ jobs:
         run: |
           mkdir -p src
           for sample in aarch64-unknown-linux-gnu arm-picolibc-eabi \
-                arm-unknown-linux-musleabi armv6-nommu-linux-uclibcgnueabi; do \
+                arm-unknown-linux-musleabi armv6-nommu-linux-uclibcgnueabi \
+                x86_64-w64-mingw32; do \
                 ct-ng $sample; \
                 sed -i -e '/CT_LOG_PROGRESS_BAR/s/y$/n/' .config; \
                 sed -i -e '/CT_LOCAL_TARBALLS_DIR/s/HOME/CT_TOP_DIR/' .config; \


### PR DESCRIPTION
Add x86_64-w64-mingw32 to the list of samples we use to fetch sources.
This should pick up the mingw related tarballs so the build steps that
follow don't have to.

Signed-off-by: Chris Packham <judge.packham@gmail.com>