### PR TITLE
mold: tell cmake which compilers to use

### DIFF
--- a/scripts/build/linker/100-mold.sh
+++ b/scripts/build/linker/100-mold.sh
@@ -16,6 +16,8 @@ do_linker_mold_build() {
 
     CT_DoLog EXTRA "Configuring mold for host"
     CT_DoExecLog CFG                                           \
+    CC="${CT_HOST}-gcc"                                        \
+    CXX="${CT_HOST}-g++"                                       \
     CFLAGS="${CT_CFLAGS_FOR_HOST}"                             \
     LDFLAGS="${CT_LDFLAGS_FOR_HOST}"                           \
     cmake "${CT_SRC_DIR}/mold"                                 \


### PR DESCRIPTION
The mold build was using gcc in the PATH, instead of the shiny gcc we just built (the way the other companion libs/tools do)