### PR TITLE
Add more caching to the CI

### DIFF
--- a/.github/workflows/build-toolchains.yml
+++ b/.github/workflows/build-toolchains.yml
@@ -55,10 +55,12 @@ jobs:
         run: |
           tar -xf ct-ng.tar
       - name: download tarballs
-        uses: actions/download-artifact@v3
+        uses: actions/cache/restore@v3
         with:
-          name: src.tar
+          path: src.tar
+          key: src.tar-${{ hashFiles('.local/share/crosstool-ng/packages') }}-${{ hashFiles('.local/share/crosstool-ng/samples') }}
       - name: extract tarballs
+        continue-on-error: true
         run: |
           tar -xvf src.tar
       - name: prereq Linux

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -61,6 +61,19 @@ jobs:
       - name: "extract ct-ng"
         run: |
           tar -xf ct-ng.tar
+      - name: cache tarballs
+        id: cache
+        uses: actions/cache@v3
+        with:
+          path: src.tar
+          key: src.tar-${{ hashFiles('.local/share/crosstool-ng/packages') }}-${{ hashFiles('.local/share/crosstool-ng/samples') }}
+          restore-keys: |
+            src.tar-${{ hashFiles('.local/share/crosstool-ng/packages') }}-
+            src.tar-
+      - name: extract tarballs
+        run: |
+          tar -xvf src.tar || true
+          touch stamp
       - name: "prereq Linux"
         if: ${{ runner.os == 'Linux' }}
         run: |
@@ -82,12 +95,8 @@ jobs:
                 ct-ng olddefconfig; \
                 ct-ng source; \
           done
+          find src -type f -not -newer stamp -delete -print
           tar -cvf src.tar src
-      - name: "upload sources"
-        uses: actions/upload-artifact@v3
-        with:
-          name: src.tar
-          path: src.tar
 
   toolchains:
     needs: [crosstool, tarballs]

--- a/scripts/functions
+++ b/scripts/functions
@@ -956,6 +956,7 @@ CT_GetFile()
         # Do we already have it in *our* tarballs dir?
         if [ -r "${CT_TARBALLS_DIR}/${basename}${ext}" ]; then
             CT_DoLog DEBUG "Already have '${CT_TARBALLS_DIR}/${basename}${ext}'"
+            touch "${CT_TARBALLS_DIR}/${basename}${ext}" # for CI
             return 0
         fi
 


### PR DESCRIPTION
more specificaly to the tarballs download. The function CT_Fetch now
touches the already existing files to be comparable to the not used ones
that can araise when a package is updated.
This comparsion is needed because if it would not exist the tarball
would grow in size due to not used but still cached packages.
This would take time but is definitly something to worry about.

Signed-off-by: Quentin Boswank <qubos@outlook.de>