### PR TITLE
gcc/13.2.0: Fix musl libdir path for loongarch64

### DIFF
--- a/packages/gcc/13.2.0/0033-LoongArch-Fix-MUSL_DYNAMIC_LINKER.patch
+++ b/packages/gcc/13.2.0/0033-LoongArch-Fix-MUSL_DYNAMIC_LINKER.patch
@@ -1,0 +1,44 @@
+From 13c5de145f027ade74ad1d890aa6118662a0c024 Mon Sep 17 00:00:00 2001
+From: Peng Fan <fanpeng@loongson.cn>
+Date: Wed, 19 Apr 2023 16:23:42 +0800
+Subject: [PATCH] LoongArch: Fix MUSL_DYNAMIC_LINKER
+
+The system based on musl has no '/lib64', so change it.
+
+https://wiki.musl-libc.org/guidelines-for-distributions.html,
+"Multilib/multi-arch" section of this introduces it.
+
+gcc/
+	* config/loongarch/gnu-user.h (MUSL_DYNAMIC_LINKER): Redefine.
+
+Signed-off-by: Peng Fan <fanpeng@loongson.cn>
+Suggested-by: Xi Ruoyao <xry111@xry111.site>
+
+(cherry picked from commit a80c68a08604b0ac625ac7fc59eae40b551b1176)
+---
+ gcc/config/loongarch/gnu-user.h | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/gcc/config/loongarch/gnu-user.h b/gcc/config/loongarch/gnu-user.h
+index aecaa02a199..fa1a5211419 100644
+--- a/gcc/config/loongarch/gnu-user.h
++++ b/gcc/config/loongarch/gnu-user.h
+@@ -33,9 +33,14 @@ along with GCC; see the file COPYING3.  If not see
+ #define GLIBC_DYNAMIC_LINKER \
+   "/lib" ABI_GRLEN_SPEC "/ld-linux-loongarch-" ABI_SPEC ".so.1"
+ 
++#define MUSL_ABI_SPEC \
++  "%{mabi=lp64d:-lp64d}" \
++  "%{mabi=lp64f:-lp64f}" \
++  "%{mabi=lp64s:-lp64s}"
++
+ #undef MUSL_DYNAMIC_LINKER
+ #define MUSL_DYNAMIC_LINKER \
+-  "/lib" ABI_GRLEN_SPEC "/ld-musl-loongarch-" ABI_SPEC ".so.1"
++  "/lib/ld-musl-loongarch" ABI_GRLEN_SPEC MUSL_ABI_SPEC ".so.1"
+ 
+ #undef GNU_USER_TARGET_LINK_SPEC
+ #define GNU_USER_TARGET_LINK_SPEC \
+-- 
+2.44.0
+

--- a/packages/gcc/13.2.0/0034-LoongArch-Modify-MUSL_DYNAMIC_LINKER.patch
+++ b/packages/gcc/13.2.0/0034-LoongArch-Modify-MUSL_DYNAMIC_LINKER.patch
@@ -1,0 +1,45 @@
+From a5f1bdfcce95d825919e89d01cb00566e728a8c6 Mon Sep 17 00:00:00 2001
+From: Lulu Cheng <chenglulu@loongson.cn>
+Date: Sat, 18 Nov 2023 11:04:42 +0800
+Subject: [PATCH] LoongArch: Modify MUSL_DYNAMIC_LINKER.
+
+Use no suffix at all in the musl dynamic linker name for hard
+float ABI. Use -sf and -sp suffixes in musl dynamic linker name
+for soft float and single precision ABIs. The following table
+outlines the musl interpreter names for the LoongArch64 ABI names.
+
+musl interpreter            | LoongArch64 ABI
+--------------------------- | -----------------
+ld-musl-loongarch64.so.1    | loongarch64-lp64d
+ld-musl-loongarch64-sp.so.1 | loongarch64-lp64f
+ld-musl-loongarch64-sf.so.1 | loongarch64-lp64s
+
+gcc/ChangeLog:
+
+	* config/loongarch/gnu-user.h (MUSL_ABI_SPEC): Modify suffix.
+
+(cherry picked from commit 8bccee51f0deac64b79cd9ad75df599422f4c8ff)
+---
+ gcc/config/loongarch/gnu-user.h | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/gcc/config/loongarch/gnu-user.h b/gcc/config/loongarch/gnu-user.h
+index fa1a5211419..5f1bd60ada3 100644
+--- a/gcc/config/loongarch/gnu-user.h
++++ b/gcc/config/loongarch/gnu-user.h
+@@ -34,9 +34,9 @@ along with GCC; see the file COPYING3.  If not see
+   "/lib" ABI_GRLEN_SPEC "/ld-linux-loongarch-" ABI_SPEC ".so.1"
+ 
+ #define MUSL_ABI_SPEC \
+-  "%{mabi=lp64d:-lp64d}" \
+-  "%{mabi=lp64f:-lp64f}" \
+-  "%{mabi=lp64s:-lp64s}"
++  "%{mabi=lp64d:}" \
++  "%{mabi=lp64f:-sp}" \
++  "%{mabi=lp64s:-sf}"
+ 
+ #undef MUSL_DYNAMIC_LINKER
+ #define MUSL_DYNAMIC_LINKER \
+-- 
+2.44.0
+

