### PR TITLE
gdb: Explicitly point to target's libgmp for native build

### DIFF
--- a/scripts/build/debug/300-gdb.sh
+++ b/scripts/build/debug/300-gdb.sh
@@ -122,6 +122,14 @@ do_debug_gdb_build()
 
         native_extra_config+=("--program-prefix=")
 
+        # Starting from GDB 11.x, gmp is needed as a dependency to build full
+        # gdb. And if target GMP gets built, explicitly point to installed library,
+        # as otherwise host library might be attempted to be used for target binary
+        # linkage.
+        if [ "${CT_GMP_TARGET}" = "y" ]; then
+            native_extra_config+=("--with-libgmp-prefix=${CT_SYSROOT_DIR}")
+        fi
+
         # gdbserver gets enabled by default with gdb
         # since gdbserver was promoted to top-level
         if [ "${CT_GDB_GDBSERVER_TOPLEVEL}" = "y" ]; then


### PR DESCRIPTION
Starting from GDB 11.x, gmp is needed as a dependency to build full gdb. And by default build system of native GDB will try to link with libgmp of the build host. And to make sure that doesn't happen we need to specify location of the target's sysroot so that library search starts from there. Which we do in that change.

Fixes [1] & [1].

[1] https://github.com/crosstool-ng/crosstool-ng/issues/2084
[2] https://github.com/crosstool-ng/crosstool-ng/issues/1656