### PR TITLE
gcc: Disable CC_GCC_ENABLE_DEFAULT_PIE on RISC-V bare metal builds

### DIFF
--- a/config/cc/gcc.in
+++ b/config/cc/gcc.in
@@ -202,6 +202,7 @@ config CC_GCC_ENABLE_DEFAULT_PIE
     prompt "Enable Position Independent Executable as default"
     default y
     depends on GCC_6_or_later && ! WINDOWS && ! ARCH_MIPS && ! ARCH_AVR && ! ARCH_PRU
+    depends on !(ARCH_RISCV && BARE_METAL)
     help
       Pass --enable-default-pie to crossgcc's configure.
       


### PR DESCRIPTION
-pie is not supported on riscv*-elf-ld so having this configuration switch enabled for these targets causes issues later when we try to use the target compiler.

References: 
- https://github.com/bminor/binutils-gdb/blob/13556f4057d37f510f77143a1632febcc5618d1f/ld/lexsup.c#L1303-L1313
- https://github.com/bminor/binutils-gdb/blob/13556f4057d37f510f77143a1632febcc5618d1f/ld/emultempl/elf.em#L84
- https://github.com/bminor/binutils-gdb/blob/13556f4057d37f510f77143a1632febcc5618d1f/ld/emulparams/elf32lriscv-defs.sh#L19-L27
