### PR TITLE
Support targeting macOS aarch64 in older GCCs

### DIFF
--- a/packages/gcc/6.5.0/0031-darwin-aarch64-config.patch
+++ b/packages/gcc/6.5.0/0031-darwin-aarch64-config.patch
@@ -1,0 +1,13 @@
+diff -ru a/config.guess b/config.guess
+--- a/config.guess	2015-12-31 22:13:28.000000000 +0100
++++ b/config.guess	2021-12-20 01:44:40.000000000 +0100
+@@ -1278,6 +1278,9 @@
+     *:Rhapsody:*:*)
+ 	echo ${UNAME_MACHINE}-apple-rhapsody${UNAME_RELEASE}
+ 	exit ;;
++    arm64:Darwin:*:*)
++	echo aarch64-apple-darwin"$UNAME_RELEASE"
++	exit ;;
+     *:Darwin:*:*)
+ 	UNAME_PROCESSOR=`uname -p` || UNAME_PROCESSOR=unknown
+ 	eval $set_cc_for_build

--- a/packages/gcc/6.5.0/0032-darwin-aarch64-self-host-driver.patch
+++ b/packages/gcc/6.5.0/0032-darwin-aarch64-self-host-driver.patch
@@ -1,0 +1,70 @@
+--- a/gcc/config.host  2017-01-09 22:01:26.000000000 +0100
++++ b/gcc/config.host   2021-12-27 23:11:12.000000000 +0100
+@@ -99,7 +99,7 @@
+ esac
+
+ case ${host} in
+-  aarch64*-*-freebsd* | aarch64*-*-linux*)
++  aarch64*-*-freebsd* | aarch64*-*-linux* | aarch64*-*-darwin*)
+     case ${target} in
+       aarch64*-*-*)
+    host_extra_gcc_objs="driver-aarch64.o"
+@@ -249,6 +249,10 @@
+     out_host_hook_obj=host-mingw32.o
+     host_lto_plugin_soname=liblto_plugin-0.dll
+     ;;
++  aarch64*-*-darwin*)
++    out_host_hook_obj="${out_host_hook_obj} host-aarch64-darwin.o"
++    host_xmake_file="${host_xmake_file} aarch64/x-darwin"
++    ;;
+   i[34567]86-*-darwin* | x86_64-*-darwin*)
+     out_host_hook_obj="${out_host_hook_obj} host-i386-darwin.o"
+     host_xmake_file="${host_xmake_file} i386/x-darwin"
+diff --git a/gcc/config/aarch64/host-aarch64-darwin.c b/gcc/config/aarch64/host-aarch64-darwin.c
+new file mode 100644
+index 0000000000000..d70f2df3bf1b3
+--- /dev/null
++++ b/gcc/config/aarch64/host-aarch64-darwin.c
+@@ -0,0 +1,33 @@
++/* aarch64/arm64-darwin host-specific hook definitions.
++
++Copyright The GNU Toolchain Authors.
++
++This file is part of GCC.
++
++GCC is free software; you can redistribute it and/or modify it under
++the terms of the GNU General Public License as published by the Free
++Software Foundation; either version 3, or (at your option) any later
++version.
++
++GCC is distributed in the hope that it will be useful, but WITHOUT ANY
++WARRANTY; without even the implied warranty of MERCHANTABILITY or
++FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++for more details.
++
++You should have received a copy of the GNU General Public License
++along with GCC; see the file COPYING3.  If not see
++<http://www.gnu.org/licenses/>.  */
++
++#define IN_TARGET_CODE 1
++
++#include "config.h"
++#include "system.h"
++#include "coretypes.h"
++#include "hosthooks.h"
++#include "hosthooks-def.h"
++#include "config/host-darwin.h"
++
++/* Darwin doesn't do anything special for arm64/aarch64 hosts; this file
++   exists just to include the generic config/host-darwin.h.  */
++
++const struct host_hooks host_hooks = HOST_HOOKS_INITIALIZER;
+diff --git a/gcc/config/aarch64/x-darwin b/gcc/config/aarch64/x-darwin
+new file mode 100644
+index 0000000000000..6d788d5e89cfb
+--- /dev/null
++++ b/gcc/config/aarch64/x-darwin
+@@ -0,0 +1,3 @@
++host-aarch64-darwin.o : $(srcdir)/config/aarch64/host-aarch64-darwin.c
++	$(COMPILE) $<
++	$(POSTCOMPILE)

