### PR TITLE
Cleanup old avr-libstdcxx code and make it usable on other targets

### DIFF
--- a/config/cc/gcc.in
+++ b/config/cc/gcc.in
@@ -53,15 +53,6 @@ config CC_GCC_ENABLE_CXX_FLAGS
       Note: just pass in the option _value_, that is only the part that goes
       after the '=' sign.
 
-config CC_GCC_EXTRA_LIBSTDCXX
-    bool "Re-enable libstdcxx"
-    default n
-    depends on LIBC_AVR_LIBC
-    select CC_CORE_PASS_2_NEEDED
-    help
-      libstdcxx is normally disabled on avr systems due to size limitations.
-      Set this option to re-enable libstdcxx support.
-
 config CC_GCC_CORE_EXTRA_CONFIG_ARRAY
     string "Core gcc extra config"
     default ""
@@ -239,6 +230,40 @@ config CC_GCC_ENABLE_TARGET_OPTSPACE
       Pass --enable-target-optspace to crossgcc's configure.
       
       This will compile crossgcc's libs with -Os.
+
+config CC_GCC_LIBSTDCXX
+    tristate "Build libstdcxx"
+    default n if ARCH_AVR || LIBC_NONE
+    default m
+    depends on CC_LANG_CXX
+    select CC_CORE_NEEDED if ARCH_AVR
+    help
+      libstdcxx is normally disabled on some systems, like avr, due to size
+      limitations or it being not supported.
+      Set this option to force libstdcxx support.
+
+       Option  | libstdcxx build    | Associated ./configure switch
+      ---------+--------------------+--------------------------------
+         Y     | forcibly           | --enable-libstdcxx
+         M     | auto               | (none, ./configure decides)
+         N     | forcibly not       | --disable-libstdcxx
+
+config CC_GCC_LIBSTDCXX_HOSTED_DISABLE
+    bool "Build freestanding libstdcxx"
+    default y if LIBC_AVR_LIBC
+    default n
+    depends on CC_GCC_LIBSTDCXX
+    help
+      libstdcxx can be compiled in two modes: hosted and freestanding.
+      Hosted mode is the default, and is used when the OS is available.
+      Freestanding mode is used when the OS is not available, like in
+      bare-metal systems.
+
+      Some architectures, like avr, do not support hosted mode, but default
+      to it, and will fail to build libstdcxx in hosted mode.
+
+      Answer 'y' here to force freestanding mode, otherwise answer let
+      ./configure decide. 
 
 config CC_GCC_LIBMUDFLAP
     bool

--- a/scripts/build/cc/gcc.sh
+++ b/scripts/build/cc/gcc.sh
@@ -389,16 +389,32 @@ do_gcc_core_backend() {
         "") extra_config+=("--disable-libstdcxx-verbose");;
     esac
 
+    if [ "${build_libstdcxx}" = "yes" ]; then
+        if [ "${CT_CC_GCC_LIBSTDCXX}" = "n" ]; then
+            build_libstdcxx="no"
+        elif [ "${CT_CC_GCC_LIBSTDCXX}" = "y" ]; then
+            extra_config+=("--enable-libstdcxx")
+        fi
+
+        if [ "${CT_LIBC_AVR_LIBC}" = "y" ]; then
+            extra_config+=("--enable-cstdio=stdio_pure")
+        fi
+
+        if [ "${CT_CC_GCC_LIBSTDCXX_HOSTED_DISABLE}" = "y" ]; then
+            extra_config+=("--disable-libstdcxx-hosted")
+        fi
+    fi
+
     if [ "${build_libstdcxx}" = "no" ]; then
         extra_config+=(--disable-libstdcxx)
     fi
 
     if [ "${CT_LIBC_PICOLIBC}" = "y" ]; then
-	extra_config+=("--with-default-libc=picolibc")
-	extra_config+=("--enable-stdio=pure")
-	if [ "${CT_PICOLIBC_older_than_1_8}" = "y" ]; then
-	    extra_config+=("--disable-wchar_t")
-	fi
+        extra_config+=("--with-default-libc=picolibc")
+        extra_config+=("--enable-stdio=pure")
+        if [ "${CT_PICOLIBC_older_than_1_8}" = "y" ]; then
+            extra_config+=("--disable-wchar_t")
+        fi
     fi
 
     core_LDFLAGS+=("${ldflags}")
