### PR TITLE
gdb: Use correct libexpat for native build

### DIFF
--- a/scripts/build/debug/300-gdb.sh
+++ b/scripts/build/debug/300-gdb.sh
@@ -175,16 +175,7 @@ do_debug_gdb_build()
         # where libexpat for build platform lives, which is
         # unacceptable for cross-compiling.
         #
-        # To prevent this '--without-libexpat-prefix' flag must be passed.
-        # Thus configure falls back to '-lexpat', which is exactly what we want.
-        #
-        # NOTE: DO NOT USE --with-libexpat-prefix (until GDB configure is smarter)!!!
-        # It conflicts with a static build: GDB's configure script will find the shared
-        # version of expat and will attempt to link that, despite the -static flag.
-        # The link will fail, and configure will abort with "expat missing or unusable"
-        # message.
-        native_extra_config+=("--with-expat")
-        native_extra_config+=("--without-libexpat-prefix")
+        native_extra_config+=("--with-expat=${CT_BUILDTOOLS_PREFIX_DIR}")
 
         do_gdb_backend \
             buildtype=native \


### PR DESCRIPTION
The native gdb needs the version of libexpat built for the target. On some systems gdb's configure will find the one from the build machine. Use --with-expat= to point at the correct one for the target.

Fixes: 2092