### PR TITLE
Fix missing quote mark

### DIFF
--- a/packages/newlib/2.5.0.20171222/version.desc
+++ b/packages/newlib/2.5.0.20171222/version.desc
@@ -1,1 +1,1 @@
-obsolete='yes
+obsolete='yes'

--- a/packages/newlib/3.0.0.20180831/version.desc
+++ b/packages/newlib/3.0.0.20180831/version.desc
@@ -1,1 +1,1 @@
-obsolete='yes
+obsolete='yes'

--- a/packages/newlib/3.1.0.20181231/version.desc
+++ b/packages/newlib/3.1.0.20181231/version.desc
@@ -1,1 +1,1 @@
-obsolete='yes
+obsolete='yes'

--- a/packages/newlib/3.2.0/version.desc
+++ b/packages/newlib/3.2.0/version.desc
@@ -1,1 +1,1 @@
-obsolete='yes
+obsolete='yes'

--- a/packages/newlib/3.3.0/version.desc
+++ b/packages/newlib/3.3.0/version.desc
@@ -1,1 +1,1 @@
-obsolete='yes
+obsolete='yes'

--- a/packages/newlib/4.1.0/version.desc
+++ b/packages/newlib/4.1.0/version.desc
@@ -1,1 +1,1 @@
-obsolete='yes
+obsolete='yes'


### PR DESCRIPTION
The missing quotes affect bootstrap routine:
./bootstrap: eval: line 646: unexpected EOF while looking for matching `'' ./bootstrap: eval: line 647: syntax error: unexpected end of file

For some reason bootstrap script ignores these errors and terminates successfully.