### PR TITLE
CI: Exclude macos,arm-picolibc-eabi combination

### DIFF
--- a/.github/workflows/build-toolchains.yml
+++ b/.github/workflows/build-toolchains.yml
@@ -34,6 +34,10 @@ jobs:
           - {host: "macos-latest", sample: "mips-unknown-linux-gnu"}
           - {host: "macos-latest", sample: "mips64-unknown-linux-gnu"}
 
+          # Exclude arm-picolibc-eabi because the multilib build output takes
+          # up too much room on the macos makers
+          - {host: "macos-latest", sample: "arm-picolibc-eabi"}
+
           # Exclude x86_64-w64-mingw32,x86_64-pc-linux-gnu because it crashes on m4 build with
           # a Segmentation fault
           - {host: "macos-latest", sample: "x86_64-w64-mingw32,x86_64-pc-linux-gnu"}


### PR DESCRIPTION
The arm-picolibc-eabi build runs out of space on the macos makers because of all the multilib permutations. For now disable the macos,arm-picolibc-eabi combination until we can think of something better.