--- a/packages/gcc/6.5.0/0033-darwin-align-pch_address_space-to-16k.patch
+++ b/packages/gcc/6.5.0/0033-darwin-align-pch_address_space-to-16k.patch
@@ -1,0 +1,32 @@
+From ac2ca688140dbf103ad18efbc8fb98e62ec40e27 Mon Sep 17 00:00:00 2001
+From: Iain Sandoe <iain@sandoe.co.uk>
+Date: Sat, 8 Aug 2020 12:15:09 +0100
+Subject: [PATCH] Darwin: Adjust the PCH area to allow for 16384byte page size.
+
+Newer versions of Darwin report pagesize 20 which means that we
+need to adjust the aligment of the PCH area.
+
+gcc/ChangeLog:
+
+	* config/host-darwin.c: Align pch_address_space to 16384.
+
+(cherry picked from commit 590febb5f6624f78b36402a7c9a9c318978f1efa)
+---
+ gcc/config/host-darwin.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/gcc/config/host-darwin.c b/gcc/config/host-darwin.c
+index 49d3af77a9237..b9cf347f1e847 100644
+--- a/gcc/config/host-darwin.c
++++ b/gcc/config/host-darwin.c
+@@ -24,7 +24,10 @@
+ #include "config/host-darwin.h"
+
+ /* Yes, this is really supposed to work.  */
+-static char pch_address_space[1024*1024*1024] __attribute__((aligned (4096)));
++/* This allows for a pagesize of 16384, which we have on Darwin20, but should
++   continue to work OK for pagesize 4096 which we have on earlier versions.
++   The size is 1 (binary) Gb.  */
++static char pch_address_space[65536*16384] __attribute__((aligned (16384)));
+
+ /* Return the address of the PCH address space, if the PCH will fit in it.  */

--- a/packages/gcc/7.5.0/0021-darwin-aarch64-config.patch
+++ b/packages/gcc/7.5.0/0021-darwin-aarch64-config.patch
@@ -1,0 +1,13 @@
+diff -ru a/config.guess b/config.guess
+--- a/config.guess	2017-03-18 19:22:06.000000000 +0100
++++ b/config.guess	2021-12-20 01:41:00.000000000 +0100
+@@ -1295,6 +1295,9 @@
+     *:Rhapsody:*:*)
+ 	echo ${UNAME_MACHINE}-apple-rhapsody${UNAME_RELEASE}
+ 	exit ;;
++    arm64:Darwin:*:*)
++	echo aarch64-apple-darwin"$UNAME_RELEASE"
++	exit ;;
+     *:Darwin:*:*)
+ 	UNAME_PROCESSOR=`uname -p` || UNAME_PROCESSOR=unknown
+ 	eval $set_cc_for_build

