### PR TITLE
strace: Fixup patch to configure

### DIFF
--- a/packages/strace/6.3/0000-configure-do-not-take-the-SUBLEVEL-part-of-the-kerne.patch
+++ b/packages/strace/6.3/0000-configure-do-not-take-the-SUBLEVEL-part-of-the-kerne.patch
@@ -33,7 +33,7 @@ Resolves: https://github.com/strace/strace/issues/253
  /* end confdefs.h.  */
  #include <linux/version.h>
 -#define USE_OS_HEADERS (LINUX_VERSION_CODE > 393984 ? 1 : -1)
-+#define USE_OS_HEADERS ((LINUX_VERSION_CODE >> 8) > (]linux_version_code[ >> 8) ? 1 : -1)
++#define USE_OS_HEADERS ((LINUX_VERSION_CODE >> 8) > (393984 >> 8) ? 1 : -1)
  int
  main ()
  {


### PR DESCRIPTION
In the rush to sort out a build issue with strace an invalid change to ./configure was made. Update the patch with the correct delta for the generated file.

Fixes #1978
Fixes: d659700d ("strace: Add strace 6.3")
Signed-off-by: Chris Packham <judge.packham@gmail.com>