@@ -697,9 +713,7 @@ do_gcc_core_backend() {
     else # build_libgcc
         core_targets=( gcc )
     fi   # ! build libgcc
-    if [    "${build_libstdcxx}" = "yes"    \
-         -a "${CT_CC_LANG_CXX}"  = "y"      \
-       ]; then
+    if [ "${build_libstdcxx}" = "yes" ]; then
         core_targets+=( target-libstdc++-v3 )
     fi
 
@@ -810,9 +824,7 @@ do_cc_for_build() {
         # lack of such a compiler, but better safe than sorry...
         build_final_opts+=( "mode=baremetal" )
         build_final_opts+=( "build_libgcc=yes" )
-        if [ "${CT_LIBC_NONE}" != "y" ]; then
-            build_final_opts+=( "build_libstdcxx=yes" )
-        fi
+        build_final_opts+=( "build_libstdcxx=yes" )
         build_final_opts+=( "build_libgfortran=yes" )
         if [ "${CT_STATIC_TOOLCHAIN}" = "y" ]; then
             build_final_opts+=( "build_staticlinked=yes" )
@@ -901,9 +913,7 @@ do_cc_for_host() {
     if [ "${CT_BARE_METAL}" = "y" ]; then
         final_opts+=( "mode=baremetal" )
         final_opts+=( "build_libgcc=yes" )
-        if [ "${CT_LIBC_NONE}" != "y" ]; then
-            final_opts+=( "build_libstdcxx=yes" )
-        fi
+        final_opts+=( "build_libstdcxx=yes" )
         final_opts+=( "build_libgfortran=yes" )
         if [ "${CT_STATIC_TOOLCHAIN}" = "y" ]; then
             final_opts+=( "build_staticlinked=yes" )
@@ -1075,16 +1085,24 @@ do_gcc_backend() {
         "") extra_config+=("--disable-libstdcxx-verbose");;
     esac
     
-    if [ "${build_libstdcxx}" = "no" ]; then
+    if [ "${CT_CC_GCC_LIBSTDCXX}" = "n" ]; then
         extra_config+=(--disable-libstdcxx)
-    elif [ "${CT_CC_GCC_EXTRA_LIBSTDCXX}" = "y" ]; then
+    elif [ "${CT_CC_GCC_LIBSTDCXX}" = "y" ]; then
         extra_config+=(--enable-libstdcxx)
     fi
 
+    if [ "${CT_CC_GCC_LIBSTDCXX_HOSTED_DISABLE}" = "y" ]; then
+        extra_config+=("--disable-libstdcxx-hosted")
+    fi
+
+    if [ "${CT_LIBC_AVR_LIBC}" = "y" ]; then
+        extra_config+=("--enable-cstdio=stdio_pure")
+    fi
+
     if [ "${CT_LIBC_PICOLIBC}" = "y" ]; then
-	extra_config+=("--with-default-libc=picolibc")
-	extra_config+=("--enable-stdio=pure")
-	extra_config+=("--disable-wchar_t")
+        extra_config+=("--with-default-libc=picolibc")
+        extra_config+=("--enable-stdio=pure")
+        extra_config+=("--disable-wchar_t")
     fi
 
     final_LDFLAGS+=("${ldflags}")

--- a/scripts/build/libc/avr-libc.sh
+++ b/scripts/build/libc/avr-libc.sh
@@ -2,7 +2,7 @@
 
 avr_libc_post_cc()
 {
-    if [ "${CT_CC_CORE_PASS_2_NEEDED}" != "y" ]; then
+    if [ "${CT_CC_CORE_NEEDED}" != "y" ]; then
         CT_DoStep INFO "Installing C library"
 
         CT_DoLog EXTRA "Copying sources to build directory"
@@ -32,7 +32,7 @@ avr_libc_post_cc()
 
 avr_libc_main()
 {
-    if [ "${CT_CC_CORE_PASS_2_NEEDED}" = "y" ]; then
+    if [ "${CT_CC_CORE_NEEDED}" = "y" ]; then
         CT_DoStep INFO "Installing C library"
 
         CT_DoLog EXTRA "Copying sources to build directory"


### PR DESCRIPTION
Should not cause major unwanted behavior changes

 - C++ is now selected by default in many configs.

I think many people would select C++ either way, and you can still disable it