### PR TITLE
scripts/functions: Use CT_Abort when paths.sh is missing

### DIFF
--- a/scripts/functions
+++ b/scripts/functions
@@ -2503,7 +2503,7 @@ if [ -r "${CT_LIB_DIR}/paths.sh" ]; then
 elif [ -r "${CT_TOP_DIR}/paths.sh" ]; then
     paths_sh_location="${CT_TOP_DIR}/paths.sh"
 else
-    CT_Error "Not found: paths.sh"
+    CT_Abort "Not found: paths.sh"
 fi
 . "${paths_sh_location}"
 


### PR DESCRIPTION
Code added to deal with --enable-local used the non-existent CT_Error instead of CT_Abort. Use the correct function so the build aborts with a useful error message.

Fixes #2141
Signed-off-by: Chris Packham <judge.packham@gmail.com>