### PR TITLE
CI: Update action versions

### DIFF
--- a/.github/workflows/build-toolchains.yml
+++ b/.github/workflows/build-toolchains.yml
@@ -47,14 +47,14 @@ jobs:
           hdiutil mount ${HOME}/Workspace.sparseimage -mountroot /Users/runner/work/crosstool-ng
           cd crosstool-ng
       - name: download ct-ng
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: crosstool.${{ matrix.host }}
       - name: extract ct-ng
         run: |
           tar -xf ct-ng.tar
       - name: download tarballs
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: src.tar
       - name: extract tarballs
@@ -73,7 +73,7 @@ jobs:
           echo "${{ github.workspace }}/.local/bin" >> $GITHUB_PATH
       - name: download x86_64-w64-mingw32.${{ matrix.host }} tarball
         if: ${{ inputs.canadian-cross }}
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: x86_64-w64-mingw32.${{ matrix.host }}.tar
       - name: install x86_64-w64-mingw32.${{ matrix.host }} toolchain
@@ -98,13 +98,13 @@ jobs:
               -cf ${{ matrix.sample }}.${{ matrix.host }}.tar .
       - name: upload ${{ matrix.sample }}.${{ matrix.host }} tarball
         if: ${{ matrix.sample == 'x86_64-w64-mingw32' }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: x86_64-w64-mingw32.${{ matrix.host }}.tar
           path: |
             x86_64-w64-mingw32.${{ matrix.host }}.tar
       - name: upload log
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.sample }}.${{ matrix.host }}.log
           path: |

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -12,7 +12,7 @@ jobs:
         host: [ "ubuntu-latest", "macos-latest" ]
     steps:
       - name: "clone"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: "prereq Linux"
         if: ${{ runner.os == 'Linux' }}
         run: |
@@ -35,12 +35,12 @@ jobs:
           make install
           tar -cf ct-ng.tar .local/
       - name: "upload ct-ng"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: crosstool.${{ matrix.host }}
           path: ct-ng.tar
       - name: "upload config.log"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: config.log.${{ matrix.host }}
           path: config.log
@@ -54,7 +54,7 @@ jobs:
         host: [ "ubuntu-latest" ]
     steps:
       - name: "download ct-ng"
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: crosstool.${{ matrix.host }}
       - name: "extract ct-ng"
@@ -83,7 +83,7 @@ jobs:
           done
           tar -cvf src.tar src
       - name: "upload sources"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: src.tar
           path: src.tar


### PR DESCRIPTION
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Update to v3 version of affected actions.

Signed-off-by: Chris Packham <judge.packham@gmail.com>