### PR TITLE
Add support of building MPFR for target and make GDB 13+ dependent on MPFR

### DIFF
--- a/config/comp_libs.in
+++ b/config/comp_libs.in
@@ -61,6 +61,10 @@ config MPFR_NEEDED
     select GMP_NEEDED
     select COMP_LIBS_MPFR
 
+config MPFR_TARGET
+    bool
+    select COMP_LIBS_MPFR
+
 config ISL_NEEDED
     bool
     select GMP_NEEDED

--- a/config/debug/gdb.in.native
+++ b/config/debug/gdb.in.native
@@ -10,6 +10,7 @@ config GDB_NATIVE
     select EXPAT_TARGET
     select NCURSES_TARGET
     select GMP_TARGET if GDB_11_or_later
+    select MPFR_TARGET if GDB_13_or_later
     help
       Build and install a native gdb for the target, to run on the target.
 

--- a/scripts/build/companion_libs/110-mpfr.sh
+++ b/scripts/build/companion_libs/110-mpfr.sh
@@ -9,7 +9,7 @@ do_mpfr_for_host() { :; }
 do_mpfr_for_target() { :; }
 
 # Overide function depending on configuration
-if [ "${CT_MPFR}" = "y" ]; then
+if [ "${CT_MPFR_TARGET}" = "y" -o "${CT_MPFR}" = "y" ]; then
 
 # Download MPFR
 do_mpfr_get() {
@@ -82,17 +82,45 @@ do_mpfr_for_host() {
     CT_EndStep
 }
 
+if [ "${CT_MPFR_TARGET}" = "y" ]; then
+do_mpfr_for_target() {
+    local -a mpfr_opts
+
+    CT_DoStep INFO "Installing MPFR for target"
+    CT_mkdir_pushd "${CT_BUILD_DIR}/build-mpfr-target-${CT_HOST}"
+
+    mpfr_opts+=( "host=${CT_TARGET}" )
+    case "${CT_TARGET}" in
+        *-*-mingw*)
+            prefix="/mingw"
+            ;;
+        *)
+            prefix="/usr"
+            ;;
+    esac
+    mpfr_opts+=( "cflags=${CT_ALL_TARGET_CFLAGS}" )
+    mpfr_opts+=( "prefix=${prefix}" )
+    mpfr_opts+=( "destdir=${CT_SYSROOT_DIR}" )
+    do_mpfr_backend "${mpfr_opts[@]}"
+
+    CT_Popd
+    CT_EndStep
+}
+fi
+
 # Build MPFR
 #     Parameter     : description               : type      : default
 #     host          : machine to run on         : tuple     : (none)
 #     prefix        : prefix to install into    : dir       : (none)
 #     cflags        : cflags to use             : string    : (empty)
 #     ldflags       : ldflags to use            : string    : (empty)
+#     destdir       : install destination       : dir       : (none)
 do_mpfr_backend() {
     local host
     local prefix
     local cflags
     local ldflags
+    local destdir
     local arg
     local -a extra_config
 
@@ -123,12 +151,34 @@ do_mpfr_backend() {
         --host=${host}                                  \
         --prefix="${prefix}"                            \
         "${extra_config[@]}"                            \
-        --with-gmp="${prefix}"                          \
+        --with-gmp="${destdir}${prefix}"                \
         --disable-shared                                \
         --enable-static
 
+    # If "${destdir}${prefix}" != "${prefix}" then it means that native MPFR
+    # is being built. In this case libgmp.la must be moved away while
+    # building MPFR. Otherwise libmpfr.la will contain this:
+    #
+    #     dependency_libs=' -L<path-to-build-dir>/lib /usr/lib/libgmp.la'
+    #
+    # Build system then tries to link MPFR with host's libgmp.a. It happens
+    # because libgmp.a and libmpfr.a are built with --prefix=/usr while
+    # cross-compiling for target and MPFR depends on GMP. In this case
+    # libtool thinks that GMP resides in /usr/lib and uses wrong path.
+    # The only way to avoid such behavior is to replace libgmp.la
+    # temporarily to force libtool using -lgmp option instead wrong one.
+    if [ "${destdir}${prefix}" != "${prefix}" ]; then
+        if [ -f ${destdir}${prefix}/lib/libgmp.la ]; then
+            mv ${destdir}${prefix}/lib/libgmp.la ${destdir}${prefix}/lib/libgmp.la.bk
+        fi
+    fi
+
     CT_DoLog EXTRA "Building MPFR"
     CT_DoExecLog ALL make ${CT_JOBSFLAGS}
+
+    if [ -f ${destdir}${prefix}/lib/libgmp.la.bk ]; then
+        mv ${destdir}${prefix}/lib/libgmp.la.bk ${destdir}${prefix}/lib/libgmp.la
+    fi
 
     if [ "${CT_COMPLIBS_CHECK}" = "y" ]; then
         if [ "${host}" = "${CT_BUILD}" ]; then
@@ -141,7 +191,7 @@ do_mpfr_backend() {
     fi
 
     CT_DoLog EXTRA "Installing MPFR"
-    CT_DoExecLog ALL make install
+    CT_DoExecLog ALL make install DESTDIR="${destdir}"
 }
 
 fi # CT_MPFR


### PR DESCRIPTION
Add support of building MPFR for target and make GDB 13+ dependent on MPFR in any case (while GDB building for host or for target) because MPFR is mandatory for GDB 13+.