### PR TITLE
glibc: Add fix for GNU make 4.4 compatibility issue

### DIFF
--- a/.github/workflows/build-toolchains.yml
+++ b/.github/workflows/build-toolchains.yml
@@ -90,6 +90,7 @@ jobs:
           sed -i -e '/CT_LOG_PROGRESS_BAR/s/y$/n/' .config
           sed -i -e '/CT_LOCAL_TARBALLS_DIR/s/HOME/CT_TOP_DIR/' .config
           sed -i -e '/CT_PREFIX_DIR/s/HOME/CT_TOP_DIR/' .config
+          test ${{ matrix.host }} = "macos-latest" && sed -i -e '/CT_GDB_CROSS_PYTHON/s/y$/n/' .config
           ct-ng build
       - name: create ${{ matrix.sample }}.${{ matrix.host }} tarball
         if: ${{ matrix.sample == 'x86_64-w64-mingw32' }}

--- a/packages/glibc/2.36/0006-Makerules-fix-MAKEFLAGS-assignment-for-upcoming-make.patch
+++ b/packages/glibc/2.36/0006-Makerules-fix-MAKEFLAGS-assignment-for-upcoming-make.patch
@@ -1,0 +1,114 @@
+From 2d7ed98add14f75041499ac189696c9bd3d757fe Mon Sep 17 00:00:00 2001
+From: Sergei Trofimovich <slyich@gmail.com>
+Date: Tue, 13 Sep 2022 13:39:13 -0400
+Subject: [PATCH] Makerules: fix MAKEFLAGS assignment for upcoming make-4.4
+ [BZ# 29564]
+
+make-4.4 will add long flags to MAKEFLAGS variable:
+
+    * WARNING: Backward-incompatibility!
+      Previously only simple (one-letter) options were added to the MAKEFLAGS
+      variable that was visible while parsing makefiles.  Now, all options
+      are available in MAKEFLAGS.
+
+This causes locale builds to fail when long options are used:
+
+    $ make --shuffle
+    ...
+    make  -C localedata install-locales
+    make: invalid shuffle mode: '1662724426r'
+
+The change fixes it by passing eash option via whitespace and dashes.
+That way option is appended to both single-word form and whitespace
+separated form.
+
+While at it fixed --silent mode detection in $(MAKEFLAGS) by filtering
+out --long-options. Otherwise options like --shuffle flag enable silent
+mode unintentionally. $(silent-make) variable consolidates the checks.
+
+Resolves: BZ# 29564
+
+CC: Paul Smith <psmith@gnu.org>
+CC: Siddhesh Poyarekar <siddhesh@gotplt.org>
+Signed-off-by: Sergei Trofimovich <slyich@gmail.com>
+Reviewed-by: Siddhesh Poyarekar <siddhesh@sourceware.org>
+---
+ Makeconfig     | 18 +++++++++++++++++-
+ Makerules      |  4 ++--
+ elf/rtld-Rules |  2 +-
+ 3 files changed, 20 insertions(+), 4 deletions(-)
+
+diff --git a/Makeconfig b/Makeconfig
+index f8164a0025..842f49eb58 100644
+--- a/Makeconfig
++++ b/Makeconfig
+@@ -43,6 +43,22 @@ else
+ $(error objdir must be defined by the build-directory Makefile)
+ endif
+ 
++# Did we request 'make -s' run? "yes" or "no".
++# Starting from make-4.4 MAKEFLAGS now contains long
++# options like '--shuffle'. To detect presence of 's'
++# we pick first word with short options. Long options
++# are guaranteed to come after whitespace. We use '-'
++# prefix to always have a word before long options
++# even if no short options were passed.
++# Typical MAKEFLAGS values to watch for:
++#   "rs --shuffle=42" (silent)
++#   " --shuffle" (not silent)
++ifeq ($(findstring s, $(firstword -$(MAKEFLAGS))),)
++silent-make := no
++else
++silent-make := yes
++endif
++
+ # Root of the sysdeps tree.
+ sysdep_dir := $(..)sysdeps
+ export sysdep_dir := $(sysdep_dir)
+@@ -917,7 +933,7 @@ endif
+ # umpteen zillion filenames along with it (we use `...' instead)
+ # but we don't want this echoing done when the user has said
+ # he doesn't want to see commands echoed by using -s.
+-ifneq	"$(findstring s,$(MAKEFLAGS))" ""	# if -s
++ifeq ($(silent-make),yes)			# if -s
+ +cmdecho	:= echo >/dev/null
+ else						# not -s
+ +cmdecho	:= echo
+diff --git a/Makerules b/Makerules
+index d1e139d03c..09c0cf8357 100644
+--- a/Makerules
++++ b/Makerules
+@@ -794,7 +794,7 @@ endif
+ # Maximize efficiency by minimizing the number of rules.
+ .SUFFIXES:	# Clear the suffix list.  We don't use suffix rules.
+ # Don't define any builtin rules.
+-MAKEFLAGS := $(MAKEFLAGS)r
++MAKEFLAGS := $(MAKEFLAGS) -r
+ 
+ # Generic rule for making directories.
+ %/:
+@@ -811,7 +811,7 @@ MAKEFLAGS := $(MAKEFLAGS)r
+ .PRECIOUS: $(foreach l,$(libtypes),$(patsubst %,$(common-objpfx)$l,c))
+ 
+ # Use the verbose option of ar and tar when not running silently.
+-ifeq	"$(findstring s,$(MAKEFLAGS))" ""	# if not -s
++ifeq ($(silent-make),no)			# if not -s
+ verbose := v
+ else	   					# -s
+ verbose	:=
+diff --git a/elf/rtld-Rules b/elf/rtld-Rules
+index ca00dd1fe2..3c5e273f2b 100644
+--- a/elf/rtld-Rules
++++ b/elf/rtld-Rules
+@@ -52,7 +52,7 @@ $(objpfx)rtld-libc.a: $(foreach dir,$(rtld-subdirs),\
+ 	mv -f $@T $@
+ 
+ # Use the verbose option of ar and tar when not running silently.
+-ifeq	"$(findstring s,$(MAKEFLAGS))" ""	# if not -s
++ifeq ($(silent-make),no)			# if not -s
+ verbose := v
+ else						# -s
+ verbose	:=
+-- 
+2.38.1
+


### PR DESCRIPTION
Add an upstream patch that resolves a compatibility issue with GNU make 4.4.

Fixes #1858
Signed-off-by: Chris Packham <judge.packham@gmail.com>