### PR TITLE
arm-none-eabi: Disable RWX segment warning in binutils

### DIFF
--- a/samples/arm-none-eabi/crosstool.config
+++ b/samples/arm-none-eabi/crosstool.config
@@ -12,3 +12,4 @@ CT_COMP_LIBS_PICOLIBC=y
 CT_MULTILIB=y
 CT_CC_GCC_MULTILIB_LIST="rmprofile aprofile"
 CT_TARGET_VENDOR="none"
+CT_BINUTILS_EXTRA_CONFIG_ARRAY="--disable-warn-rwx-segments"


### PR DESCRIPTION
This warning is designed to catch likely vulnerabilities in code run
under memory protection -- allowing execution from memory which is
writable. However, embedded arm systems frequently require placing code
in RAM, for performance or functionality reasons. Disable the warning
that recent versions of binutils has added.

Signed-off-by: Keith Packard <keithp@keithp.com>