### PR TITLE
Enable support for building libgccjit

### DIFF
--- a/config/cc.in
+++ b/config/cc.in
@@ -20,6 +20,9 @@ config CC_SUPPORT_ADA
 config CC_SUPPORT_D
     bool
 
+config CC_SUPPORT_JIT
+    bool
+
 config CC_SUPPORT_OBJC
     bool
 
@@ -52,6 +55,17 @@ config CC_LANG_FORTRAN
 
       Only select this if you know that your specific version of the
       compiler supports this language.
+
+config CC_LANG_JIT
+    bool
+    prompt "JIT (EXPERIMENTAL)"
+    depends on CC_SUPPORT_JIT
+    depends on EXPERIMENTAL
+    help
+      Enable building the GCC JIT library.
+
+      Only select this if you know that your specific version of the
+      compiler supports the libgccjit.
 
 if ! BARE_METAL
 

--- a/config/cc/gcc.in
+++ b/config/cc/gcc.in
@@ -5,6 +5,7 @@
 ## select CC_SUPPORT_JAVA if !GCC_7_or_later && OBSOLETE
 ## select CC_SUPPORT_ADA
 ## select CC_SUPPORT_D
+## select CC_SUPPORT_JIT
 ## select CC_SUPPORT_OBJC
 ## select CC_SUPPORT_OBJCXX
 ## select CC_SUPPORT_GOLANG

--- a/scripts/build/cc/gcc.sh
+++ b/scripts/build/cc/gcc.sh
@@ -45,6 +45,7 @@ cc_gcc_lang_list() {
     [ "${CT_CC_LANG_ADA}" = "y"      ] && lang_list+=",ada"
     [ "${CT_CC_LANG_D}" = "y"      ] && lang_list+=",d"
     [ "${CT_CC_LANG_JAVA}" = "y"     ] && lang_list+=",java"
+    [ "${CT_CC_LANG_JIT}" = "y"      ] && lang_list+=",jit"
     [ "${CT_CC_LANG_OBJC}" = "y"     ] && lang_list+=",objc"
     [ "${CT_CC_LANG_OBJCXX}" = "y"   ] && lang_list+=",obj-c++"
     [ "${CT_CC_LANG_GOLANG}" = "y"   ] && lang_list+=",go"
@@ -341,6 +342,10 @@ do_gcc_core_backend() {
     # Hint GCC we'll use a bit special version of Newlib
     if [ "${CT_LIBC_NEWLIB_NANO_FORMATTED_IO}" = "y" ]; then
         extra_config+=("--enable-newlib-nano-formatted-io")
+    fi
+
+    if [ "${CT_CC_LANG_JIT}" = "y" ]; then
+        extra_config+=("--enable-host-shared")
     fi
 
     if [ "${CT_CC_CXA_ATEXIT}" = "y" ]; then

--- a/scripts/build/companion_libs/050-zlib.sh
+++ b/scripts/build/companion_libs/050-zlib.sh
@@ -80,6 +80,10 @@ do_zlib_backend() {
         eval "${arg// /\\ }"
     done
 
+    if [ "${CT_CC_LANG_JIT}" = "y" ]; then
+        cflags="${cflags} -fPIC"
+    fi
+
     case "${host}" in
     *-mingw32)
         # zlib treats mingw host differently and requires using a different

--- a/scripts/build/companion_libs/100-gmp.sh
+++ b/scripts/build/companion_libs/100-gmp.sh
@@ -109,7 +109,7 @@ do_gmp_backend() {
 
     CT_DoLog EXTRA "Configuring GMP"
 
-    # To avoind “illegal text-relocation” linking error against
+    # To avoid “illegal text-relocation” linking error against
     # the static library, see:
     #     https://github.com/Homebrew/homebrew-core/pull/25470
     case "${host}" in
@@ -117,6 +117,10 @@ do_gmp_backend() {
             extra_config+=("--with-pic")
             ;;
     esac
+
+    if [ "${CT_CC_LANG_JIT}" = "y" ]; then
+        extra_config+=("--with-pic")
+    fi
 
     # GMP's configure script doesn't respect the host parameter
     # when not cross-compiling, ie when build == host so set

--- a/scripts/build/companion_libs/110-mpfr.sh
+++ b/scripts/build/companion_libs/110-mpfr.sh
@@ -94,6 +94,7 @@ do_mpfr_backend() {
     local cflags
     local ldflags
     local arg
+    local -a extra_config
 
     for arg in "$@"; do
         eval "${arg// /\\ }"
@@ -101,11 +102,15 @@ do_mpfr_backend() {
 
     # Under Cygwin, we can't build a thread-safe library
     case "${CT_HOST}" in
-        *cygwin*)   mpfr_opts+=( --disable-thread-safe );;
-        *mingw*)    mpfr_opts+=( --disable-thread-safe );;
-        *darwin*)   mpfr_opts+=( --disable-thread-safe );;
-        *)          mpfr_opts+=( --enable-thread-safe  );;
+        *cygwin*)   extra_config+=( --disable-thread-safe );;
+        *mingw*)    extra_config+=( --disable-thread-safe );;
+        *darwin*)   extra_config+=( --disable-thread-safe );;
+        *)          extra_config+=( --enable-thread-safe  );;
     esac
