### PR TITLE
binutils: build static gold without -all-static

### DIFF
--- a/scripts/build/binutils/binutils.sh
+++ b/scripts/build/binutils/binutils.sh
@@ -176,6 +176,12 @@ do_binutils_backend() {
 
     [ "${CT_TOOLCHAIN_ENABLE_NLS}" != "y" ] && extra_config+=("--disable-nls")
 
+    if [ "${CT_STATIC_TOOLCHAIN}" = "y" ] && [ "${CT_BINUTILS_LINKER_GOLD}" = "y" ]; then
+        # gold links with CXXLINK/g++, not libtool, and does not understand
+        # -all-static
+        extra_config+=("--with-gold-ldflags=--static")
+    fi
+
     # Disable usage of glob for higher compatibility.
     # Not strictly needed for anything but GDB anyways.
     export ac_cv_func_glob=no
@@ -209,6 +215,9 @@ do_binutils_backend() {
     fi
 
     CT_DoLog EXTRA "Building binutils"
+    if [ "${CT_BINUTILS_LINKER_GOLD}" = "y" ]; then
+        CT_DoExecLog ALL make -C gold ${CT_JOBSFLAGS}
+    fi
     CT_DoExecLog ALL make "${extra_make_flags[@]}" ${CT_JOBSFLAGS}
 
     CT_DoLog EXTRA "Installing binutils"


### PR DESCRIPTION
Most of the binutils programs are built with gcc and linked with libtool, but gold (and dwp) are exceptions being C++ programs. autotools tries to link with $(CXXLD), which usually maps to g++, and not libtool like for the C programs.

binutils.sh passes LDFLAGS="$ldflags -all-static" to make, which assumes the linking program is always libtool, but this fails for gold. By checking if we're currently building binutils with gold we can pass the g++ flag --static to the C++ linker (through --with-gold-ldflags=... to configure), and build gold in a separate make invocation without the overriden LDFLAGS.