### PR TITLE
Make package reproducible on arch linux

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -65,7 +65,7 @@ bash-completion/ct-ng: bash-completion/ct-ng.in Makefile
 # Also, lintian is picky about execute-bit on the scripts
 install-data-hook:
 	rm -f $(DESTDIR)$(man1dir)/$(ctng_progname).1.gz
-	gzip -9 $(DESTDIR)$(man1dir)/$(ctng_progname).1
+	gzip -n -9 $(DESTDIR)$(man1dir)/$(ctng_progname).1
 	chmod a+x $(DESTDIR)$(pkgdatadir)/scripts/config.guess
 	chmod a+x $(DESTDIR)$(pkgdatadir)/scripts/config.sub
 	rm -f $(DESTDIR)$(pkgdatadir)/LICENSE


### PR DESCRIPTION
Currently this package is not fully reproducible on arch linux. See the [diffoscope](https://reproducible.archlinux.org/api/v0/builds/594872/diffoscope).
The issue is the recorded timestamp in the gzip header which can easily be ignored with the [no-name](https://wiki.debian.org/ReproducibleBuilds/TimestampsInGzipHeaders) flag for gzip.