### PR TITLE
CI: Install meson and ninja for macOS

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -22,7 +22,7 @@ jobs:
         if: ${{ runner.os == 'macOS' }}
         run: |
           brew install autoconf automake bash binutils gawk gnu-sed \
-               gnu-tar help2man make ncurses texinfo libtool
+               gnu-tar help2man libtool make meson ncurses ninja texinfo
       - name: "build ct-ng"
         run: |
           if [ "$RUNNER_OS" == "macOS" ]; then


### PR DESCRIPTION
Meson and Ninja are used by picolibc. Explicitly install these tools which we appear to have been getting by some transitive dependency up to now.