+
+    if [ "${CT_CC_LANG_JIT}" = "y" ]; then
+        extra_config+=("--with-pic")
+    fi
 
     CT_DoLog EXTRA "Configuring MPFR"
     CT_DoExecLog CFG                                    \
@@ -117,6 +122,7 @@ do_mpfr_backend() {
         --build=${CT_BUILD}                             \
         --host=${host}                                  \
         --prefix="${prefix}"                            \
+        "${extra_config[@]}"                            \
         --with-gmp="${prefix}"                          \
         --disable-shared                                \
         --enable-static

--- a/scripts/build/companion_libs/121-isl.sh
+++ b/scripts/build/companion_libs/121-isl.sh
@@ -82,6 +82,10 @@ do_isl_backend() {
         eval "${arg// /\\ }"
     done
 
+    if [ "${CT_CC_LANG_JIT}" = "y" ]; then
+        extra_config+=("--with-pic")
+    fi
+
     CT_DoLog EXTRA "Configuring ISL"
 
     CT_DoExecLog CFG                                \

--- a/scripts/build/companion_libs/130-cloog.sh
+++ b/scripts/build/companion_libs/130-cloog.sh
@@ -83,6 +83,10 @@ do_cloog_backend() {
     cloog_opts+=( --with-isl=system --with-isl-prefix="${prefix}" )
     cloog_opts+=( --without-osl )
 
+    if [ "${CT_CC_LANG_JIT}" = "y" ]; then
+        cloog_opts+=("--with-pic")
+    fi
+
     CT_DoLog EXTRA "Configuring CLooG"
 
     CT_DoExecLog CFG                                    \

--- a/scripts/build/companion_libs/140-mpc.sh
+++ b/scripts/build/companion_libs/140-mpc.sh
@@ -38,6 +38,11 @@ do_mpc_for_build() {
     mpc_opts+=( "prefix=${CT_BUILDTOOLS_PREFIX_DIR}" )
     mpc_opts+=( "cflags=${CT_CFLAGS_FOR_BUILD}" )
     mpc_opts+=( "ldflags=${CT_LDFLAGS_FOR_BUILD}" )
+
+    if [ "${CT_CC_LANG_JIT}" = "y" ]; then
+        mpc_opts+=("--with-pic")
+    fi
+
     do_mpc_backend "${mpc_opts[@]}"
 
     CT_Popd
@@ -73,10 +78,16 @@ do_mpc_backend() {
     local cflags
     local ldflags
     local arg
+    local -a extra_config
 
     for arg in "$@"; do
         eval "${arg// /\\ }"
     done
+
+    if [ "${CT_CC_LANG_JIT}" = "y" ]; then
+        extra_config+=("--with-pic")
+    fi
+
 
     CT_DoLog EXTRA "Configuring MPC"
 
@@ -87,6 +98,7 @@ do_mpc_backend() {
     "${CT_SRC_DIR}/mpc/configure"                   \
         --build=${CT_BUILD}                         \
         --host=${host}                              \
+        "${extra_config[@]}"                        \
         --prefix="${prefix}"                        \
         --with-gmp="${prefix}"                      \
         --with-mpfr="${prefix}"                     \


### PR DESCRIPTION
libgccjit is still under development and, despite its name, may also be used for ahead-of-time compilation.

Documentation can be found on the gcc website:
https://gcc.gnu.org/onlinedocs/jit/internals/index.html https://gcc.gnu.org/wiki/JIT

With this change it's possible to enable the building of the libgccjit. It's enabled as a language (with --enable-languages=jit) even if not a language frontend at all.

The main changes are related to the requirement of having everything host side built as Position Independent Code (PIC) with --enable-host-shared. GCC has the needed logic for building its dependencies (mpc, gmp, mpfr, ...) correctly when built "in-tree", which is not the case with crosstool-ng (see https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=05048fc29f0)

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>