### PR TITLE
improve a workaround for a glibc and GNU make incompatibility

### DIFF
--- a/config/libc/glibc.in
+++ b/config/libc/glibc.in
@@ -68,7 +68,7 @@ config GLIBC_DEP_MAKE_4_0
 # where the build process hangs indefinitely
 config GLIBC_DEP_MAKE_4_3
     def_bool y
-    depends on GLIBC_older_than_2_32 && CONFIGURE_has_make_4_4_or_newer
+    depends on GLIBC_older_than_2_32 && (CONFIGURE_has_make_4_4_or_newer || GLIBC_DEP_MAKE_4_0)
     select COMP_TOOLS_MAKE
     select MAKE_GNUMAKE_SYMLINK
     select MAKE_REQUIRE_older_than_4_4


### PR DESCRIPTION
Versions of GNU make newer than 4.4 trigger a hang in versions of glibc older than 2.31. In e63c40854c977f488bee159a8f8ebf5fc06c8666, this was fixed when the host platform provided make >= 4.4. However, if the host distro provides only an ancient version of make, crosstool-ng would still build make 4.4 as a comp tool, which would fail to build glibc.

Extend the previous workaround to build make 4.3 when building old glibc versions which require it.

See also #1946