### PR TITLE
configure.ac: AC_PROG_LEX set to noyywrap

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -93,7 +93,7 @@ AC_PROG_CC
 AM_PROG_CC_C_O
 AC_PROG_CXX
 AC_PROG_CPP
-AC_PROG_LEX([yywrap])
+AC_PROG_LEX([noyywrap])
 AC_PROG_YACC
 AS_IF([test -z "$CC" -o -z "$CXX"],
       [AC_MSG_ERROR([no suitable compiler found])])


### PR DESCRIPTION
It appears that noyywrap is actually what is needed for kconfig.
Particularly on arclinux where the default flex installation does not
provide the yywrap function.

Fixes #1790
Fixes 015d039e ("AC_PROG_LEX set to yywrap")

Signed-off-by: Chris Packham <judge.packham@gmail.com>