### PR TITLE
Revert "binutils: Disable glob for better portability"

### DIFF
--- a/scripts/build/binutils/binutils.sh
+++ b/scripts/build/binutils/binutils.sh
@@ -182,10 +182,6 @@ do_binutils_backend() {
         extra_config+=("--without-zstd")
     fi
 
-    # Disable usage of glob for higher compatibility.
-    # Not strictly needed for anything but GDB anyways.
-    export ac_cv_func_glob=no
-
     CT_DoLog DEBUG "Extra config passed: '${extra_config[*]}'"
 
     CT_DoExecLog CFG                                            \


### PR DESCRIPTION
This reverts commit 57f59092852dff18fbda68fdbf23f850ad182c40. This was originally added so that a toolchain could be built on a newer system but run on an older one. With the benefit of hindsight that is probably the wrong approach. The best way of achieving that goal would be to use docker/podman container to provide an environment that is the same as the oldest supported system and build inside that. The resulting toolchain should be compatible with the old system and the new one.

Closes #2094