### PR TITLE
gdb: Use correct arguments for static linking

### DIFF
--- a/config/debug/gdb.in
+++ b/config/debug/gdb.in
@@ -18,3 +18,8 @@ config GDB_DEP_NO_STD_FUTURE
 config GDB_GDBSERVER_TOPLEVEL
     def_bool y
     depends on GDB_10_or_later
+
+# As of GDB 13.x libtool is used for linking
+config GDB_CC_LD_LIBTOOL
+    def_bool y
+    depends on GDB_13_or_later

--- a/scripts/build/debug/300-gdb.sh
+++ b/scripts/build/debug/300-gdb.sh
@@ -348,7 +348,11 @@ do_gdb_backend()
         "${extra_config[@]}"                        \
 
     if [ "${static}" = "y" ]; then
-        extra_make_flags+=("LDFLAGS=${ldflags} -all-static")
+        if [ "${GDB_CC_LD_LIBTOOL}" = "y" ]; then
+            extra_make_flags+=("LDFLAGS=${ldflags} -all-static")
+        else
+            extra_make_flags+=("LDFLAGS=${ldflags} -static")
+        fi
         CT_DoLog EXTRA "Prepare gdb for static build"
         CT_DoExecLog ALL make ${CT_JOBSFLAGS} configure-host
     fi


### PR DESCRIPTION
As of version 13.x GDB uses libtool for linking instead of g++ these take different arguments for static linking.  Commit 6146b5a6 ("use -all-static when building a static gdb") attempted to deal with this but had the effect of causing older GDB versions to fail to build statically. Add a new internal flag GDB_CC_LD_LIBTOOL and use this to decide whether to pass `-static` or `-all-static`.

Fixes #2053
Signed-off-by: Chris Packham <judge.packham@gmail.com>