### PR TITLE
glibc: Turn implicit-int back into warning

### DIFF
--- a/config/libc/glibc.in
+++ b/config/libc/glibc.in
@@ -197,8 +197,8 @@ config GLIBC_ENABLE_DEBUG
 config GLIBC_EXTRA_CFLAGS
     string
     prompt "extra target CFLAGS"
-    default "-Wno-missing-attributes -Wno-array-bounds -Wno-array-parameter -Wno-stringop-overflow -Wno-maybe-uninitialized" if GLIBC_2_29_or_older && GCC_11_or_later
-    default ""
+    default "-Wno-missing-attributes -Wno-array-bounds -Wno-array-parameter -Wno-stringop-overflow -Wno-maybe-uninitialized" if GLIBC_2_29_or_older && GCC_11_or_later && !GCC_14_or_later
+    default "-Wno-missing-attributes -Wno-array-bounds -Wno-array-parameter -Wno-stringop-overflow -Wno-maybe-uninitialized -Wno-implicit-int" if GLIBC_2_29_or_older && GCC_14_or_later
     help
       Extra target CFLAGS to use when building.
 


### PR DESCRIPTION
As of GCC14 implicit-int has been upgraded to an error. While this is generally a good idea it trips up some older code (particularly in autoconf generated configure scripts). Add -Wno-implicit-int to CFLAGS for glibc when using an old GLIBC with a new GCC.

Fixes #2208
Signed-off-by: Chris Packham <judge.packham@gmail.com>