### PR TITLE
scripts/functions: Update sourceware mirrors

### DIFF
--- a/scripts/functions
+++ b/scripts/functions
@@ -1786,9 +1786,10 @@ CT_Mirrors()
         echo "ftp://ftp.gnu.org/gnu/${project}"
         ;;
     sourceware)
+        echo "https://sourceware.org/${project}/ftp"
         echo "ftp://sourceware.org/pub/${project}"
-        echo "http://mirrors.kernel.org/sourceware/${project}"
-        echo "http://gcc.gnu.org/pub/${project}"
+        echo "https://mirrors.kernel.org/sourceware/${project}"
+        echo "https://gcc.gnu.org/pub/${project}"
         ;;
     Linaro)
         local version="${3}"


### PR DESCRIPTION
Add https mirror for sourceware.org. Use https instead of http for kernel.org and gnu.org.