### PR TITLE
config: add dependency on cmake

### DIFF
--- a/config/configure.in.in
+++ b/config/configure.in.in
@@ -15,6 +15,9 @@ config CONFIGURE_has_wget
 config CONFIGURE_has_curl
     @KCONFIG_curl@
 
+config CONFIGURE_has_cmake
+    @KCONFIG_cmake@
+
 config CONFIGURE_has_meson
     @KCONFIG_meson@
 

--- a/configure.ac
+++ b/configure.ac
@@ -153,6 +153,10 @@ AC_CHECK_PROGS([curl], [curl])
 CTNG_SET_KCONFIG_OPTION([curl])
 AC_SUBST([curl])
 
+AC_CHECK_PROGS([cmake], [cmake])
+CTNG_SET_KCONFIG_OPTION([cmake])
+AC_SUBST([cmake])
+
 AC_CHECK_PROGS([meson], [meson])
 CTNG_SET_KCONFIG_OPTION([meson])
 AC_SUBST([meson])


### PR DESCRIPTION
We want to add mold linker support to crosstool-ng, which will require cmake while building. Hence add a dependency to cmake.

Relevant for https://github.com/crosstool-ng/crosstool-ng/pull/2150