### PR TITLE
gdb: Fix extra config variable name for native GDB

### DIFF
--- a/scripts/build/debug/300-gdb.sh
+++ b/scripts/build/debug/300-gdb.sh
@@ -167,8 +167,8 @@ do_debug_gdb_build()
         # version of expat and will attempt to link that, despite the -static flag.
         # The link will fail, and configure will abort with "expat missing or unusable"
         # message.
-        extra_config+=("--with-expat")
-        extra_config+=("--without-libexpat-prefix")
+        native_extra_config+=("--with-expat")
+        native_extra_config+=("--without-libexpat-prefix")
 
         do_gdb_backend \
             buildtype=native \


### PR DESCRIPTION
Variable ``native_extra_config`` must be used for configuration options instead for ``extra_config`` for native GDB.