### PR TITLE
packages/gcc: Add gcc patch to allow getenv default values

### DIFF
--- a/packages/gcc/12.2.0/0005-driver-Extend-getenv-function-to-allow-default-value.patch
+++ b/packages/gcc/12.2.0/0005-driver-Extend-getenv-function-to-allow-default-value.patch
@@ -1,0 +1,102 @@
+From fff469f89d865ef3c15efe8e6b0511ea4d48603d Mon Sep 17 00:00:00 2001
+From: Keith Packard <keithp@keithp.com>
+Date: Fri, 26 Aug 2022 14:30:03 -0700
+Subject: [PATCH 6/6] driver: Extend 'getenv' function to allow default value
+
+Right now, a missing environment variable provided to the 'getenv'
+function in a .specs file causes a fatal error. That makes writing a
+spec file that uses the GCC_EXEC_PREFIX value difficult as that
+variable is only set when the driver has been relocated, but not when
+run from the defined location. This makes building a relocatable
+toolchain difficult to extend to other ancilary pieces which use specs
+files to locate header and library files adjacent to the toolchain.
+
+This patch adds an optional third argument to the getenv function that
+can be used to fall back to the standard installation path when the
+driver hasn't set GCC_EXEC_PREFIX in the environment.
+
+For example, if an alternate C library is installed in
+${prefix}/extra, then this change allows the specs file to locate that
+relative to the gcc directory, if gcc is located in the original
+installation directory (which would leave GCC_EXEC_PREFIX unset), or
+if the gcc tree has been moved to a different location (where gcc
+would set GCC_EXEC_PREFIX itself):
+
+*cpp:
+-isystem %:getenv(GCC_EXEC_PREFIX ../../extra/include ${prefix}/extra/include)
+
+I considered changing the behavior of either the %R sequence so that
+it had a defined behavior when there was no sysroot defined, or making
+the driver always set the GCC_EXEC_PREFIX environment variable and
+decided that the approach of adding functionality to getenv where it
+was previously invalid would cause the least potential for affecting
+existing usage.
+
+Signed-off-by: Keith Packard <keithp@keithp.com>
+---
+ gcc/doc/invoke.texi | 18 +++++++++++-------
+ gcc/gcc.cc          | 10 +++++++++-
+ 2 files changed, 20 insertions(+), 8 deletions(-)
+
+diff --git a/gcc/doc/invoke.texi b/gcc/doc/invoke.texi
+index ff6c338bedb..38eeeb7174b 100644
+--- a/gcc/doc/invoke.texi
++++ b/gcc/doc/invoke.texi
+@@ -33776,17 +33776,21 @@ The following built-in spec functions are provided:
+ 
+ @table @code
+ @item @code{getenv}
+-The @code{getenv} spec function takes two arguments: an environment
+-variable name and a string.  If the environment variable is not
+-defined, a fatal error is issued.  Otherwise, the return value is the
+-value of the environment variable concatenated with the string.  For
+-example, if @env{TOPDIR} is defined as @file{/path/to/top}, then:
++
++The @code{getenv} spec function takes two or three arguments: an
++environment variable name, a string and an optional default value.  If
++the environment variable is not defined and a default value is
++provided, that is used as the return value; otherwise a fatal error is
++issued.  Otherwise, the return value is the value of the environment
++variable concatenated with the string.  For example, if @env{TOPDIR}
++is defined as @file{/path/to/top}, then:
+ 
+ @smallexample
+-%:getenv(TOPDIR /include)
++%:getenv(TOPDIR /include /path/to/default/include)
+ @end smallexample
+ 
+-expands to @file{/path/to/top/include}.
++expands to @file{/path/to/top/include}. If @env{TOPDIR} is not
++defined, then this expands to @file{/path/to/default/include}.
+ 
+ @item @code{if-exists}
+ The @code{if-exists} spec function takes one argument, an absolute
+diff --git a/gcc/gcc.cc b/gcc/gcc.cc
+index bb07cc244e3..930d9835768 100644
+--- a/gcc/gcc.cc
++++ b/gcc/gcc.cc
+@@ -10194,12 +10194,20 @@ getenv_spec_function (int argc, const char **argv)
+   char *ptr;
+   size_t len;
+ 
+-  if (argc != 2)
++  if (argc != 2 && argc != 3)
+     return NULL;
+ 
+   varname = argv[0];
+   value = env.get (varname);
+ 
++  if (!value && argc == 3)
++    {
++      value = argv[2];
++      result = XNEWVAR(char, strlen(value) + 1);
++      strcpy(result, value);
++      return result;
++    }
++
+   /* If the variable isn't defined and this is allowed, craft our expected
+      return value.  Assume variable names used in specs strings don't contain
+      any active spec character so don't need escaping.  */
+-- 
+2.39.0
+


### PR DESCRIPTION
This patch, submitted upstream but not (yet?) accepted, adds a third parameter to the specs file 'getenv' function that provides a value for when the environment variable is not set, instead of having gcc fail.

This seemed like the safest way to provide a mechanism for getting the installed location of the toolchain from inside a specs file as, when not installed in the built-in location, gcc already sets the GCC_EXEC_PREFIX environment variable to a well defined location within that directory hierarchy, but when installed in the location specified at compile time, gcc does not. Providing a default value that matches the compile-time location then allows the specs file to compute paths relative to the current GCC installation location, whereever it is installed.