### PR TITLE
glibc: Bring in fix for CVE-2023-4911

### DIFF
--- a/packages/glibc/2.34/0003-tunables-Terminate-if-end-of-input-is-reached-CVE-20.patch
+++ b/packages/glibc/2.34/0003-tunables-Terminate-if-end-of-input-is-reached-CVE-20.patch
@@ -1,0 +1,156 @@
+From dcc367f148bc92e7f3778a125f7a416b093964d9 Mon Sep 17 00:00:00 2001
+From: Siddhesh Poyarekar <siddhesh@sourceware.org>
+Date: Tue, 19 Sep 2023 18:39:32 -0400
+Subject: [PATCH] tunables: Terminate if end of input is reached
+ (CVE-2023-4911)
+
+The string parsing routine may end up writing beyond bounds of tunestr
+if the input tunable string is malformed, of the form name=name=val.
+This gets processed twice, first as name=name=val and next as name=val,
+resulting in tunestr being name=name=val:name=val, thus overflowing
+tunestr.
+
+Terminate the parsing loop at the first instance itself so that tunestr
+does not overflow.
+
+This also fixes up tst-env-setuid-tunables to actually handle failures
+correct and add new tests to validate the fix for this CVE.
+
+Signed-off-by: Siddhesh Poyarekar <siddhesh@sourceware.org>
+Reviewed-by: Carlos O'Donell <carlos@redhat.com>
+(cherry picked from commit 1056e5b4c3f2d90ed2b4a55f96add28da2f4c8fa)
+---
+ elf/dl-tunables.c             | 17 +++++++++-------
+ elf/tst-env-setuid-tunables.c | 37 +++++++++++++++++++++++++++--------
+ 3 files changed, 44 insertions(+), 15 deletions(-)
+
+diff --git a/elf/dl-tunables.c b/elf/dl-tunables.c
+index 8009e54ee5..837474b504 100644
+--- a/elf/dl-tunables.c
++++ b/elf/dl-tunables.c
+@@ -188,11 +188,7 @@ parse_tunables (char *tunestr, char *valstring)
+       /* If we reach the end of the string before getting a valid name-value
+ 	 pair, bail out.  */
+       if (p[len] == '\0')
+-	{
+-	  if (__libc_enable_secure)
+-	    tunestr[off] = '\0';
+-	  return;
+-	}
++	break;
+ 
+       /* We did not find a valid name-value pair before encountering the
+ 	 colon.  */
+@@ -252,9 +248,16 @@ parse_tunables (char *tunestr, char *valstring)
+ 	    }
+ 	}
+ 
+-      if (p[len] != '\0')
+-	p += len + 1;
++      /* We reached the end while processing the tunable string.  */
++      if (p[len] == '\0')
++	break;
++
++      p += len + 1;
+     }
++
++  /* Terminate tunestr before we leave.  */
++  if (__libc_enable_secure)
++    tunestr[off] = '\0';
+ }
+ #endif
+ 
+diff --git a/elf/tst-env-setuid-tunables.c b/elf/tst-env-setuid-tunables.c
+index 05619c9adc..cd4e843640 100644
+--- a/elf/tst-env-setuid-tunables.c
++++ b/elf/tst-env-setuid-tunables.c
+@@ -52,6 +52,8 @@ const char *teststrings[] =
+   "glibc.malloc.perturb=0x800:not_valid.malloc.check=2:glibc.malloc.mmap_threshold=4096",
+   "glibc.not_valid.check=2:glibc.malloc.mmap_threshold=4096",
+   "not_valid.malloc.check=2:glibc.malloc.mmap_threshold=4096",
++  "glibc.malloc.mmap_threshold=glibc.malloc.mmap_threshold=4096",
++  "glibc.malloc.check=2",
+   "glibc.malloc.garbage=2:glibc.maoc.mmap_threshold=4096:glibc.malloc.check=2",
+   "glibc.malloc.check=4:glibc.malloc.garbage=2:glibc.maoc.mmap_threshold=4096",
+   ":glibc.malloc.garbage=2:glibc.malloc.check=1",
+@@ -70,6 +72,8 @@ const char *resultstrings[] =
+   "glibc.malloc.perturb=0x800:glibc.malloc.mmap_threshold=4096",
+   "glibc.malloc.mmap_threshold=4096",
+   "glibc.malloc.mmap_threshold=4096",
++  "glibc.malloc.mmap_threshold=glibc.malloc.mmap_threshold=4096",
++  "",
+   "",
+   "",
+   "",
+@@ -84,11 +88,18 @@ test_child (int off)
+   const char *val = getenv ("GLIBC_TUNABLES");
+ 
+ #if HAVE_TUNABLES
++  printf ("    [%d] GLIBC_TUNABLES is %s\n", off, val);
++  fflush (stdout);
+   if (val != NULL && strcmp (val, resultstrings[off]) == 0)
+     return 0;
+ 
+   if (val != NULL)
+-    printf ("[%d] Unexpected GLIBC_TUNABLES VALUE %s\n", off, val);
++    printf ("    [%d] Unexpected GLIBC_TUNABLES VALUE %s, expected %s\n",
++	    off, val, resultstrings[off]);
++  else
++    printf ("    [%d] GLIBC_TUNABLES environment variable absent\n", off);
++
++  fflush (stdout);
+ 
+   return 1;
+ #else
+@@ -117,21 +128,26 @@ do_test (int argc, char **argv)
+       if (ret != 0)
+ 	exit (1);
+ 
+-      exit (EXIT_SUCCESS);
++      /* Special return code to make sure that the child executed all the way
++	 through.  */
++      exit (42);
+     }
+   else
+     {
+-      int ret = 0;
+-
+       /* Spawn tests.  */
+       for (int i = 0; i < array_length (teststrings); i++)
+ 	{
+ 	  char buf[INT_BUFSIZE_BOUND (int)];
+ 
+-	  printf ("Spawned test for %s (%d)\n", teststrings[i], i);
++	  printf ("[%d] Spawned test for %s\n", i, teststrings[i]);
+ 	  snprintf (buf, sizeof (buf), "%d\n", i);
++	  fflush (stdout);
+ 	  if (setenv ("GLIBC_TUNABLES", teststrings[i], 1) != 0)
+-	    exit (1);
++	    {
++	      printf ("    [%d] Failed to set GLIBC_TUNABLES: %m", i);
++	      support_record_failure ();
++	      continue;
++	    }
+ 
+ 	  int status = support_capture_subprogram_self_sgid (buf);
+ 
+@@ -139,9 +155,14 @@ do_test (int argc, char **argv)
+ 	  if (WEXITSTATUS (status) == EXIT_UNSUPPORTED)
+ 	    return EXIT_UNSUPPORTED;
+ 
+-	  ret |= status;
++	  if (WEXITSTATUS (status) != 42)
++	    {
++	      printf ("    [%d] child failed with status %d\n", i,
++		      WEXITSTATUS (status));
++	      support_record_failure ();
++	    }
+ 	}
+-      return ret;
++      return 0;
+     }
+ }
+ 
+-- 
+2.42.0
+

