### PR TITLE
CI: Update to macos-latest

### DIFF
--- a/.github/workflows/build-toolchains.yml
+++ b/.github/workflows/build-toolchains.yml
@@ -18,25 +18,25 @@ jobs:
     runs-on: ${{ matrix.host }}
     strategy:
       matrix:
-        host: [ "ubuntu-latest", "macos-10.15" ]
+        host: [ "ubuntu-latest", "macos-latest" ]
         sample: ${{ fromJSON(inputs.samples) }}
         exclude:
           # Exclude both glibc & uClibc ARC Linux toolchains as
           # there's no known use of ARC Linux toolchains on Mac,
           # and anyway glibc fails to build for ARC700,
           # see https://github.com/crosstool-ng/crosstool-ng/pull/1456#issuecomment-779150246
-          - { host: "macos-10.15", sample: "arc-multilib-linux-gnu" }
-          - { host: "macos-10.15", sample: "arc-multilib-linux-uclibc" }
+          - { host: "macos-latest", sample: "arc-multilib-linux-gnu" }
+          - { host: "macos-latest", sample: "arc-multilib-linux-uclibc" }
 
           # Exclude mips*-*-linux-gnu because of <byteswap.h> usage in
           # elf-entry.c for linux kernel headers.  <byteswap.h> is a GNU
           # extension and doesn't exist on MacOS X
-          - { host: "macos-10.15", sample: "mips-unknown-linux-gnu" }
-          - { host: "macos-10.15", sample: "mips64-unknown-linux-gnu" }
+          - { host: "macos-latest", sample: "mips-unknown-linux-gnu" }
+          - { host: "macos-latest", sample: "mips64-unknown-linux-gnu" }
 
           # Exclude x86_64-w64-mingw32,x86_64-pc-linux-gnu because it crashes on m4 build with
           # a Segmentation fault
-          - { host: "macos-10.15", sample: "x86_64-w64-mingw32,x86_64-pc-linux-gnu" }
+          - { host: "macos-latest", sample: "x86_64-w64-mingw32,x86_64-pc-linux-gnu" }
     steps:
       - name: create case sensitive workspace volume for macOS
         if: ${{ runner.os == 'macOS' }}

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.host }}
     strategy:
       matrix:
-        host: [ "ubuntu-latest", "macos-10.15" ]
+        host: [ "ubuntu-latest", "macos-latest" ]
     steps:
       - name: "clone"
         uses: actions/checkout@v2


### PR DESCRIPTION
Update the CI actions from macos-10.15 to macos-latest.

Signed-off-by: Chris Packham <judge.packham@gmail.com>