### PR TITLE
Build libopcodes for target

### DIFF
--- a/config/binutils/binutils.in
+++ b/config/binutils/binutils.in
@@ -184,6 +184,11 @@ config BINUTILS_FOR_TARGET_BFD
     prompt "libbfd"
     default y
 
+config BINUTILS_FOR_TARGET_OPCODES
+    bool
+    prompt "libopcodes"
+    default y
+
 endif # BINUTILS_FOR_TARGET
 
 if ARCH_BINFMT_FLAT

--- a/scripts/build/binutils/binutils.sh
+++ b/scripts/build/binutils/binutils.sh
@@ -310,8 +310,9 @@ do_binutils_for_target() {
     local -a install_targets
     local t
 
-    [ "${CT_BINUTILS_FOR_TARGET_IBERTY}" = "y" ] && targets+=("libiberty")
-    [ "${CT_BINUTILS_FOR_TARGET_BFD}"    = "y" ] && targets+=("bfd")
+    [ "${CT_BINUTILS_FOR_TARGET_IBERTY}"  = "y" ] && targets+=("libiberty")
+    [ "${CT_BINUTILS_FOR_TARGET_BFD}"     = "y" ] && targets+=("bfd")
+    [ "${CT_BINUTILS_FOR_TARGET_OPCODES}" = "y" ] && targets+=("opcodes")
     for t in "${targets[@]}"; do
         build_targets+=("all-${t}")
         install_targets+=("install-${t}")


### PR DESCRIPTION
Add an option to build and install binutil's libopcodes into the toolchain.

Setting the default to 'y' like in the libbfd and libiberty options, not sure if that is ok.