### PR TITLE
Fix `./configure --with-ncurses` not working on Arch Linux

### DIFF
--- a/m4/ax_with_curses_extra.m4
+++ b/m4/ax_with_curses_extra.m4
@@ -212,6 +212,9 @@ AC_DEFUN([_AX_WITH_CURSES_EXTRA], [
     ], [
         AS_IF([test "x$ax_cv_curses_which" = xncursesw], [
             _AX_WITH_CURSES_CHECKEXTRA([$1], [$2], [$3], [ncursesw/$4], [$5])
+            AS_IF([test x$[]ax_cv_[]m4_tolower($1) != "xyes"], [
+		_AX_WITH_CURSES_CHECKEXTRA([$1], [$2], [$3], [$4], [$6])
+            ])
         ], [test "x$ax_cv_curses_which" = xncurses], [
             _AX_WITH_CURSES_CHECKEXTRA([$1], [$2], [$3], [$4], [$6])
             AS_IF([test x$[]ax_cv_[]m4_tolower($1) != "xyes"], [


### PR DESCRIPTION
Should fix #1853

Reverts the changes introduced to `m4/ax_with_curses_extra.m4` in 59b664806c55dc1e5878448be2536fe110944f62, which seem to make `cofigure` look only for `ncursesw/panel.h` and not consider `panel.h` as a candidate, thus causing `./configure --with-ncurses` to fail with "error: panel library not found" on systems (such as Arch Linux) where ncurses headers are not put under the `ncursesw/` directory.