--- a/packages/gcc/7.5.0/0022-darwin-aarch64-self-host-driver.patch
+++ b/packages/gcc/7.5.0/0022-darwin-aarch64-self-host-driver.patch
@@ -1,0 +1,96 @@
+From 834c8749ced550af3f17ebae4072fb7dfb90d271 Mon Sep 17 00:00:00 2001
+From: Iain Sandoe <iain@sandoe.co.uk>
+Date: Tue, 18 Aug 2020 22:29:51 +0100
+Subject: [PATCH] Darwin, aarch64 : Initial support for the self-host driver.
+
+At present, there is no special action needed for aarch64-darwin
+this just pulls in generic Darwin code.
+
+Signed-off-by: Iain Sandoe <iain@sandoe.co.uk>
+
+gcc/ChangeLog:
+
+	* config.host: Add support for aarch64-*-darwin.
+	* config/aarch64/host-aarch64-darwin.c: New file.
+	* config/aarch64/x-darwin: New file.
+---
+ gcc/config.host                          |  7 ++++-
+ gcc/config/aarch64/host-aarch64-darwin.c | 33 ++++++++++++++++++++++++
+ gcc/config/aarch64/x-darwin              |  3 +++
+ 3 files changed, 42 insertions(+), 1 deletion(-)
+ create mode 100644 gcc/config/aarch64/host-aarch64-darwin.c
+ create mode 100644 gcc/config/aarch64/x-darwin
+
+diff --git a/gcc/config.host b/gcc/config.host
+index 0a02c33cc8044..81ff7ed1043e2 100644
+--- a/gcc/config.host
++++ b/gcc/config.host
+@@ -99,7 +99,8 @@ case ${host} in
+ esac
+
+ case ${host} in
+-  aarch64*-*-freebsd* | aarch64*-*-linux* | aarch64*-*-fuchsia*)
++  aarch64*-*-freebsd* | aarch64*-*-linux* | aarch64*-*-fuchsia* |\
++  aarch64*-*-darwin*)
+     case ${target} in
+       aarch64*-*-*)
+ 	host_extra_gcc_objs="driver-aarch64.o"
+@@ -249,6 +250,10 @@ case ${host} in
+     out_host_hook_obj=host-mingw32.o
+     host_lto_plugin_soname=liblto_plugin-0.dll
+     ;;
++  aarch64*-*-darwin*)
++    out_host_hook_obj="${out_host_hook_obj} host-aarch64-darwin.o"
++    host_xmake_file="${host_xmake_file} aarch64/x-darwin"
++    ;;
+   i[34567]86-*-darwin* | x86_64-*-darwin*)
+     out_host_hook_obj="${out_host_hook_obj} host-i386-darwin.o"
+     host_xmake_file="${host_xmake_file} i386/x-darwin"
+diff --git a/gcc/config/aarch64/host-aarch64-darwin.c b/gcc/config/aarch64/host-aarch64-darwin.c
+new file mode 100644
+index 0000000000000..d70f2df3bf1b3
+--- /dev/null
++++ b/gcc/config/aarch64/host-aarch64-darwin.c
+@@ -0,0 +1,33 @@
++/* aarch64/arm64-darwin host-specific hook definitions.
++
++Copyright The GNU Toolchain Authors.
++
++This file is part of GCC.
++
++GCC is free software; you can redistribute it and/or modify it under
++the terms of the GNU General Public License as published by the Free
++Software Foundation; either version 3, or (at your option) any later
++version.
++
++GCC is distributed in the hope that it will be useful, but WITHOUT ANY
++WARRANTY; without even the implied warranty of MERCHANTABILITY or
++FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++for more details.
++
++You should have received a copy of the GNU General Public License
++along with GCC; see the file COPYING3.  If not see
++<http://www.gnu.org/licenses/>.  */
++
++#define IN_TARGET_CODE 1
++
++#include "config.h"
++#include "system.h"
++#include "coretypes.h"
++#include "hosthooks.h"
++#include "hosthooks-def.h"
++#include "config/host-darwin.h"
++
++/* Darwin doesn't do anything special for arm64/aarch64 hosts; this file
++   exists just to include the generic config/host-darwin.h.  */
++
++const struct host_hooks host_hooks = HOST_HOOKS_INITIALIZER;
+diff --git a/gcc/config/aarch64/x-darwin b/gcc/config/aarch64/x-darwin
+new file mode 100644
+index 0000000000000..6d788d5e89cfb
+--- /dev/null
++++ b/gcc/config/aarch64/x-darwin
+@@ -0,0 +1,3 @@
++host-aarch64-darwin.o : $(srcdir)/config/aarch64/host-aarch64-darwin.c
++	$(COMPILE) $<
++	$(POSTCOMPILE)

--- a/packages/gcc/7.5.0/0023-darwin-align-pch_address_space-to-16k.patch
+++ b/packages/gcc/7.5.0/0023-darwin-align-pch_address_space-to-16k.patch
@@ -1,0 +1,32 @@
+From ac2ca688140dbf103ad18efbc8fb98e62ec40e27 Mon Sep 17 00:00:00 2001
+From: Iain Sandoe <iain@sandoe.co.uk>
+Date: Sat, 8 Aug 2020 12:15:09 +0100
+Subject: [PATCH] Darwin: Adjust the PCH area to allow for 16384byte page size.
+
+Newer versions of Darwin report pagesize 20 which means that we
+need to adjust the aligment of the PCH area.
+
+gcc/ChangeLog:
+
+	* config/host-darwin.c: Align pch_address_space to 16384.
+
+(cherry picked from commit 590febb5f6624f78b36402a7c9a9c318978f1efa)
+---
+ gcc/config/host-darwin.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/gcc/config/host-darwin.c b/gcc/config/host-darwin.c
+index 49d3af77a9237..b9cf347f1e847 100644
+--- a/gcc/config/host-darwin.c
++++ b/gcc/config/host-darwin.c
+@@ -24,7 +24,10 @@
+ #include "config/host-darwin.h"
+
+ /* Yes, this is really supposed to work.  */
+-static char pch_address_space[1024*1024*1024] __attribute__((aligned (4096)));
++/* This allows for a pagesize of 16384, which we have on Darwin20, but should
++   continue to work OK for pagesize 4096 which we have on earlier versions.
++   The size is 1 (binary) Gb.  */
++static char pch_address_space[65536*16384] __attribute__((aligned (16384)));
+
+ /* Return the address of the PCH address space, if the PCH will fit in it.  */