--- a/packages/glibc/2.35/0004-tunables-Terminate-if-end-of-input-is-reached-CVE-20.patch
+++ b/packages/glibc/2.35/0004-tunables-Terminate-if-end-of-input-is-reached-CVE-20.patch
@@ -1,0 +1,156 @@
+From c84018a05aec80f5ee6f682db0da1130b0196aef Mon Sep 17 00:00:00 2001
+From: Siddhesh Poyarekar <siddhesh@sourceware.org>
+Date: Tue, 19 Sep 2023 18:39:32 -0400
+Subject: [PATCH] tunables: Terminate if end of input is reached
+ (CVE-2023-4911)
+
+The string parsing routine may end up writing beyond bounds of tunestr
+if the input tunable string is malformed, of the form name=name=val.
+This gets processed twice, first as name=name=val and next as name=val,
+resulting in tunestr being name=name=val:name=val, thus overflowing
+tunestr.
+
+Terminate the parsing loop at the first instance itself so that tunestr
+does not overflow.
+
+This also fixes up tst-env-setuid-tunables to actually handle failures
+correct and add new tests to validate the fix for this CVE.
+
+Signed-off-by: Siddhesh Poyarekar <siddhesh@sourceware.org>
+Reviewed-by: Carlos O'Donell <carlos@redhat.com>
+(cherry picked from commit 1056e5b4c3f2d90ed2b4a55f96add28da2f4c8fa)
+---
+ elf/dl-tunables.c             | 17 +++++++++-------
+ elf/tst-env-setuid-tunables.c | 37 +++++++++++++++++++++++++++--------
+ 3 files changed, 44 insertions(+), 15 deletions(-)
+
+diff --git a/elf/dl-tunables.c b/elf/dl-tunables.c
+index 8e7ee9df10..76cf8b9da3 100644
+--- a/elf/dl-tunables.c
++++ b/elf/dl-tunables.c
+@@ -187,11 +187,7 @@ parse_tunables (char *tunestr, char *valstring)
+       /* If we reach the end of the string before getting a valid name-value
+ 	 pair, bail out.  */
+       if (p[len] == '\0')
+-	{
+-	  if (__libc_enable_secure)
+-	    tunestr[off] = '\0';
+-	  return;
+-	}
++	break;
+ 
+       /* We did not find a valid name-value pair before encountering the
+ 	 colon.  */
+@@ -251,9 +247,16 @@ parse_tunables (char *tunestr, char *valstring)
+ 	    }
+ 	}
+ 
+-      if (p[len] != '\0')
+-	p += len + 1;
++      /* We reached the end while processing the tunable string.  */
++      if (p[len] == '\0')
++	break;
++
++      p += len + 1;
+     }
++
++  /* Terminate tunestr before we leave.  */
++  if (__libc_enable_secure)
++    tunestr[off] = '\0';
+ }
+ #endif
+ 
+diff --git a/elf/tst-env-setuid-tunables.c b/elf/tst-env-setuid-tunables.c
+index 88182b7b25..5e9e4c5756 100644
+--- a/elf/tst-env-setuid-tunables.c
++++ b/elf/tst-env-setuid-tunables.c
+@@ -52,6 +52,8 @@ const char *teststrings[] =
+   "glibc.malloc.perturb=0x800:not_valid.malloc.check=2:glibc.malloc.mmap_threshold=4096",
+   "glibc.not_valid.check=2:glibc.malloc.mmap_threshold=4096",
+   "not_valid.malloc.check=2:glibc.malloc.mmap_threshold=4096",
++  "glibc.malloc.mmap_threshold=glibc.malloc.mmap_threshold=4096",
++  "glibc.malloc.check=2",
+   "glibc.malloc.garbage=2:glibc.maoc.mmap_threshold=4096:glibc.malloc.check=2",
+   "glibc.malloc.check=4:glibc.malloc.garbage=2:glibc.maoc.mmap_threshold=4096",
+   ":glibc.malloc.garbage=2:glibc.malloc.check=1",
+@@ -70,6 +72,8 @@ const char *resultstrings[] =
+   "glibc.malloc.perturb=0x800:glibc.malloc.mmap_threshold=4096",
+   "glibc.malloc.mmap_threshold=4096",
+   "glibc.malloc.mmap_threshold=4096",
++  "glibc.malloc.mmap_threshold=glibc.malloc.mmap_threshold=4096",
++  "",
+   "",
+   "",
+   "",
+@@ -84,11 +88,18 @@ test_child (int off)
+   const char *val = getenv ("GLIBC_TUNABLES");
+ 
+ #if HAVE_TUNABLES
++  printf ("    [%d] GLIBC_TUNABLES is %s\n", off, val);
++  fflush (stdout);
+   if (val != NULL && strcmp (val, resultstrings[off]) == 0)
+     return 0;
+ 
+   if (val != NULL)
+-    printf ("[%d] Unexpected GLIBC_TUNABLES VALUE %s\n", off, val);
++    printf ("    [%d] Unexpected GLIBC_TUNABLES VALUE %s, expected %s\n",
++	    off, val, resultstrings[off]);
++  else
++    printf ("    [%d] GLIBC_TUNABLES environment variable absent\n", off);
++
++  fflush (stdout);
+ 
+   return 1;
+ #else
+@@ -117,21 +128,26 @@ do_test (int argc, char **argv)
+       if (ret != 0)
+ 	exit (1);
+ 
+-      exit (EXIT_SUCCESS);
++      /* Special return code to make sure that the child executed all the way
++	 through.  */
++      exit (42);
+     }
+   else
+     {
+-      int ret = 0;
+-
+       /* Spawn tests.  */
+       for (int i = 0; i < array_length (teststrings); i++)
+ 	{
+ 	  char buf[INT_BUFSIZE_BOUND (int)];
+ 
+-	  printf ("Spawned test for %s (%d)\n", teststrings[i], i);
++	  printf ("[%d] Spawned test for %s\n", i, teststrings[i]);
+ 	  snprintf (buf, sizeof (buf), "%d\n", i);
++	  fflush (stdout);
+ 	  if (setenv ("GLIBC_TUNABLES", teststrings[i], 1) != 0)
+-	    exit (1);
++	    {
++	      printf ("    [%d] Failed to set GLIBC_TUNABLES: %m", i);
++	      support_record_failure ();
++	      continue;
++	    }
+ 
+ 	  int status = support_capture_subprogram_self_sgid (buf);
+ 
+@@ -139,9 +155,14 @@ do_test (int argc, char **argv)
+ 	  if (WEXITSTATUS (status) == EXIT_UNSUPPORTED)
+ 	    return EXIT_UNSUPPORTED;
+ 
+-	  ret |= status;
++	  if (WEXITSTATUS (status) != 42)
++	    {
++	      printf ("    [%d] child failed with status %d\n", i,
++		      WEXITSTATUS (status));
++	      support_record_failure ();
++	    }
+ 	}
+-      return ret;
++      return 0;
+     }
+ }
+ 
+-- 
+2.42.0
+

