### PR TITLE
CI: switch to macos-13 runners

### DIFF
--- a/.github/workflows/build-toolchains.yml
+++ b/.github/workflows/build-toolchains.yml
@@ -19,25 +19,25 @@ jobs:
     runs-on: ${{ matrix.host }}
     strategy:
       matrix:
-        host: ["ubuntu-22.04", "macos-12"]
+        host: ["ubuntu-22.04", "macos-13"]
         sample: ${{ fromJSON(inputs.samples) }}
         exclude:
           # Exclude both glibc & uClibc ARC Linux toolchains as
           # there's no known use of ARC Linux toolchains on Mac,
           # and anyway glibc fails to build for ARC700,
           # see https://github.com/crosstool-ng/crosstool-ng/pull/1456#issuecomment-779150246
-          - {host: "macos-12", sample: "arc-multilib-linux-gnu"}
-          - {host: "macos-12", sample: "arc-multilib-linux-uclibc"}
+          - {host: "macos-13", sample: "arc-multilib-linux-gnu"}
+          - {host: "macos-13", sample: "arc-multilib-linux-uclibc"}
 
           # Exclude mips*-*-linux-gnu because of <byteswap.h> usage in
           # elf-entry.c for linux kernel headers.  <byteswap.h> is a GNU
           # extension and doesn't exist on MacOS X
-          - {host: "macos-12", sample: "mips-unknown-linux-gnu"}
-          - {host: "macos-12", sample: "mips64-unknown-linux-gnu"}
+          - {host: "macos-13", sample: "mips-unknown-linux-gnu"}
+          - {host: "macos-13", sample: "mips64-unknown-linux-gnu"}
 
           # Exclude x86_64-w64-mingw32,x86_64-pc-linux-gnu because it crashes on m4 build with
           # a Segmentation fault
-          - {host: "macos-12", sample: "x86_64-w64-mingw32,x86_64-pc-linux-gnu"}
+          - {host: "macos-13", sample: "x86_64-w64-mingw32,x86_64-pc-linux-gnu"}
     steps:
       - name: create case sensitive workspace volume for macOS
         if: ${{ runner.os == 'macOS' }}
@@ -72,7 +72,7 @@ jobs:
         if: ${{ runner.os == 'macOS' }}
         run: |
           brew install autoconf automake bash binutils gawk gnu-sed \
-               gnu-tar help2man make ncurses pkg-config texinfo libtool
+               gnu-tar help2man make meson ncurses ninja pkg-config texinfo libtool
           echo "${{ github.workspace }}/.local/bin" >> "$GITHUB_PATH"
       - name: download x86_64-w64-mingw32.${{ matrix.host }} tarball
         if: ${{ inputs.canadian-cross }}
@@ -94,7 +94,7 @@ jobs:
           sed -i -e '/CT_LOCAL_TARBALLS_DIR/s/HOME/CT_TOP_DIR/' .config
           sed -i -e '/CT_PREFIX_DIR/s/HOME/CT_TOP_DIR/' .config
           sed -i -e '/CT_GLIBC_ENABLE_DEBUG/s/y$/n/' .config
-          test ${{ matrix.host }} = "macos-12" && sed -i -e '/CT_GDB_CROSS_PYTHON/s/y$/n/' .config
+          test ${{ matrix.host }} = "macos-13" && sed -i -e '/CT_GDB_CROSS_PYTHON/s/y$/n/' .config
           ct-ng build
       - name: create ${{ matrix.sample }}.${{ matrix.host }} tarball
         if: ${{ matrix.sample == 'x86_64-w64-mingw32' }}

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.host }}
     strategy:
       matrix:
-        host: ["ubuntu-22.04", "macos-12"]
+        host: ["ubuntu-22.04", "macos-13"]
     steps:
       - name: "clone"
         uses: actions/checkout@v4


### PR DESCRIPTION
GitHub has dropped support for macos-12.

https://github.com/actions/runner-images/issues/10721

We had problems with macos-14 when it was first rolled out. Lets give macos-13 a try. We'll probably have to migrate to macos-14 or macos-15 eventually but hopefully we can leave that until after the ct-ng 1.27.0 release.