--- a/packages/gcc/8.5.0/0023-darwin-aarch64-config.patch
+++ b/packages/gcc/8.5.0/0023-darwin-aarch64-config.patch
@@ -1,0 +1,13 @@
+diff -ru a/config.guess b/config.guess
+--- a/config.guess	2021-05-14 10:42:08.000000000 +0200
++++ b/config.guess	2021-12-20 01:38:22.000000000 +0100
+@@ -1276,6 +1276,9 @@
+     *:Rhapsody:*:*)
+ 	echo ${UNAME_MACHINE}-apple-rhapsody${UNAME_RELEASE}
+ 	exit ;;
++    arm64:Darwin:*:*)
++	echo aarch64-apple-darwin"$UNAME_RELEASE"
++	exit ;;
+     *:Darwin:*:*)
+ 	UNAME_PROCESSOR=`uname -p` || UNAME_PROCESSOR=unknown
+ 	eval $set_cc_for_build

--- a/packages/gcc/8.5.0/0024-darwin-aarch64-self-host-driver.patch
+++ b/packages/gcc/8.5.0/0024-darwin-aarch64-self-host-driver.patch
@@ -1,0 +1,96 @@
+From 834c8749ced550af3f17ebae4072fb7dfb90d271 Mon Sep 17 00:00:00 2001
+From: Iain Sandoe <iain@sandoe.co.uk>
+Date: Tue, 18 Aug 2020 22:29:51 +0100
+Subject: [PATCH] Darwin, aarch64 : Initial support for the self-host driver.
+
+At present, there is no special action needed for aarch64-darwin
+this just pulls in generic Darwin code.
+
+Signed-off-by: Iain Sandoe <iain@sandoe.co.uk>
+
+gcc/ChangeLog:
+
+	* config.host: Add support for aarch64-*-darwin.
+	* config/aarch64/host-aarch64-darwin.c: New file.
+	* config/aarch64/x-darwin: New file.
+---
+ gcc/config.host                          |  7 ++++-
+ gcc/config/aarch64/host-aarch64-darwin.c | 33 ++++++++++++++++++++++++
+ gcc/config/aarch64/x-darwin              |  3 +++
+ 3 files changed, 42 insertions(+), 1 deletion(-)
+ create mode 100644 gcc/config/aarch64/host-aarch64-darwin.c
+ create mode 100644 gcc/config/aarch64/x-darwin
+
+diff --git a/gcc/config.host b/gcc/config.host
+index 0a02c33cc8044..81ff7ed1043e2 100644
+--- a/gcc/config.host
++++ b/gcc/config.host
+@@ -99,7 +99,8 @@ case ${host} in
+ esac
+
+ case ${host} in
+-  aarch64*-*-freebsd* | aarch64*-*-linux* | aarch64*-*-fuchsia*)
++  aarch64*-*-freebsd* | aarch64*-*-linux* | aarch64*-*-fuchsia* |\
++  aarch64*-*-darwin*)
+     case ${target} in
+       aarch64*-*-*)
+ 	host_extra_gcc_objs="driver-aarch64.o"
+@@ -256,6 +257,10 @@ case ${host} in
+     host_extra_gcc_objs="${host_extra_gcc_objs} driver-mingw32.o"
+     host_lto_plugin_soname=liblto_plugin-0.dll
+     ;;
++  aarch64*-*-darwin*)
++    out_host_hook_obj="${out_host_hook_obj} host-aarch64-darwin.o"
++    host_xmake_file="${host_xmake_file} aarch64/x-darwin"
++    ;;
+   i[34567]86-*-darwin* | x86_64-*-darwin*)
+     out_host_hook_obj="${out_host_hook_obj} host-i386-darwin.o"
+     host_xmake_file="${host_xmake_file} i386/x-darwin"
+diff --git a/gcc/config/aarch64/host-aarch64-darwin.c b/gcc/config/aarch64/host-aarch64-darwin.c
+new file mode 100644
+index 0000000000000..d70f2df3bf1b3
+--- /dev/null
++++ b/gcc/config/aarch64/host-aarch64-darwin.c
+@@ -0,0 +1,33 @@
++/* aarch64/arm64-darwin host-specific hook definitions.
++
++Copyright The GNU Toolchain Authors.
++
++This file is part of GCC.
++
++GCC is free software; you can redistribute it and/or modify it under
++the terms of the GNU General Public License as published by the Free
++Software Foundation; either version 3, or (at your option) any later
++version.
++
++GCC is distributed in the hope that it will be useful, but WITHOUT ANY
++WARRANTY; without even the implied warranty of MERCHANTABILITY or
++FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++for more details.
++
++You should have received a copy of the GNU General Public License
++along with GCC; see the file COPYING3.  If not see
++<http://www.gnu.org/licenses/>.  */
++
++#define IN_TARGET_CODE 1
++
++#include "config.h"
++#include "system.h"
++#include "coretypes.h"
++#include "hosthooks.h"
++#include "hosthooks-def.h"
++#include "config/host-darwin.h"
++
++/* Darwin doesn't do anything special for arm64/aarch64 hosts; this file
++   exists just to include the generic config/host-darwin.h.  */
++
++const struct host_hooks host_hooks = HOST_HOOKS_INITIALIZER;
+diff --git a/gcc/config/aarch64/x-darwin b/gcc/config/aarch64/x-darwin
+new file mode 100644
+index 0000000000000..6d788d5e89cfb
+--- /dev/null
++++ b/gcc/config/aarch64/x-darwin
+@@ -0,0 +1,3 @@
++host-aarch64-darwin.o : $(srcdir)/config/aarch64/host-aarch64-darwin.c
++	$(COMPILE) $<
++	$(POSTCOMPILE)

