### PR TITLE
CI: Update to v4 actions

### DIFF
--- a/.github/workflows/build-toolchains.yml
+++ b/.github/workflows/build-toolchains.yml
@@ -48,14 +48,14 @@ jobs:
           hdiutil mount ${HOME}/Workspace.sparseimage -mountroot /Users/runner/work/crosstool-ng
           cd crosstool-ng
       - name: download ct-ng
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: crosstool.${{ matrix.host }}
       - name: extract ct-ng
         run: |
           tar -xf ct-ng.tar
       - name: download tarballs
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: src.tar
           key: src.tar-${{ hashFiles('.local/share/crosstool-ng/packages') }}-${{ hashFiles('.local/share/crosstool-ng/samples') }}
@@ -76,7 +76,7 @@ jobs:
           echo "${{ github.workspace }}/.local/bin" >> $GITHUB_PATH
       - name: download x86_64-w64-mingw32.${{ matrix.host }} tarball
         if: ${{ inputs.canadian-cross }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: x86_64-w64-mingw32.${{ matrix.host }}.tar
       - name: install x86_64-w64-mingw32.${{ matrix.host }} toolchain
@@ -103,13 +103,13 @@ jobs:
               -cf ${{ matrix.sample }}.${{ matrix.host }}.tar .
       - name: upload ${{ matrix.sample }}.${{ matrix.host }} tarball
         if: ${{ matrix.sample == 'x86_64-w64-mingw32' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.sample }}.${{ matrix.host }}.tar
           path: |
             ${{ matrix.sample }}.${{ matrix.host }}.tar
       - name: upload log
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.sample }}.${{ matrix.host }}.log
           path: |

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -13,7 +13,7 @@ jobs:
         host: ["ubuntu-22.04", "macos-latest"]
     steps:
       - name: "clone"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: "prereq Linux"
         if: ${{ runner.os == 'Linux' }}
         run: |
@@ -36,12 +36,12 @@ jobs:
           make install
           tar -cf ct-ng.tar .local/
       - name: "upload ct-ng"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: crosstool.${{ matrix.host }}
           path: ct-ng.tar
       - name: "upload config.log"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: config.log.${{ matrix.host }}
           path: config.log
@@ -55,7 +55,7 @@ jobs:
         host: ["ubuntu-22.04"]
     steps:
       - name: "download ct-ng"
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: crosstool.${{ matrix.host }}
       - name: "extract ct-ng"
@@ -63,7 +63,7 @@ jobs:
           tar -xf ct-ng.tar
       - name: cache tarballs
         id: cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: src.tar
           key: src.tar-${{ hashFiles('.local/share/crosstool-ng/packages') }}-${{ hashFiles('.local/share/crosstool-ng/samples') }}


### PR DESCRIPTION
As per [1] we need to update our actions to use the newer node versions.

[1] - https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/