### PR TITLE
avr,pru: Disable CT_CC_GCC_ENABLE_DEFAULT_PIE

### DIFF
--- a/config/cc/gcc.in
+++ b/config/cc/gcc.in
@@ -201,7 +201,7 @@ config CC_GCC_ENABLE_DEFAULT_PIE
     bool
     prompt "Enable Position Independent Executable as default"
     default y
-    depends on GCC_6_or_later && ! WINDOWS && ! ARCH_MIPS
+    depends on GCC_6_or_later && ! WINDOWS && ! ARCH_MIPS && ! ARCH_AVR && ! ARCH_PRU
     help
       Pass --enable-default-pie to crossgcc's configure.
       


### PR DESCRIPTION
PIE is not supported by PRU and AVR backends for GCC.

This fixes LD errors when trying to link user programs with a crosstool-NG toolchain:

  /home/dinux/x-tools/avr/lib/gcc/avr/12.2.0/../../../../avr/bin/ld: -pie not supported
  collect2: error: ld returned 1 exit status

Signed-off-by: Dimitar Dimitrov <dimitar@dinux.eu>