### PR TITLE
CI: pin macos runners to macos-12

### DIFF
--- a/.github/workflows/build-toolchains.yml
+++ b/.github/workflows/build-toolchains.yml
@@ -19,25 +19,25 @@ jobs:
     runs-on: ${{ matrix.host }}
     strategy:
       matrix:
-        host: ["ubuntu-22.04", "macos-latest"]
+        host: ["ubuntu-22.04", "macos-12"]
         sample: ${{ fromJSON(inputs.samples) }}
         exclude:
           # Exclude both glibc & uClibc ARC Linux toolchains as
           # there's no known use of ARC Linux toolchains on Mac,
           # and anyway glibc fails to build for ARC700,
           # see https://github.com/crosstool-ng/crosstool-ng/pull/1456#issuecomment-779150246
-          - {host: "macos-latest", sample: "arc-multilib-linux-gnu"}
-          - {host: "macos-latest", sample: "arc-multilib-linux-uclibc"}
+          - {host: "macos-12", sample: "arc-multilib-linux-gnu"}
+          - {host: "macos-12", sample: "arc-multilib-linux-uclibc"}
 
           # Exclude mips*-*-linux-gnu because of <byteswap.h> usage in
           # elf-entry.c for linux kernel headers.  <byteswap.h> is a GNU
           # extension and doesn't exist on MacOS X
-          - {host: "macos-latest", sample: "mips-unknown-linux-gnu"}
-          - {host: "macos-latest", sample: "mips64-unknown-linux-gnu"}
+          - {host: "macos-12", sample: "mips-unknown-linux-gnu"}
+          - {host: "macos-12", sample: "mips64-unknown-linux-gnu"}
 
           # Exclude x86_64-w64-mingw32,x86_64-pc-linux-gnu because it crashes on m4 build with
           # a Segmentation fault
-          - {host: "macos-latest", sample: "x86_64-w64-mingw32,x86_64-pc-linux-gnu"}
+          - {host: "macos-12", sample: "x86_64-w64-mingw32,x86_64-pc-linux-gnu"}
     steps:
       - name: create case sensitive workspace volume for macOS
         if: ${{ runner.os == 'macOS' }}
@@ -94,7 +94,7 @@ jobs:
           sed -i -e '/CT_LOCAL_TARBALLS_DIR/s/HOME/CT_TOP_DIR/' .config
           sed -i -e '/CT_PREFIX_DIR/s/HOME/CT_TOP_DIR/' .config
           sed -i -e '/CT_GLIBC_ENABLE_DEBUG/s/y$/n/' .config
-          test ${{ matrix.host }} = "macos-latest" && sed -i -e '/CT_GDB_CROSS_PYTHON/s/y$/n/' .config
+          test ${{ matrix.host }} = "macos-12" && sed -i -e '/CT_GDB_CROSS_PYTHON/s/y$/n/' .config
           ct-ng build
       - name: create ${{ matrix.sample }}.${{ matrix.host }} tarball
         if: ${{ matrix.sample == 'x86_64-w64-mingw32' }}

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.host }}
     strategy:
       matrix:
-        host: ["ubuntu-22.04", "macos-latest"]
+        host: ["ubuntu-22.04", "macos-12"]
     steps:
       - name: "clone"
         uses: actions/checkout@v4


### PR DESCRIPTION
macos-latest has recently (as of April 2024) started transitioning to macos-14 (previously it was macos-12). This seems to be missing things we rely on (e.g. makeinfo) and even when those are added throws other errors.  For now lets pin things to macos-12 until someone can spend some time looking at why we can't use macos-14.