--- a/packages/glibc/2.36/0007-tunables-Terminate-if-end-of-input-is-reached-CVE-20.patch
+++ b/packages/glibc/2.36/0007-tunables-Terminate-if-end-of-input-is-reached-CVE-20.patch
@@ -1,0 +1,156 @@
+From 22955ad85186ee05834e47e665056148ca07699c Mon Sep 17 00:00:00 2001
+From: Siddhesh Poyarekar <siddhesh@sourceware.org>
+Date: Tue, 19 Sep 2023 18:39:32 -0400
+Subject: [PATCH] tunables: Terminate if end of input is reached
+ (CVE-2023-4911)
+
+The string parsing routine may end up writing beyond bounds of tunestr
+if the input tunable string is malformed, of the form name=name=val.
+This gets processed twice, first as name=name=val and next as name=val,
+resulting in tunestr being name=name=val:name=val, thus overflowing
+tunestr.
+
+Terminate the parsing loop at the first instance itself so that tunestr
+does not overflow.
+
+This also fixes up tst-env-setuid-tunables to actually handle failures
+correct and add new tests to validate the fix for this CVE.
+
+Signed-off-by: Siddhesh Poyarekar <siddhesh@sourceware.org>
+Reviewed-by: Carlos O'Donell <carlos@redhat.com>
+(cherry picked from commit 1056e5b4c3f2d90ed2b4a55f96add28da2f4c8fa)
+---
+ elf/dl-tunables.c             | 17 +++++++++-------
+ elf/tst-env-setuid-tunables.c | 37 +++++++++++++++++++++++++++--------
+ 3 files changed, 44 insertions(+), 15 deletions(-)
+
+diff --git a/elf/dl-tunables.c b/elf/dl-tunables.c
+index 8e7ee9df10..76cf8b9da3 100644
+--- a/elf/dl-tunables.c
++++ b/elf/dl-tunables.c
+@@ -187,11 +187,7 @@ parse_tunables (char *tunestr, char *valstring)
+       /* If we reach the end of the string before getting a valid name-value
+ 	 pair, bail out.  */
+       if (p[len] == '\0')
+-	{
+-	  if (__libc_enable_secure)
+-	    tunestr[off] = '\0';
+-	  return;
+-	}
++	break;
+ 
+       /* We did not find a valid name-value pair before encountering the
+ 	 colon.  */
+@@ -251,9 +247,16 @@ parse_tunables (char *tunestr, char *valstring)
+ 	    }
+ 	}
+ 
+-      if (p[len] != '\0')
+-	p += len + 1;
++      /* We reached the end while processing the tunable string.  */
++      if (p[len] == '\0')
++	break;
++
++      p += len + 1;
+     }
++
++  /* Terminate tunestr before we leave.  */
++  if (__libc_enable_secure)
++    tunestr[off] = '\0';
+ }
+ #endif
+ 
+diff --git a/elf/tst-env-setuid-tunables.c b/elf/tst-env-setuid-tunables.c
+index 88182b7b25..5e9e4c5756 100644
+--- a/elf/tst-env-setuid-tunables.c
++++ b/elf/tst-env-setuid-tunables.c
+@@ -52,6 +52,8 @@ const char *teststrings[] =
+   "glibc.malloc.perturb=0x800:not_valid.malloc.check=2:glibc.malloc.mmap_threshold=4096",
+   "glibc.not_valid.check=2:glibc.malloc.mmap_threshold=4096",
+   "not_valid.malloc.check=2:glibc.malloc.mmap_threshold=4096",
++  "glibc.malloc.mmap_threshold=glibc.malloc.mmap_threshold=4096",
++  "glibc.malloc.check=2",
+   "glibc.malloc.garbage=2:glibc.maoc.mmap_threshold=4096:glibc.malloc.check=2",
+   "glibc.malloc.check=4:glibc.malloc.garbage=2:glibc.maoc.mmap_threshold=4096",
+   ":glibc.malloc.garbage=2:glibc.malloc.check=1",
+@@ -70,6 +72,8 @@ const char *resultstrings[] =
+   "glibc.malloc.perturb=0x800:glibc.malloc.mmap_threshold=4096",
+   "glibc.malloc.mmap_threshold=4096",
+   "glibc.malloc.mmap_threshold=4096",
++  "glibc.malloc.mmap_threshold=glibc.malloc.mmap_threshold=4096",
++  "",
+   "",
+   "",
+   "",
+@@ -84,11 +88,18 @@ test_child (int off)
+   const char *val = getenv ("GLIBC_TUNABLES");
+ 
+ #if HAVE_TUNABLES
++  printf ("    [%d] GLIBC_TUNABLES is %s\n", off, val);
++  fflush (stdout);
+   if (val != NULL && strcmp (val, resultstrings[off]) == 0)
+     return 0;
+ 
+   if (val != NULL)
+-    printf ("[%d] Unexpected GLIBC_TUNABLES VALUE %s\n", off, val);
++    printf ("    [%d] Unexpected GLIBC_TUNABLES VALUE %s, expected %s\n",
++	    off, val, resultstrings[off]);
++  else
++    printf ("    [%d] GLIBC_TUNABLES environment variable absent\n", off);
++
++  fflush (stdout);
+ 
+   return 1;
+ #else
+@@ -117,21 +128,26 @@ do_test (int argc, char **argv)
+       if (ret != 0)
+ 	exit (1);
+ 
+-      exit (EXIT_SUCCESS);
++      /* Special return code to make sure that the child executed all the way
++	 through.  */
++      exit (42);
+     }
+   else
+     {
+-      int ret = 0;
+-
+       /* Spawn tests.  */
+       for (int i = 0; i < array_length (teststrings); i++)
+ 	{
+ 	  char buf[INT_BUFSIZE_BOUND (int)];
+ 
+-	  printf ("Spawned test for %s (%d)\n", teststrings[i], i);
++	  printf ("[%d] Spawned test for %s\n", i, teststrings[i]);
+ 	  snprintf (buf, sizeof (buf), "%d\n", i);
++	  fflush (stdout);
+ 	  if (setenv ("GLIBC_TUNABLES", teststrings[i], 1) != 0)
+-	    exit (1);
++	    {
++	      printf ("    [%d] Failed to set GLIBC_TUNABLES: %m", i);
++	      support_record_failure ();
++	      continue;
++	    }
+ 
+ 	  int status = support_capture_subprogram_self_sgid (buf);
+ 
+@@ -139,9 +155,14 @@ do_test (int argc, char **argv)
+ 	  if (WEXITSTATUS (status) == EXIT_UNSUPPORTED)
+ 	    return EXIT_UNSUPPORTED;
+ 
+-	  ret |= status;
++	  if (WEXITSTATUS (status) != 42)
++	    {
++	      printf ("    [%d] child failed with status %d\n", i,
++		      WEXITSTATUS (status));
++	      support_record_failure ();
++	    }
+ 	}
+-      return ret;
++      return 0;
+     }
+ }
+ 
+-- 
+2.42.0
+

