### PR TITLE
Add default msvcrt options for mingw-w64

### DIFF
--- a/config/libc/mingw-w64.in
+++ b/config/libc/mingw-w64.in
@@ -17,6 +17,42 @@ config MINGW_SECURE_API
     bool "Expose secure API prototypes"
     default y
 
+choice
+    bool
+    prompt "Default C Runtime to use"
+    default MINGW_DEFAULT_MSVCRT_DEFAULT
+    help
+      See mingw-w64 help for full list of possible values.
+      Most commonly one would want to upgrade this to ucrt
+      for a more modern C runtime.
+      Targeting specific older/newer MSVC versions is possible
+      as well though.
+
+config MINGW_DEFAULT_MSVCRT_DEFAULT
+    bool
+    prompt "Default"
+    help
+      Don't set a default msvcrt, leave decision to mingw.
+
+config MINGW_DEFAULT_MSVCRT_MSVCRT
+    bool
+    prompt "msvcrt"
+
+config MINGW_DEFAULT_MSVCRT_UCRT
+    bool
+    prompt "ucrt"
+
+config MINGW_DEFAULT_MSVCRT_CUSTOM
+    bool
+    prompt "Custom"
+
+endchoice
+
+config MINGW_DEFAULT_MSVCRT
+    string "Custom default C Runtime to use"
+    depends on MINGW_DEFAULT_MSVCRT_CUSTOM
+    default ""
+
 config MINGW_DIRECTX
     bool "Include DirectX development files"
 

--- a/scripts/build/libc/mingw-w64.sh
+++ b/scripts/build/libc/mingw-w64.sh
@@ -25,6 +25,14 @@ mingw_w64_headers() {
         sdk_opts+=( "--enable-secure-api"  )
     fi
 
+    if [ "${CT_MINGW_DEFAULT_MSVCRT_MSVCRT}" = "y" ]; then
+        sdk_opts+=( "--with-default-msvcrt=msvcrt" )
+    elif [ "${CT_MINGW_DEFAULT_MSVCRT_UCRT}" = "y" ]; then
+        sdk_opts+=( "--with-default-msvcrt=ucrt" )
+    elif [ -n "${CT_MINGW_DEFAULT_MSVCRT}" ]; then
+        sdk_opts+=( "--with-default-msvcrt=${CT_MINGW_DEFAULT_MSVCRT}" )
+    fi
+
     CT_mkdir_pushd "${CT_BUILD_DIR}/build-mingw-w64-headers"
 
     CT_DoLog EXTRA "Configuring Headers"
@@ -174,6 +182,7 @@ mingw_w64_main()
 {
     # Used when iterating over libwinpthread
     local default_libprefix
+    local -a crt_opts
 
     do_check_mingw_vendor_tuple
 
@@ -183,6 +192,14 @@ mingw_w64_main()
 
     CT_mkdir_pushd "${CT_BUILD_DIR}/build-mingw-w64-crt"
 
+    if [ "${CT_MINGW_DEFAULT_MSVCRT_MSVCRT}" = "y" ]; then
+        crt_opts+=( "--with-default-msvcrt=msvcrt" )
+    elif [ "${CT_MINGW_DEFAULT_MSVCRT_UCRT}" = "y" ]; then
+        crt_opts+=( "--with-default-msvcrt=ucrt" )
+    elif [ -n "${CT_MINGW_DEFAULT_MSVCRT}" ]; then
+        crt_opts+=( "--with-default-msvcrt=${CT_MINGW_DEFAULT_MSVCRT}"  )
+    fi
+
     mingw_w64_set_install_prefix
     CT_DoExecLog CFG \
     ${CONFIG_SHELL} \
@@ -190,7 +207,8 @@ mingw_w64_main()
         --with-sysroot=${CT_SYSROOT_DIR} \
         --prefix=${MINGW_INSTALL_PREFIX} \
         --build=${CT_BUILD} \
-        --host=${CT_TARGET}
+        --host=${CT_TARGET} \
+        "${crt_opts[@]}"
 
     # mingw-w64-crt has a missing dependency occasionally breaking the
     # parallel build. See https://github.com/crosstool-ng/crosstool-ng/issues/246


### PR DESCRIPTION
This also addresses issue #1896.

I wasn't sure if I should make this just a bool for ucrt, a selection of the known list, or just a free-form text.
In the end, I decided for a plain string, since it gives users the most flexibility.