### PR TITLE
 CI: Disable canadian-cross build step

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -136,10 +136,10 @@ jobs:
           "xtensa-fsf-linux-uclibc"
         ]
 
-  canadian-cross:
-    needs: [toolchains]
-    uses: ./.github/workflows/build-toolchains.yml
-    with:
-      samples: >-
-        ["x86_64-w64-mingw32,x86_64-pc-linux-gnu"]
-      canadian-cross: true
+#  canadian-cross:
+#    needs: [toolchains]
+#    uses: ./.github/workflows/build-toolchains.yml
+#    with:
+#      samples: >-
+#        ["x86_64-w64-mingw32,x86_64-pc-linux-gnu"]
+#      canadian-cross: true


### PR DESCRIPTION
We're currently hitting some disk space limits in the CI builds when building a canadian cross configuration