### PR TITLE
mingw-w64: enable wildcard

### DIFF
--- a/scripts/build/libc/mingw-w64.sh
+++ b/scripts/build/libc/mingw-w64.sh
@@ -208,6 +208,7 @@ mingw_w64_main()
         --prefix=${MINGW_INSTALL_PREFIX} \
         --build=${CT_BUILD} \
         --host=${CT_TARGET} \
+        --enable-wildcard \
         "${crt_opts[@]}"
 
     # mingw-w64-crt has a missing dependency occasionally breaking the


### PR DESCRIPTION
Wildcard is an opt-in (disabled by the default) feature that is used by many GNU tools like Binutils.

Signed-off-by: Mateusz Mikuła <mati865@gmail.com>