--- a/packages/gcc/8.5.0/0025-darwin-align-pch_address_space-to-16k.patch
+++ b/packages/gcc/8.5.0/0025-darwin-align-pch_address_space-to-16k.patch
@@ -1,0 +1,32 @@
+From ac2ca688140dbf103ad18efbc8fb98e62ec40e27 Mon Sep 17 00:00:00 2001
+From: Iain Sandoe <iain@sandoe.co.uk>
+Date: Sat, 8 Aug 2020 12:15:09 +0100
+Subject: [PATCH] Darwin: Adjust the PCH area to allow for 16384byte page size.
+
+Newer versions of Darwin report pagesize 20 which means that we
+need to adjust the aligment of the PCH area.
+
+gcc/ChangeLog:
+
+	* config/host-darwin.c: Align pch_address_space to 16384.
+
+(cherry picked from commit 590febb5f6624f78b36402a7c9a9c318978f1efa)
+---
+ gcc/config/host-darwin.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/gcc/config/host-darwin.c b/gcc/config/host-darwin.c
+index 49d3af77a9237..b9cf347f1e847 100644
+--- a/gcc/config/host-darwin.c
++++ b/gcc/config/host-darwin.c
+@@ -24,7 +24,10 @@
+ #include "config/host-darwin.h"
+
+ /* Yes, this is really supposed to work.  */
+-static char pch_address_space[1024*1024*1024] __attribute__((aligned (4096)));
++/* This allows for a pagesize of 16384, which we have on Darwin20, but should
++   continue to work OK for pagesize 4096 which we have on earlier versions.
++   The size is 1 (binary) Gb.  */
++static char pch_address_space[65536*16384] __attribute__((aligned (16384)));
+
+ /* Return the address of the PCH address space, if the PCH will fit in it.  */

--- a/packages/gcc/9.5.0/0019-darwin-aarch64-config.patch
+++ b/packages/gcc/9.5.0/0019-darwin-aarch64-config.patch
@@ -1,0 +1,13 @@
+diff -ru a/config.guess b/config.guess
+--- a/config.guess	2021-06-01 09:53:04.000000000 +0200
++++ b/config.guess	2021-12-20 01:29:55.000000000 +0100
+@@ -1309,6 +1309,9 @@
+     *:Rhapsody:*:*)
+ 	echo "$UNAME_MACHINE"-apple-rhapsody"$UNAME_RELEASE"
+ 	exit ;;
++    arm64:Darwin:*:*)
++	echo aarch64-apple-darwin"$UNAME_RELEASE"
++	exit ;;
+     *:Darwin:*:*)
+ 	UNAME_PROCESSOR=`uname -p` || UNAME_PROCESSOR=unknown
+ 	set_cc_for_build