--- a/packages/gcc/13.2.0/0035-LoongArch-Use-lib-instead-of-lib64-as-the-library-se.patch
+++ b/packages/gcc/13.2.0/0035-LoongArch-Use-lib-instead-of-lib64-as-the-library-se.patch
@@ -1,0 +1,80 @@
+From 2f7d4728dbfd976788f77b8f43d4dc3c718b71b7 Mon Sep 17 00:00:00 2001
+From: Yang Yujie <yangyujie@loongson.cn>
+Date: Wed, 6 Mar 2024 09:19:59 +0800
+Subject: [PATCH] LoongArch: Use /lib instead of /lib64 as the library search
+ path for MUSL.
+
+gcc/ChangeLog:
+
+	* config.gcc: Add a case for loongarch*-*-linux-musl*.
+	* config/loongarch/linux.h: Disable the multilib-compatible
+	treatment for *musl* targets.
+	* config/loongarch/musl.h: New file.
+---
+ gcc/config.gcc               |  3 +++
+ gcc/config/loongarch/linux.h |  4 +++-
+ gcc/config/loongarch/musl.h  | 23 +++++++++++++++++++++++
+ 3 files changed, 29 insertions(+), 1 deletion(-)
+ create mode 100644 gcc/config/loongarch/musl.h
+
+diff --git a/gcc/config.gcc b/gcc/config.gcc
+index 648b3dc21..73ce82698 100644
+--- a/gcc/config.gcc
++++ b/gcc/config.gcc
+@@ -2478,6 +2478,9 @@ riscv*-*-freebsd*)
+ 
+ loongarch*-*-linux*)
+ 	tm_file="elfos.h gnu-user.h linux.h linux-android.h glibc-stdint.h ${tm_file}"
++	case ${target} in
++	  *-linux-musl*) tm_file="${tm_file} loongarch/musl.h"
++	esac
+ 	tm_file="${tm_file} loongarch/gnu-user.h loongarch/linux.h"
+ 	extra_options="${extra_options} linux-android.opt"
+ 	tmake_file="${tmake_file} loongarch/t-linux"
+diff --git a/gcc/config/loongarch/linux.h b/gcc/config/loongarch/linux.h
+index 9059d2441..f01d6f750 100644
+--- a/gcc/config/loongarch/linux.h
++++ b/gcc/config/loongarch/linux.h
+@@ -21,7 +21,9 @@ along with GCC; see the file COPYING3.  If not see
+  * This ensures that a compiler configured with --disable-multilib
+  * can work in a multilib environment.  */
+ 
+-#if defined(LA_DISABLE_MULTILIB) && defined(LA_DISABLE_MULTIARCH)
++#if !defined(LA_DEFAULT_TARGET_MUSL) \
++  && defined(LA_DISABLE_MULTILIB) \
++  && defined(LA_DISABLE_MULTIARCH)
+ 
+   #if DEFAULT_ABI_BASE == ABI_BASE_LP64D
+     #define ABI_LIBDIR "lib64"
+diff --git a/gcc/config/loongarch/musl.h b/gcc/config/loongarch/musl.h
+new file mode 100644
+index 000000000..fa43bc866
+--- /dev/null
++++ b/gcc/config/loongarch/musl.h
+@@ -0,0 +1,23 @@
++/* Definitions for MUSL C library support.
++   Copyright (C) 2024 Free Software Foundation, Inc.
++
++This file is part of GCC.
++
++GCC is free software; you can redistribute it and/or modify
++it under the terms of the GNU General Public License as published by
++the Free Software Foundation; either version 3, or (at your option)
++any later version.
++
++GCC is distributed in the hope that it will be useful,
++but WITHOUT ANY WARRANTY; without even the implied warranty of
++MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++GNU General Public License for more details.
++
++You should have received a copy of the GNU General Public License
++along with GCC; see the file COPYING3.  If not see
++<http://www.gnu.org/licenses/>.  */
++
++
++#ifndef LA_DEFAULT_TARGET_MUSL
++#define LA_DEFAULT_TARGET_MUSL
++#endif
+-- 
+2.44.0
+


### PR DESCRIPTION
This patch adds two gcc commits to fix musl libdir path for loongarch64:

* 13c5de14 ("LoongArch: Fix MUSL_DYNAMIC_LINKER")
* a5f1bdfc ("LoongArch: Modify MUSL_DYNAMIC_LINKER.")
* 2f7d4728 ("LoongArch: Use /lib instead of /lib64 as the library search path for MUSL.")