### PR TITLE
allow plugins and LTO with static toolchains

### DIFF
--- a/config/binutils/binutils.in
+++ b/config/binutils/binutils.in
@@ -128,7 +128,6 @@ config BINUTILS_LINKER_DEFAULT
 config BINUTILS_PLUGINS
     bool
     prompt "Enable support for plugins"
-    depends on ! STATIC_TOOLCHAIN
     help
       binutils can be extended through the use of plugins.
       Especially, gold can use the lto-plugin, as installed

--- a/config/cc/gcc.in
+++ b/config/cc/gcc.in
@@ -29,7 +29,6 @@
 config CC_GCC_ENABLE_PLUGINS
     def_bool y
     depends on BINUTILS_PLUGINS
-    depends on ! STATIC_TOOLCHAIN
 
 # If binutils installs gold, enable support for gold in gcc
 config CC_GCC_GOLD
@@ -194,7 +193,6 @@ config CC_GCC_USE_GRAPHITE
 config CC_GCC_USE_LTO
     bool "Enable LTO"
     default y
-    depends on ! STATIC_TOOLCHAIN
     select ZLIB_NEEDED
     help
       Enable the Link Time Optimisations.


### PR DESCRIPTION
I was able to build a static toolchain that supports LTO by disabling these restrictions. Based on the original commits, it seems that this was a temporary limitation of the toolchain build and separately of Arch. I tested this with an arm-none-eabi target on Debian Bookworm.

https://github.com/crosstool-ng/crosstool-ng/commit/0841e2f820de7a4dca1
https://github.com/crosstool-ng/crosstool-ng/commit/45512b003d04b5a89c5