### PR TITLE
gcc: Don't set --enable-default-pie by default

### DIFF
--- a/config/cc/gcc.in
+++ b/config/cc/gcc.in
@@ -202,7 +202,7 @@ comment "Settings for libraries running on target"
 config CC_GCC_ENABLE_DEFAULT_PIE
     bool
     prompt "Enable Position Independent Executable as default"
-    default y
+    default n
     depends on GCC_6_or_later && ! WINDOWS && ! ARCH_MIPS && ! ARCH_AVR && ! ARCH_PRU
     depends on !(ARCH_RISCV && BARE_METAL)
     help


### PR DESCRIPTION
This changes how existing crosstool-ng setups work, causing many of the bare-metal ones to fail.

Closes: #1900 