### PR TITLE
scripts: Save toolchain config as regular file

### DIFF
--- a/scripts/functions
+++ b/scripts/functions
@@ -2539,8 +2539,7 @@ CT_InstallConfigurationFile()
     local path="${1}"
     local suffix="${2}"
 
-    CT_DoExecLog ALL mkdir -p "${CT_PREFIX_DIR}/bin"
-    CT_DoExecLog DEBUG ${install} -m 0755 "${CT_LIB_DIR}/scripts/toolchain-config.in" "${CT_PREFIX_DIR}/bin/${CT_TARGET}-${suffix}.config"
-    CT_DoExecLog DEBUG ${sed} -i -e 's,@@grep@@,"'"${grep}"'",;' "${CT_PREFIX_DIR}/bin/${CT_TARGET}-${suffix}.config"
-    bzip2 -c -9 "${path}" >>"${CT_PREFIX_DIR}/bin/${CT_TARGET}-${suffix}.config"
+    CT_DoExecLog ALL mkdir -p "${CT_PREFIX_DIR}/share"
+    CT_DoExecLog DEBUG ${install} -m 0644 "${path}" "${CT_PREFIX_DIR}/share/${CT_TARGET}-${suffix}.config"
+    CT_DoExecLog DEBUG bzip2 -9 "${CT_PREFIX_DIR}/share/${CT_TARGET}-${suffix}.config"
 }

--- a/scripts/toolchain-config.in
+++ b/scripts/toolchain-config.in
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-tail -n+5 "${0}" |bzcat
-exit 0


### PR DESCRIPTION
Since commit 16c6cc99 ("Save the toolchain configuration to its own file, as an auto-extracting shell script:") we've been saving the configuration as a self extracting script. This is a little non-obvious as it looks like it should be a regular file but the bzipped payload means it can be easily inspected. It may also cause alarm for users who should rightly be suspicious of unexpected binaries that get shipped along with packaged toolchains. It also assumes that bzip2 (or at least bzcat) is available on the machine running the toolchain.

Instead of the self extracting shell script save the config as a regular compressed file with an obvious file extension.