--- a/packages/glibc/2.37/0002-tunables-Terminate-if-end-of-input-is-reached-CVE-20.patch
+++ b/packages/glibc/2.37/0002-tunables-Terminate-if-end-of-input-is-reached-CVE-20.patch
@@ -1,0 +1,156 @@
+From b4e23c75aea756b4bddc4abcf27a1c6dca8b6bd3 Mon Sep 17 00:00:00 2001
+From: Siddhesh Poyarekar <siddhesh@sourceware.org>
+Date: Tue, 19 Sep 2023 18:39:32 -0400
+Subject: [PATCH] tunables: Terminate if end of input is reached
+ (CVE-2023-4911)
+
+The string parsing routine may end up writing beyond bounds of tunestr
+if the input tunable string is malformed, of the form name=name=val.
+This gets processed twice, first as name=name=val and next as name=val,
+resulting in tunestr being name=name=val:name=val, thus overflowing
+tunestr.
+
+Terminate the parsing loop at the first instance itself so that tunestr
+does not overflow.
+
+This also fixes up tst-env-setuid-tunables to actually handle failures
+correct and add new tests to validate the fix for this CVE.
+
+Signed-off-by: Siddhesh Poyarekar <siddhesh@sourceware.org>
+Reviewed-by: Carlos O'Donell <carlos@redhat.com>
+(cherry picked from commit 1056e5b4c3f2d90ed2b4a55f96add28da2f4c8fa)
+---
+ elf/dl-tunables.c             | 17 +++++++++-------
+ elf/tst-env-setuid-tunables.c | 37 +++++++++++++++++++++++++++--------
+ 3 files changed, 44 insertions(+), 15 deletions(-)
+
+diff --git a/elf/dl-tunables.c b/elf/dl-tunables.c
+index 327b9eb52f..985b69c180 100644
+--- a/elf/dl-tunables.c
++++ b/elf/dl-tunables.c
+@@ -187,11 +187,7 @@ parse_tunables (char *tunestr, char *valstring)
+       /* If we reach the end of the string before getting a valid name-value
+ 	 pair, bail out.  */
+       if (p[len] == '\0')
+-	{
+-	  if (__libc_enable_secure)
+-	    tunestr[off] = '\0';
+-	  return;
+-	}
++	break;
+ 
+       /* We did not find a valid name-value pair before encountering the
+ 	 colon.  */
+@@ -251,9 +247,16 @@ parse_tunables (char *tunestr, char *valstring)
+ 	    }
+ 	}
+ 
+-      if (p[len] != '\0')
+-	p += len + 1;
++      /* We reached the end while processing the tunable string.  */
++      if (p[len] == '\0')
++	break;
++
++      p += len + 1;
+     }
++
++  /* Terminate tunestr before we leave.  */
++  if (__libc_enable_secure)
++    tunestr[off] = '\0';
+ }
+ #endif
+ 
+diff --git a/elf/tst-env-setuid-tunables.c b/elf/tst-env-setuid-tunables.c
+index 807b426012..1f5e7f4f06 100644
+--- a/elf/tst-env-setuid-tunables.c
++++ b/elf/tst-env-setuid-tunables.c
+@@ -52,6 +52,8 @@ const char *teststrings[] =
+   "glibc.malloc.perturb=0x800:not_valid.malloc.check=2:glibc.malloc.mmap_threshold=4096",
+   "glibc.not_valid.check=2:glibc.malloc.mmap_threshold=4096",
+   "not_valid.malloc.check=2:glibc.malloc.mmap_threshold=4096",
++  "glibc.malloc.mmap_threshold=glibc.malloc.mmap_threshold=4096",
++  "glibc.malloc.check=2",
+   "glibc.malloc.garbage=2:glibc.maoc.mmap_threshold=4096:glibc.malloc.check=2",
+   "glibc.malloc.check=4:glibc.malloc.garbage=2:glibc.maoc.mmap_threshold=4096",
+   ":glibc.malloc.garbage=2:glibc.malloc.check=1",
+@@ -70,6 +72,8 @@ const char *resultstrings[] =
+   "glibc.malloc.perturb=0x800:glibc.malloc.mmap_threshold=4096",
+   "glibc.malloc.mmap_threshold=4096",
+   "glibc.malloc.mmap_threshold=4096",
++  "glibc.malloc.mmap_threshold=glibc.malloc.mmap_threshold=4096",
++  "",
+   "",
+   "",
+   "",
+@@ -84,11 +88,18 @@ test_child (int off)
+   const char *val = getenv ("GLIBC_TUNABLES");
+ 
+ #if HAVE_TUNABLES
++  printf ("    [%d] GLIBC_TUNABLES is %s\n", off, val);
++  fflush (stdout);
+   if (val != NULL && strcmp (val, resultstrings[off]) == 0)
+     return 0;
+ 
+   if (val != NULL)
+-    printf ("[%d] Unexpected GLIBC_TUNABLES VALUE %s\n", off, val);
++    printf ("    [%d] Unexpected GLIBC_TUNABLES VALUE %s, expected %s\n",
++	    off, val, resultstrings[off]);
++  else
++    printf ("    [%d] GLIBC_TUNABLES environment variable absent\n", off);
++
++  fflush (stdout);
+ 
+   return 1;
+ #else
+@@ -117,21 +128,26 @@ do_test (int argc, char **argv)
+       if (ret != 0)
+ 	exit (1);
+ 
+-      exit (EXIT_SUCCESS);
++      /* Special return code to make sure that the child executed all the way
++	 through.  */
++      exit (42);
+     }
+   else
+     {
+-      int ret = 0;
+-
+       /* Spawn tests.  */
+       for (int i = 0; i < array_length (teststrings); i++)
+ 	{
+ 	  char buf[INT_BUFSIZE_BOUND (int)];
+ 
+-	  printf ("Spawned test for %s (%d)\n", teststrings[i], i);
++	  printf ("[%d] Spawned test for %s\n", i, teststrings[i]);
+ 	  snprintf (buf, sizeof (buf), "%d\n", i);
++	  fflush (stdout);
+ 	  if (setenv ("GLIBC_TUNABLES", teststrings[i], 1) != 0)
+-	    exit (1);
++	    {
++	      printf ("    [%d] Failed to set GLIBC_TUNABLES: %m", i);
++	      support_record_failure ();
++	      continue;
++	    }
+ 
+ 	  int status = support_capture_subprogram_self_sgid (buf);
+ 
+@@ -139,9 +155,14 @@ do_test (int argc, char **argv)
+ 	  if (WEXITSTATUS (status) == EXIT_UNSUPPORTED)
+ 	    return EXIT_UNSUPPORTED;
+ 
+-	  ret |= status;
++	  if (WEXITSTATUS (status) != 42)
++	    {
++	      printf ("    [%d] child failed with status %d\n", i,
++		      WEXITSTATUS (status));
++	      support_record_failure ();
++	    }
+ 	}
+-      return ret;
++      return 0;
+     }
+ }
+ 
+-- 
+2.42.0
+

