### PR TITLE
Fix typo retrun→return in 0001-fix-configure-for-gcc14.patch

### DIFF
--- a/packages/libelf/0.8.13/0001-fix-configure-for-gcc14.patch
+++ b/packages/libelf/0.8.13/0001-fix-configure-for-gcc14.patch
@@ -95,7 +95,7 @@ diff -Naur libelf-0.8.13-orig/configure libelf-0.8.13/configure
    memmove(buf + 1, buf, 9);
    if (strcmp(buf, "0012345678")) exit(1);
    exit(0);
-+  retrun 0;
++  return 0;
  }
  EOF
  if { (eval echo configure:2545: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest${ac_exeext} && (./conftest; exit) 2>/dev/null


### PR DESCRIPTION
Fixes a typo introduced in d97a1ecdf0058251c33f6e98ee30d0ca9c93d6ab.