### PR TITLE
bootstrap: follow symlinks

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -804,7 +804,7 @@ msg "*** Gathering the list of data files to install"
 {
     declare -A seen_files
     echo -n "verbatim_data ="
-    find COPYING config contrib licenses.d packages samples scripts -type f | LANG=C sort | while read f; do
+    find -L COPYING config contrib licenses.d packages samples scripts -type f | LANG=C sort | while read f; do
         # Implement some kind of .installignore for these files?
         case "${f}" in
             # Avoid temp files


### PR DESCRIPTION
newlib-nano package shares patches with newlib package via symlinks. If a user chooses local setup (--enable-local) it works perfectly, but if a user chooses normal setup (make install), the links are lost.