### PR TITLE
Add gnatls

### DIFF
--- a/TODO
+++ b/TODO
@@ -87,7 +87,7 @@ A (slightly) ordered set of tasks for crosstool-NG. Written in a cryptic languag
 [ ] Common location for sources provided by ctng - duma.in, gdbinit.in, uclibc{,-ng}-config.in ...
 [ ] CTNG_LD_IS=bfd has no effect on subsequent build steps, as each step runs in its own environment
 [ ] Enable other languages in some sample(s):
-  [ ] Ada (?) - requires gnatbind/gnatmake on the host
+  [ ] Ada (?) - requires gnatbind/gnatmake/gnatls/gnatlink on the host
     [X] Seems to build
     [ ] Try to run
   [ ] Obj-C/C++

--- a/scripts/crosstool-NG.sh
+++ b/scripts/crosstool-NG.sh
@@ -437,7 +437,7 @@ if [ -z "${CT_RESTART}" ]; then
             t="${!r}-"
         fi
 
-        for tool in ar as dlltool gcc gcc-ar gcc-nm gcc-ranlib g++ gcj gnatbind gdc gnatmake ld libtool nm objcopy objdump ranlib strip windres; do
+        for tool in ar as dlltool gcc gcc-ar gcc-nm gcc-ranlib g++ gcj gnatbind gdc gnatmake gnatls gnatlink ld libtool nm objcopy objdump ranlib strip windres; do
             # First try with prefix + suffix
             # Then try with prefix only
             # Then try with suffix only, but only for BUILD, and HOST iff REAL_BUILD == REAL_HOST
@@ -485,6 +485,7 @@ if [ -z "${CT_RESTART}" ]; then
                     # If any other is missing, only warn at low level
                     *)
                         # It does not deserve a WARN level.
+                        # TBD Do we want to check for tools required by specific languages here? i.e gnat* if Ada is selected.
                         CT_DoLog DEBUG "  Missing: '${t}${tool}${!s}' or '${t}${tool}' or '${tool}' : not required."
                         ;;
                 esac


### PR DESCRIPTION
Fix for  issue #2048

crosstool-NG.sh
Add gnatls to the list of tools pulled into the build environment. This is needed just like gnatbind and gnatmake for Ada.
Added comment in area check for tools to see if someone would want to check the required tools based on additional languages selected 

Updated comment in TODO to add gnatls to list
