### PR TITLE
glibc: fix the broken build for glibc 2.19 with gcc 13.

### DIFF
--- a/scripts/build/libc/glibc.sh
+++ b/scripts/build/libc/glibc.sh
@@ -249,8 +249,8 @@ glibc_backend_once()
             build_cppflags="${build_cppflags} -I${CT_BUILDTOOLS_PREFIX_DIR}/include/"
             build_ldflags="${build_ldflags} -lintl -liconv"
             case "$CT_BUILD" in
-                *cygwin*|*freebsd*)
-                # Additionally, stat in FreeBSD, Cygwin, and possibly others
+                *cygwin*|*freebsd*|aarch64*darwin*)
+                # Additionally, stat in FreeBSD, Cygwin, Darwin arm64 and possibly others
                 # is always 64bit, so replace struct stat64 with stat.
                 build_cppflags="${build_cppflags} -Dstat64=stat"
                 ;;


### PR DESCRIPTION
macos silicon SDK does not contain stat64 (and other LFS extension), and glibc 2.19 makes use of it.

glibc 2.17 with gcc 13 is OK without this fix, but I am not sure of other versions of glibc. But this change should be harmless generally.