--- a/packages/glibc/2.38/0002-Propagate-GLIBC_TUNABLES-in-setxid-binaries.patch
+++ b/packages/glibc/2.38/0002-Propagate-GLIBC_TUNABLES-in-setxid-binaries.patch
@@ -1,0 +1,32 @@
+From 73e3fcd1a552783e66ff1f65c5f322e2f17a81d1 Mon Sep 17 00:00:00 2001
+From: Siddhesh Poyarekar <siddhesh@sourceware.org>
+Date: Tue, 19 Sep 2023 13:25:40 -0400
+Subject: [PATCH 1/2] Propagate GLIBC_TUNABLES in setxid binaries
+
+GLIBC_TUNABLES scrubbing happens earlier than envvar scrubbing and some
+tunables are required to propagate past setxid boundary, like their
+env_alias.  Rely on tunable scrubbing to clean out GLIBC_TUNABLES like
+before, restoring behaviour in glibc 2.37 and earlier.
+
+Signed-off-by: Siddhesh Poyarekar <siddhesh@sourceware.org>
+Reviewed-by: Carlos O'Donell <carlos@redhat.com>
+(cherry picked from commit 0d5f9ea97f1b39f2a855756078771673a68497e1)
+---
+ sysdeps/generic/unsecvars.h | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/sysdeps/generic/unsecvars.h b/sysdeps/generic/unsecvars.h
+index 81397fb90b..8278c50a84 100644
+--- a/sysdeps/generic/unsecvars.h
++++ b/sysdeps/generic/unsecvars.h
+@@ -4,7 +4,6 @@
+ #define UNSECURE_ENVVARS \
+   "GCONV_PATH\0"							      \
+   "GETCONF_DIR\0"							      \
+-  "GLIBC_TUNABLES\0"							      \
+   "HOSTALIASES\0"							      \
+   "LD_AUDIT\0"								      \
+   "LD_DEBUG\0"								      \
+-- 
+2.42.0
+

