### PR TITLE
packages: Fix broken zlib mirror URL

### DIFF
--- a/packages/zlib/package.desc
+++ b/packages/zlib/package.desc
@@ -1,4 +1,4 @@
 repository='git https://github.com/madler/zlib.git'
-mirrors='https://github.com/madler/zlib/releases/download/v${CT_ZLIB_VERSION} https://www.zlib.net/'
+mirrors='https://github.com/madler/zlib/releases/download/v${CT_ZLIB_VERSION} https://www.zlib.net/fossils'
 archive_formats='.tar.xz .tar.gz'
 signature_format='packed/.asc'


### PR DESCRIPTION
The [fossils directory](https://zlib.net/fossils/) contains all versions of zlib, including the current version.