### PR TITLE
Detect if a package src_dir is missing

### DIFF
--- a/scripts/functions
+++ b/scripts/functions
@@ -2283,10 +2283,11 @@ CT_DoExtractPatch()
             CT_DoExecLog ALL rm -f "${src_dir}/.${basename}".*
         fi
 
-        if [ -f "${src_dir}/.${basename}.extracted" ]; then
+        if [ -f "${src_dir}/.${basename}.extracted" -a -d "${src_dir}/${basename}" ]; then
             CT_DoLog DEBUG "Already extracted ${basename}"
         else
             CT_DoLog EXTRA "Extracting ${basename}"
+            CT_DoExecLog ALL rm -f "${src_dir}/.${basename}".*
             CT_DoExecLog ALL touch "${src_dir}/.${basename}.extracting"
             if [ "${src_release}" = "y" ]; then
                 archive="${archive_filename}"


### PR DESCRIPTION
If a user deletes the package directory under `.build/src/` but fails to remove the hidden stamp files the CT_DoExtractPatch function will detect this, delete the stamps and perform the full extract-and-patch step.