### PR TITLE
Revert "Update requirements: autoconf==2.71 and automake>=1.16"

### DIFF
--- a/config/configure.in.in
+++ b/config/configure.in.in
@@ -36,14 +36,14 @@ config CONFIGURE_has_libtool_2_4_or_newer
 config CONFIGURE_has_libtoolize_2_4_or_newer
     @KCONFIG_libtoolize_2_4_or_newer@
 
-config CONFIGURE_has_autoconf_2_71_or_newer
-    @KCONFIG_autoconf_2_71_or_newer@
+config CONFIGURE_has_autoconf_2_65_or_newer
+    @KCONFIG_autoconf_2_65_or_newer@
 
-config CONFIGURE_has_autoreconf_2_71_or_newer
-    @KCONFIG_autoreconf_2_71_or_newer@
+config CONFIGURE_has_autoreconf_2_65_or_newer
+    @KCONFIG_autoreconf_2_65_or_newer@
 
-config CONFIGURE_has_automake_1_16_or_newer
-    @KCONFIG_automake_1_16_or_newer@
+config CONFIGURE_has_automake_1_15_or_newer
+    @KCONFIG_automake_1_15_or_newer@
 
 config CONFIGURE_has_gnu_m4_1_4_12_or_newer
     @KCONFIG_gnu_m4_1_4_12_or_newer@

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
 
-AC_PREREQ([2.71])
+AC_PREREQ([2.69])
 
 AC_INIT(
     [crosstool-NG],
@@ -226,25 +226,25 @@ CTNG_PROG_VERSION_REQ_ANY([LIBTOOLIZE],
     [libtoolize_2_4_or_newer])
 
 CTNG_PROG_VERSION([AUTOCONF],
-    [GNU autoconf >= 2.71],
+    [GNU autoconf >= 2.65],
     [autoconf],
     [autoconf],
     [\(GNU Autoconf\) ([3-9]\.|2\.[7-9][0-9]|2\.6[5-9])],
-    [autoconf_2_71_or_newer])
+    [autoconf_2_65_or_newer])
 
 CTNG_PROG_VERSION([AUTORECONF],
-    [GNU autoreconf >= 2.71],
+    [GNU autoreconf >= 2.63],
     [autoreconf],
     [autoreconf],
     [\(GNU Autoconf\) ([3-9]\.|2\.[7-9][0-9]|2\.6[5-9])],
-    [autoreconf_2_71_or_newer])
+    [autoreconf_2_65_or_newer])
 
 CTNG_PROG_VERSION([AUTOMAKE],
-    [GNU automake >= 1.16],
+    [GNU automake >= 1.15],
     [automake],
     [automake],
     [\(GNU automake\) ([2-9]\.|1\.[2-9][0-9]|1\.1[5-9])],
-    [automake_1_16_or_newer])
+    [automake_1_15_or_newer])
 
 CTNG_PROG_VERSION([M4],
     [GNU m4 >= 1.4.12],


### PR DESCRIPTION
This reverts commit 658f5e574f4025655da318fb0b688a394b6ff43f, which was made without any justification, and prevents using crosstool-ng even in decently recent distributions like Ubuntu 20.04 (which has autoconf 2.69).

We have tested that ./bootstrap && ./configure --enable-local works fine on Ubuntu 18.04, which uses autoconf 2.69 and automake 1.15, so the existing requirements were enough.