### PR TITLE
companion_libs: zstd: Build nomt configuration

### DIFF
--- a/scripts/build/companion_libs/070-zstd.sh
+++ b/scripts/build/companion_libs/070-zstd.sh
@@ -81,7 +81,7 @@ do_zstd_backend() {
     done
 
     CT_DoLog EXTRA "Building zstd"
-    CT_DoExecLog ALL make ${CT_JOBSFLAGS} -C "${CT_SRC_DIR}/zstd/lib" libzstd.a-mt-release BUILD_DIR="${PWD}" CC="${host}-gcc" AS="${host}-as" CFLAGS="${cflags}" LDFLAGS="${ldflags}"
+    CT_DoExecLog ALL make ${CT_JOBSFLAGS} -C "${CT_SRC_DIR}/zstd/lib" libzstd.a-nomt-release BUILD_DIR="${PWD}" CC="${host}-gcc" AS="${host}-as" CFLAGS="${cflags}" LDFLAGS="${ldflags}"
 
     # There is no library only check in zstd
 


### PR DESCRIPTION
We have been building the multi threaded zstd target. This requires that anything that links with lzstd also links with lpthread. On more recent systems this is fine because lpthread is part of GNU libc so the -pthread option is a no-op but on other systems this will cause GCC to either fail to build or to silently disable zstd compression. By building the libzstd.a-nomt-release we can be compatible with older GCC versions and ensure that support for zstd is not silently dropped.

Fixes: #2198