### PR TITLE
Specify header path in CT_CC_SYSROOT_ARG only for glibc

### DIFF
--- a/scripts/build/cc/gcc.sh
+++ b/scripts/build/cc/gcc.sh
@@ -282,6 +282,7 @@ do_gcc_core_backend() {
         gcc_build|gcc_host)
             CT_DoLog EXTRA "Configuring final gcc compiler"
             extra_config+=( "${CT_CC_SYSROOT_ARG[@]}" )
+            extra_config+=( "--with-headers=${CT_PREFIX_DIR}/${CT_TARGET}/include" )
             extra_user_config=( "${CT_CC_GCC_EXTRA_CONFIG_ARRAY[@]}" )
             log_txt="final gcc compiler"
             # to inhibit the libiberty and libgcc tricks later on

--- a/scripts/crosstool-NG.sh
+++ b/scripts/crosstool-NG.sh
@@ -361,10 +361,12 @@ if [ -z "${CT_RESTART}" ]; then
         # binutils 2.14 and later obey it, older binutils ignore it.
         # Lets you build a working 32->64 bit cross gcc
         CT_BINUTILS_SYSROOT_ARG="--with-sysroot=${CT_SYSROOT_DIR}"
-        # Use --with-headers, else final gcc will define disable_glibc while
-        # building libgcc, and you'll have no profiling
         CT_CC_CORE_SYSROOT_ARG=("--without-headers")
-        CT_CC_SYSROOT_ARG=("--with-headers=${CT_HEADERS_DIR}")
+        if [ "${CT_LIBC_GLIBC}" = "y" ]; then
+            # Use --with-headers, else final gcc will define disable_glibc while
+            # building libgcc, and you'll have no profiling
+            CT_CC_SYSROOT_ARG=("--with-headers=${CT_HEADERS_DIR}")
+        fi
     fi
     CT_DoExecLog ALL mkdir -p "${CT_SYSROOT_DIR}"
     CT_DoExecLog ALL mkdir -p "${CT_DEBUGROOT_DIR}"


### PR DESCRIPTION
When building a non-sysrooted toolchain, `--with-headers` argument is specified in `CT_CC_SYSROOT_ARG` as a hack, supposedly because "final gcc will define disable_glibc while building libgcc, and you'll have no profiling."

This, however, leads to `--with-headers` being specified multiple times when building libstdc++ for additional libc variants (e.g. newlib-nano and picolibc) and results in wrong libc headers being used by the libstdc++ build under certain circumstances -- GCC does not use the last specified `--with-headers` when building for macOS and Windows hosts.

Since the above hack is intended for glibc only, this commit adds a check to ensure that `--with-headers` is added to `CT_CC_SYSROOT_ARG` only when building glibc.

In addition, the final gcc build process was relying on `CT_CC_SYSROOT_ARG` to provide the `--with-headers` argument pointing to the libc header directory.

Since `CT_CC_SYSROOT_ARG` no longer provides `--with-headers`, this adds one directly to the final gcc build invocation.

---

Root cause analysis: https://github.com/zephyrproject-rtos/sdk-ng/issues/760#issuecomment-2367486671
Tested in https://github.com/zephyrproject-rtos/sdk-ng/pull/797 (https://github.com/zephyrproject-rtos/sdk-ng/actions/runs/11015607860)

---

p.s. For Canadian cross builds, there is an additional GCC patch required to make it work properly -- https://github.com/zephyrproject-rtos/gcc/pull/36