### PR TITLE
Properly build multilib bare-metal RISC-V

### DIFF
--- a/config/cc/gcc.in
+++ b/config/cc/gcc.in
@@ -81,6 +81,7 @@ config CC_GCC_EXTRA_CONFIG_ARRAY
 config CC_GCC_MULTILIB_LIST
     string "List of multilib variants"
     depends on MULTILIB
+    depends on ! (ARCH_RISCV && BARE_METAL)
     default "m2,m2e,m4,m4-single,m4-single-only,m2a,m2a-single" if GCC_11_or_later && ARCH_SH
     default "aprofile,rmprofile" if ARCH_ARM && ARCH_32
     help
@@ -88,6 +89,18 @@ config CC_GCC_MULTILIB_LIST
       the multilib variants to be built. Refer to GCC installation manual
       for the format of this option for a particular architecture.
       Leave empty to use the default list for this architecture.
+
+config CC_GCC_MULTILIB_GENERATOR
+    string "Generator of RISC-V multilib variants"
+    depends on MULTILIB
+    depends on (ARCH_RISCV && BARE_METAL)
+    default ""
+    help
+      Multilib generator for RISC-V architecture.
+
+      For more information please refer to gcc manual
+
+      If unsure, leave empty.
 
 config STATIC_TOOLCHAIN
     bool

--- a/samples/riscv64-multilib-elf/crosstool.config
+++ b/samples/riscv64-multilib-elf/crosstool.config
@@ -1,0 +1,10 @@
+CT_CONFIG_VERSION="4"
+CT_EXPERIMENTAL=y
+CT_ARCH_RISCV=y
+CT_MULTILIB=y
+CT_ARCH_USE_MMU=y
+CT_ARCH_64=y
+CT_ARCH_ARCH="rv64gc"
+CT_TARGET_VENDOR="multilib"
+CT_CC_GCC_MULTILIB_GENERATOR="rv32e-ilp32e--;rv32ea-ilp32e--;rv32em-ilp32e--;rv32eac-ilp32e--;rv32emac-ilp32e--;rv32i-ilp32--;rv32ia-ilp32--;rv32im-ilp32--;rv32if-ilp32f--;rv32ifd-ilp32d--;rv32iaf-ilp32f--;rv32iafd-ilp32d--;rv32imf-ilp32f--;rv32imfd-ilp32d--;rv32iac-ilp32--;rv32imac-ilp32--;rv32imafc-ilp32f--;rv32imafdc-ilp32d--;rv64i-lp64--;rv64ia-lp64--;rv64im-lp64--;rv64if-lp64f--;rv64ifd-lp64d--;rv64iaf-lp64f--;rv64iafd-lp64d--;rv64imf-lp64f--;rv64imaf-lp64f--;rv64iac-lp64--;rv64imac-lp64--;rv64imafc-lp64f--;rv64imafdc-lp64d--"
+CT_CC_LANG_CXX=y

--- a/samples/riscv64-multilib-elf/reported.by
+++ b/samples/riscv64-multilib-elf/reported.by
@@ -1,0 +1,3 @@
+reporter_name="Kirill K. Smirnov"
+reporter_url=""
+reporter_comment="Example of multilib bare-metal RISC-V"

--- a/scripts/build/cc/gcc.sh
+++ b/scripts/build/cc/gcc.sh
@@ -541,6 +541,9 @@ do_gcc_core_backend() {
         if [ -n "${CT_CC_GCC_MULTILIB_LIST}" ]; then
             extra_config+=("--with-multilib-list=${CT_CC_GCC_MULTILIB_LIST}")
         fi
+        if [ -n "${CT_CC_GCC_MULTILIB_GENERATOR}" ]; then
+            extra_config+=("--with-multilib-generator=${CT_CC_GCC_MULTILIB_GENERATOR}")
+        fi
     fi
 
     CT_DoLog DEBUG "Extra config passed: '${extra_config[*]}'"
@@ -1201,6 +1204,9 @@ do_gcc_backend() {
         extra_config+=("--enable-multiarch")
         if [ -n "${CT_CC_GCC_MULTILIB_LIST}" ]; then
             extra_config+=("--with-multilib-list=${CT_CC_GCC_MULTILIB_LIST}")
+        fi
+        if [ -n "${CT_CC_GCC_MULTILIB_GENERATOR}" ]; then
+            extra_config+=("--with-multilib-generator=${CT_CC_GCC_MULTILIB_GENERATOR}")
         fi
     fi
 


### PR DESCRIPTION
To build multilib RISC-V toolchain one should use --with-multilib-generator option instead of --with-multilib-list.

Add corresponding example configuration file.