--- a/packages/gcc/9.5.0/0020-darwin-aarch64-self-host-driver.patch
+++ b/packages/gcc/9.5.0/0020-darwin-aarch64-self-host-driver.patch
@@ -1,0 +1,96 @@
+From 834c8749ced550af3f17ebae4072fb7dfb90d271 Mon Sep 17 00:00:00 2001
+From: Iain Sandoe <iain@sandoe.co.uk>
+Date: Tue, 18 Aug 2020 22:29:51 +0100
+Subject: [PATCH] Darwin, aarch64 : Initial support for the self-host driver.
+
+At present, there is no special action needed for aarch64-darwin
+this just pulls in generic Darwin code.
+
+Signed-off-by: Iain Sandoe <iain@sandoe.co.uk>
+
+gcc/ChangeLog:
+
+	* config.host: Add support for aarch64-*-darwin.
+	* config/aarch64/host-aarch64-darwin.c: New file.
+	* config/aarch64/x-darwin: New file.
+---
+ gcc/config.host                          |  7 ++++-
+ gcc/config/aarch64/host-aarch64-darwin.c | 33 ++++++++++++++++++++++++
+ gcc/config/aarch64/x-darwin              |  3 +++
+ 3 files changed, 42 insertions(+), 1 deletion(-)
+ create mode 100644 gcc/config/aarch64/host-aarch64-darwin.c
+ create mode 100644 gcc/config/aarch64/x-darwin
+
+diff --git a/gcc/config.host b/gcc/config.host
+index 0a02c33cc8044..81ff7ed1043e2 100644
+--- a/gcc/config.host
++++ b/gcc/config.host
+@@ -99,7 +99,8 @@ case ${host} in
+ esac
+
+ case ${host} in
+-  aarch64*-*-freebsd* | aarch64*-*-linux* | aarch64*-*-fuchsia*)
++  aarch64*-*-freebsd* | aarch64*-*-linux* | aarch64*-*-fuchsia* |\
++  aarch64*-*-darwin*)
+     case ${target} in
+       aarch64*-*-*)
+ 	host_extra_gcc_objs="driver-aarch64.o"
+@@ -251,6 +252,10 @@ case ${host} in
+     host_extra_gcc_objs="${host_extra_gcc_objs} driver-mingw32.o"
+     host_lto_plugin_soname=liblto_plugin-0.dll
+     ;;
++  aarch64*-*-darwin*)
++    out_host_hook_obj="${out_host_hook_obj} host-aarch64-darwin.o"
++    host_xmake_file="${host_xmake_file} aarch64/x-darwin"
++    ;;
+   i[34567]86-*-darwin* | x86_64-*-darwin*)
+     out_host_hook_obj="${out_host_hook_obj} host-i386-darwin.o"
+     host_xmake_file="${host_xmake_file} i386/x-darwin"
+diff --git a/gcc/config/aarch64/host-aarch64-darwin.c b/gcc/config/aarch64/host-aarch64-darwin.c
+new file mode 100644
+index 0000000000000..d70f2df3bf1b3
+--- /dev/null
++++ b/gcc/config/aarch64/host-aarch64-darwin.c
+@@ -0,0 +1,33 @@
++/* aarch64/arm64-darwin host-specific hook definitions.
++
++Copyright The GNU Toolchain Authors.
++
++This file is part of GCC.
++
++GCC is free software; you can redistribute it and/or modify it under
++the terms of the GNU General Public License as published by the Free
++Software Foundation; either version 3, or (at your option) any later
++version.
++
++GCC is distributed in the hope that it will be useful, but WITHOUT ANY
++WARRANTY; without even the implied warranty of MERCHANTABILITY or
++FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++for more details.
++
++You should have received a copy of the GNU General Public License
++along with GCC; see the file COPYING3.  If not see
++<http://www.gnu.org/licenses/>.  */
++
++#define IN_TARGET_CODE 1
++
++#include "config.h"
++#include "system.h"
++#include "coretypes.h"
++#include "hosthooks.h"
++#include "hosthooks-def.h"
++#include "config/host-darwin.h"
++
++/* Darwin doesn't do anything special for arm64/aarch64 hosts; this file
++   exists just to include the generic config/host-darwin.h.  */
++
++const struct host_hooks host_hooks = HOST_HOOKS_INITIALIZER;
+diff --git a/gcc/config/aarch64/x-darwin b/gcc/config/aarch64/x-darwin
+new file mode 100644
+index 0000000000000..6d788d5e89cfb
+--- /dev/null
++++ b/gcc/config/aarch64/x-darwin
+@@ -0,0 +1,3 @@
++host-aarch64-darwin.o : $(srcdir)/config/aarch64/host-aarch64-darwin.c
++	$(COMPILE) $<
++	$(POSTCOMPILE)


### PR DESCRIPTION
Ported from https://github.com/richfelker/musl-cross-make/pull/129