### PR TITLE
glibc: Add option for building libcrypt

### DIFF
--- a/config/libc/glibc.in
+++ b/config/libc/glibc.in
@@ -155,6 +155,12 @@ config GLIBC_HAS_OBSOLETE_RPC
     def_bool y
     depends on GLIBC_2_14_or_later && !GLIBC_2_32_or_later
 
+# As of 2.38 libcrypt is no longer built by default. It will likely be removed in a future
+# version.
+config GLIBC_HAS_OBSOLETE_LIBCRYPT
+    def_bool y
+    depends on GLIBC_2_38_or_later
+
 config GLIBC_EXTRA_CONFIG_ARRAY
     string
     prompt "extra config"
@@ -202,6 +208,13 @@ config GLIBC_ENABLE_OBSOLETE_RPC
     depends on GLIBC_HAS_OBSOLETE_RPC
     help
       Allow building applications using obsolete (Sun) RPC.
+
+config GLIBC_ENABLE_OBSOLETE_LIBCRYPT
+    bool "Enable obsolete libcrypt"
+    default n
+    depends on GLIBC_HAS_OBSOLETE_LIBCRYPT
+    help
+      Allow building applications using obsolete libcrypt APIs.
 
 config GLIBC_ENABLE_FORTIFIED_BUILD
     bool

--- a/scripts/build/libc/glibc.sh
+++ b/scripts/build/libc/glibc.sh
@@ -66,6 +66,10 @@ glibc_backend_once()
         extra_config+=( --enable-obsolete-rpc )
     fi
 
+    if [ "${CT_GLIBC_ENABLE_OBSOLETE_LIBCRYPT}" = "y" ]; then
+        extra_config+=( --enable-crypt )
+    fi
+
     # Add some default glibc config options if not given by user.
     # We don't need to be conditional on whether the user did set different
     # values, as they CT_GLIBC_EXTRA_CONFIG_ARRAY is passed after


### PR DESCRIPTION
As of glibc-2.38 libcrypt is not built by default. Add an option to allow building libcrypt support into glibc.