### PR TITLE
Add the gdc compiler to the list of tools checked/linked

### DIFF
--- a/scripts/crosstool-NG.sh
+++ b/scripts/crosstool-NG.sh
@@ -437,7 +437,7 @@ if [ -z "${CT_RESTART}" ]; then
             t="${!r}-"
         fi
 
-        for tool in ar as dlltool gcc g++ gcj gnatbind gnatmake ld libtool nm objcopy objdump ranlib strip windres; do
+        for tool in ar as dlltool gcc g++ gcj gnatbind gdc gnatmake ld libtool nm objcopy objdump ranlib strip windres; do
             # First try with prefix + suffix
             # Then try with prefix only
             # Then try with suffix only, but only for BUILD, and HOST iff REAL_BUILD == REAL_HOST


### PR DESCRIPTION
Add gdc to the tool list but leave it optionnal.

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>