### PR TITLE
Drop --passive-ftp from wget's default options

### DIFF
--- a/config/global/download.in
+++ b/config/global/download.in
@@ -67,7 +67,7 @@ if DOWNLOAD_AGENT_WGET
 
 config DOWNLOAD_WGET_OPTIONS
     string "Extra options to wget"
-    default "--passive-ftp --tries=3 -nc --progress=dot:binary"
+    default "--tries=3 -nc --progress=dot:binary"
 
 endif
 


### PR DESCRIPTION
In some distributions (as Fedora), wget2 is used instead of wget. wget2 doesn't support the --passive-ftp option causing every download to fail. Also, according to wget's NEWS file [0], --passive-ftp is already the default in wget since 1.10.

Remove the --passive-ftp from wget's default options.

[0] https://gitlab.com/gnuwget/wget/-/blob/master/NEWS#L733