### PR TITLE
CI: Use ${{ matrix.sample }} when uploading artifacts

### DIFF
--- a/.github/workflows/build-toolchains.yml
+++ b/.github/workflows/build-toolchains.yml
@@ -101,9 +101,9 @@ jobs:
         if: ${{ matrix.sample == 'x86_64-w64-mingw32' }}
         uses: actions/upload-artifact@v3
         with:
-          name: x86_64-w64-mingw32.${{ matrix.host }}.tar
+          name: ${{ matrix.sample }}.${{ matrix.host }}.tar
           path: |
-            x86_64-w64-mingw32.${{ matrix.host }}.tar
+            ${{ matrix.sample }}.${{ matrix.host }}.tar
       - name: upload log
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
Update some hard coded names to use ${{ matrix.sample }} instead. This will allow us to upload other artifacts in the future.

Signed-off-by: Chris Packham <judge.packham@gmail.com>