### PR TITLE
config/arch/x86: enable libsanitizer

### DIFF
--- a/config/arch/x86.in
+++ b/config/arch/x86.in
@@ -9,7 +9,7 @@
 ## select ARCH_SUPPORTS_WITH_CPU
 ## select ARCH_SUPPORTS_WITH_TUNE
 ## select ARCH_SUPPORTS_WITH_32_64
-## select ARCH_SUPPORTS_LIBSANITIZER if ARCH_64
+## select ARCH_SUPPORTS_LIBSANITIZER
 ##
 ## help The x86 architecture, as defined by:
 ## help     32-bit (ia32) : http://www.intel.com/


### PR DESCRIPTION
GCC's libsanitizer module does provide a subset of support for x86 targets (e.g. libasan). GCC's `libsanitizer/configure.tgt` file only outlines flags for optional sanitizers.