### PR TITLE
Correct casing for Ada lang

### DIFF
--- a/config/cc.in
+++ b/config/cc.in
@@ -67,7 +67,7 @@ config CC_LANG_JAVA
 
 config CC_LANG_ADA
     bool
-    prompt "ADA (EXPERIMENTAL)"
+    prompt "Ada (EXPERIMENTAL)"
     depends on CC_SUPPORT_ADA
     depends on EXPERIMENTAL
     help


### PR DESCRIPTION
Ada is a name, not an acronym, so it doesn't need to be up-cased.

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>