### PR TITLE
Do not process 'packages' folder twice

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -8,7 +8,7 @@ SUBDIRS		= kconfig
 bin_SCRIPTS		= ct-ng
 CLEANFILES		= ct-ng bash-completion/ct-ng docs/ct-ng.1
 EXTRA_DIST		= bootstrap ct-ng.in bash-completion/ct-ng.in \
-				  docs/ct-ng.1.in packages maintainer testing
+				  docs/ct-ng.1.in maintainer testing
 
 if INSTALL_BASH_COMPLETION
 compdir				= @BASH_COMPLETION_DIR@


### PR DESCRIPTION
The folder 'packages' is processed in bootstrap, so there is no need to process it again in Makefile.
This fixes a regression introduced in eb62ec3fbe3982f5f16561675fd0820d4313a0b4