### PR TITLE
Updates to github workflows to work with `gh act`

### DIFF
--- a/.github/workflows/build-toolchains.yml
+++ b/.github/workflows/build-toolchains.yml
@@ -66,7 +66,7 @@ jobs:
       - name: prereq Linux
         if: ${{ runner.os == 'Linux' }}
         run: |
-          sudo apt-get install -y gperf help2man libtool-bin meson ninja-build
+          sudo apt-get update && sudo apt-get install -y bison flex gperf help2man libtool-bin meson ninja-build texinfo
           echo "${{ github.workspace }}/.local/bin" >> "$GITHUB_PATH"
       - name: prereq macOS
         if: ${{ runner.os == 'macOS' }}

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -17,7 +17,7 @@ jobs:
       - name: "prereq Linux"
         if: ${{ runner.os == 'Linux' }}
         run: |
-          sudo apt-get install -y gperf help2man libtool-bin meson ninja-build
+          sudo apt-get update && sudo apt-get install -y bison flex gperf help2man libtool-bin meson ninja-build texinfo
       - name: "prereq macOS"
         if: ${{ runner.os == 'macOS' }}
         run: |
@@ -80,7 +80,7 @@ jobs:
       - name: "prereq Linux"
         if: ${{ runner.os == 'Linux' }}
         run: |
-          sudo apt-get install -y gperf help2man libtool-bin
+          sudo apt-get update && sudo apt-get install -y bison flex gperf help2man libtool-bin texinfo
           echo "$GITHUB_WORKSPACE/.local/bin" >> "$GITHUB_PATH"
       - name: "ct-ng source"
         run: |


### PR DESCRIPTION
* Run `apt-get update` before installing packages, as the local VM may not have these packages already installed like the github.com runners do.
* Add bison, flex, and texinfo, as they may not already be on the local VM as they may be on the github.com runners.