### PR TITLE
Allow for Runtime-less build of GDC and GNAT

### DIFF
--- a/config/cc.in
+++ b/config/cc.in
@@ -67,18 +67,6 @@ config CC_LANG_JIT
       Only select this if you know that your specific version of the
       compiler supports the libgccjit.
 
-if ! BARE_METAL
-
-config CC_LANG_JAVA
-    bool
-    prompt "Java"
-    depends on CC_SUPPORT_JAVA
-    help
-      Enable building a Java compiler.
-
-      Only select this if you know that your specific version of the
-      compiler supports this language.
-
 config CC_LANG_ADA
     bool
     prompt "Ada (EXPERIMENTAL)"
@@ -88,7 +76,8 @@ config CC_LANG_ADA
       Enable building an Ada compiler.
 
       Only select this if you know that your specific version of the
-      compiler supports this language.
+      compiler supports this language. If the target is bare, the runtime
+      won't be included.
 
 config CC_LANG_D
     bool
@@ -97,6 +86,19 @@ config CC_LANG_D
     depends on EXPERIMENTAL
     help
       Enable building a D compiler.
+
+      Only select this if you know that your specific version of the
+      compiler supports this language. If the target is bare, the runtime
+      won't be included.
+
+if ! BARE_METAL
+
+config CC_LANG_JAVA
+    bool
+    prompt "Java"
+    depends on CC_SUPPORT_JAVA
+    help
+      Enable building a Java compiler.
 
       Only select this if you know that your specific version of the
       compiler supports this language.


### PR DESCRIPTION
Both D and GNAT have their own runtimes (resp. libphotos and libada). It is still possible to build the compiler proper without any runtime, and have an external runtime installed later. This is most commonly found in embedded systems.

An example for D is: https://github.com/KitsunebiGames/tinyd-rt
An example for Ada: https://github.com/Fabien-Chouteau/bare_runtime