### PR TITLE
newlib: Mark versions <= 4.1.0 as obsolete

### DIFF
--- a/packages/newlib/2.5.0.20171222/version.desc
+++ b/packages/newlib/2.5.0.20171222/version.desc
@@ -1,0 +1,1 @@
+obsolete='yes

--- a/packages/newlib/3.0.0.20180831/version.desc
+++ b/packages/newlib/3.0.0.20180831/version.desc
@@ -1,0 +1,1 @@
+obsolete='yes

--- a/packages/newlib/3.1.0.20181231/version.desc
+++ b/packages/newlib/3.1.0.20181231/version.desc
@@ -1,0 +1,1 @@
+obsolete='yes

--- a/packages/newlib/3.2.0/version.desc
+++ b/packages/newlib/3.2.0/version.desc
@@ -1,0 +1,1 @@
+obsolete='yes

--- a/packages/newlib/3.3.0/version.desc
+++ b/packages/newlib/3.3.0/version.desc
@@ -1,0 +1,1 @@
+obsolete='yes

--- a/packages/newlib/4.1.0/version.desc
+++ b/packages/newlib/4.1.0/version.desc
@@ -1,0 +1,1 @@
+obsolete='yes


### PR DESCRIPTION
Mark newlib 2.5.0.20171222, 3.0.0.20180831, 3.1.0.20181231, 3.2.0, 3.3.0 and 4.1.0 as obsolete. These can be dropped after the next crosstool-ng release.