### PR TITLE
gdb: Bring in upstream fix for build error

### DIFF
--- a/packages/gdb/13.1/0000-gdbserver-linux-low.cc-Fix-a-typo-in-ternary-operato.patch
+++ b/packages/gdb/13.1/0000-gdbserver-linux-low.cc-Fix-a-typo-in-ternary-operato.patch
@@ -1,0 +1,21 @@
+From 2e977d9901393ea1bacbe1896af0929e968bc811 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Wed, 22 Feb 2023 16:28:22 -0800
+Subject: [PATCH] gdbserver/linux-low.cc: Fix a typo in ternary operator
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ gdbserver/linux-low.cc |    2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/gdbserver/linux-low.cc
++++ b/gdbserver/linux-low.cc
+@@ -5390,7 +5390,7 @@
+       if (lseek (fd, memaddr, SEEK_SET) != -1)
+ 	bytes = (readbuf != nullptr
+ 		 ? read (fd, readbuf, len)
+-		 ? write (fd, writebuf, len));
++		 : write (fd, writebuf, len));
+ #endif
+ 
+       if (bytes < 0)


### PR DESCRIPTION
On systems that lack pread64() (e.g. musl) the following build error is observed.

  src/gdb/gdbserver/linux-low.cc:5393:45: error: expected ':' before ')' token
  src/gdb/gdbserver/linux-low.cc:5393:45: error: expected primary-expression before ')' token
  src/gdb/gdbserver/linux-low.cc:5393:45: error: expected ':' before ')' token
  src/gdb/gdbserver/linux-low.cc:5393:45: error: expected primary-expression before ')' token

Bring in the upstream fix for this error.