### PR TITLE
CI: Install meson and ninja when building

### DIFF
--- a/.github/workflows/build-toolchains.yml
+++ b/.github/workflows/build-toolchains.yml
@@ -63,7 +63,7 @@ jobs:
       - name: prereq Linux
         if: ${{ runner.os == 'Linux' }}
         run: |
-          sudo apt-get install -y gperf help2man libtool-bin
+          sudo apt-get install -y gperf help2man libtool-bin meson ninja-build
           echo "${{ github.workspace }}/.local/bin" >> $GITHUB_PATH
       - name: prereq macOS
         if: ${{ runner.os == 'macOS' }}

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -16,7 +16,7 @@ jobs:
       - name: "prereq Linux"
         if: ${{ runner.os == 'Linux' }}
         run: |
-          sudo apt-get install -y gperf help2man libtool-bin
+          sudo apt-get install -y gperf help2man libtool-bin meson ninja-build
       - name: "prereq macOS"
         if: ${{ runner.os == 'macOS' }}
         run: |


### PR DESCRIPTION
Add meson and ninja-build to the prerequisites so we actually build
picolibc.

Signed-off-by: Chris Packham <judge.packham@gmail.com>