--- a/packages/glibc/2.38/0003-tunables-Terminate-if-end-of-input-is-reached-CVE-20.patch
+++ b/packages/glibc/2.38/0003-tunables-Terminate-if-end-of-input-is-reached-CVE-20.patch
@@ -1,0 +1,156 @@
+From 750a45a783906a19591fb8ff6b7841470f1f5701 Mon Sep 17 00:00:00 2001
+From: Siddhesh Poyarekar <siddhesh@sourceware.org>
+Date: Tue, 19 Sep 2023 18:39:32 -0400
+Subject: [PATCH 2/2] tunables: Terminate if end of input is reached
+ (CVE-2023-4911)
+
+The string parsing routine may end up writing beyond bounds of tunestr
+if the input tunable string is malformed, of the form name=name=val.
+This gets processed twice, first as name=name=val and next as name=val,
+resulting in tunestr being name=name=val:name=val, thus overflowing
+tunestr.
+
+Terminate the parsing loop at the first instance itself so that tunestr
+does not overflow.
+
+This also fixes up tst-env-setuid-tunables to actually handle failures
+correct and add new tests to validate the fix for this CVE.
+
+Signed-off-by: Siddhesh Poyarekar <siddhesh@sourceware.org>
+Reviewed-by: Carlos O'Donell <carlos@redhat.com>
+(cherry picked from commit 1056e5b4c3f2d90ed2b4a55f96add28da2f4c8fa)
+---
+ elf/dl-tunables.c             | 17 +++++++++-------
+ elf/tst-env-setuid-tunables.c | 37 +++++++++++++++++++++++++++--------
+ 3 files changed, 44 insertions(+), 15 deletions(-)
+
+diff --git a/elf/dl-tunables.c b/elf/dl-tunables.c
+index 62b7332d95..cae67efa0a 100644
+--- a/elf/dl-tunables.c
++++ b/elf/dl-tunables.c
+@@ -180,11 +180,7 @@ parse_tunables (char *tunestr, char *valstring)
+       /* If we reach the end of the string before getting a valid name-value
+ 	 pair, bail out.  */
+       if (p[len] == '\0')
+-	{
+-	  if (__libc_enable_secure)
+-	    tunestr[off] = '\0';
+-	  return;
+-	}
++	break;
+ 
+       /* We did not find a valid name-value pair before encountering the
+ 	 colon.  */
+@@ -244,9 +240,16 @@ parse_tunables (char *tunestr, char *valstring)
+ 	    }
+ 	}
+ 
+-      if (p[len] != '\0')
+-	p += len + 1;
++      /* We reached the end while processing the tunable string.  */
++      if (p[len] == '\0')
++	break;
++
++      p += len + 1;
+     }
++
++  /* Terminate tunestr before we leave.  */
++  if (__libc_enable_secure)
++    tunestr[off] = '\0';
+ }
+ 
+ /* Enable the glibc.malloc.check tunable in SETUID/SETGID programs only when
+diff --git a/elf/tst-env-setuid-tunables.c b/elf/tst-env-setuid-tunables.c
+index 7dfb0e073a..f0b92c97e7 100644
+--- a/elf/tst-env-setuid-tunables.c
++++ b/elf/tst-env-setuid-tunables.c
+@@ -50,6 +50,8 @@ const char *teststrings[] =
+   "glibc.malloc.perturb=0x800:not_valid.malloc.check=2:glibc.malloc.mmap_threshold=4096",
+   "glibc.not_valid.check=2:glibc.malloc.mmap_threshold=4096",
+   "not_valid.malloc.check=2:glibc.malloc.mmap_threshold=4096",
++  "glibc.malloc.mmap_threshold=glibc.malloc.mmap_threshold=4096",
++  "glibc.malloc.check=2",
+   "glibc.malloc.garbage=2:glibc.maoc.mmap_threshold=4096:glibc.malloc.check=2",
+   "glibc.malloc.check=4:glibc.malloc.garbage=2:glibc.maoc.mmap_threshold=4096",
+   ":glibc.malloc.garbage=2:glibc.malloc.check=1",
+@@ -68,6 +70,8 @@ const char *resultstrings[] =
+   "glibc.malloc.perturb=0x800:glibc.malloc.mmap_threshold=4096",
+   "glibc.malloc.mmap_threshold=4096",
+   "glibc.malloc.mmap_threshold=4096",
++  "glibc.malloc.mmap_threshold=glibc.malloc.mmap_threshold=4096",
++  "",
+   "",
+   "",
+   "",
+@@ -81,11 +85,18 @@ test_child (int off)
+ {
+   const char *val = getenv ("GLIBC_TUNABLES");
+ 
++  printf ("    [%d] GLIBC_TUNABLES is %s\n", off, val);
++  fflush (stdout);
+   if (val != NULL && strcmp (val, resultstrings[off]) == 0)
+     return 0;
+ 
+   if (val != NULL)
+-    printf ("[%d] Unexpected GLIBC_TUNABLES VALUE %s\n", off, val);
++    printf ("    [%d] Unexpected GLIBC_TUNABLES VALUE %s, expected %s\n",
++	    off, val, resultstrings[off]);
++  else
++    printf ("    [%d] GLIBC_TUNABLES environment variable absent\n", off);
++
++  fflush (stdout);
+ 
+   return 1;
+ }
+@@ -106,21 +117,26 @@ do_test (int argc, char **argv)
+       if (ret != 0)
+ 	exit (1);
+ 
+-      exit (EXIT_SUCCESS);
++      /* Special return code to make sure that the child executed all the way
++	 through.  */
++      exit (42);
+     }
+   else
+     {
+-      int ret = 0;
+-
+       /* Spawn tests.  */
+       for (int i = 0; i < array_length (teststrings); i++)
+ 	{
+ 	  char buf[INT_BUFSIZE_BOUND (int)];
+ 
+-	  printf ("Spawned test for %s (%d)\n", teststrings[i], i);
++	  printf ("[%d] Spawned test for %s\n", i, teststrings[i]);
+ 	  snprintf (buf, sizeof (buf), "%d\n", i);
++	  fflush (stdout);
+ 	  if (setenv ("GLIBC_TUNABLES", teststrings[i], 1) != 0)
+-	    exit (1);
++	    {
++	      printf ("    [%d] Failed to set GLIBC_TUNABLES: %m", i);
++	      support_record_failure ();
++	      continue;
++	    }
+ 
+ 	  int status = support_capture_subprogram_self_sgid (buf);
+ 
+@@ -128,9 +144,14 @@ do_test (int argc, char **argv)
+ 	  if (WEXITSTATUS (status) == EXIT_UNSUPPORTED)
+ 	    return EXIT_UNSUPPORTED;
+ 
+-	  ret |= status;
++	  if (WEXITSTATUS (status) != 42)
++	    {
++	      printf ("    [%d] child failed with status %d\n", i,
++		      WEXITSTATUS (status));
++	      support_record_failure ();
++	    }
+ 	}
+-      return ret;
++      return 0;
+     }
+ }
+ 
+-- 
+2.42.0
+


### PR DESCRIPTION
Bring in the upstream fix for the tunables CVE. The patches are taken from glibc's git repository. These needed to drop the changes to the NEWS file which would conflict due to the changes not being brought in.