### PR TITLE
picolibc: Avoid build system headers

### DIFF
--- a/scripts/build/companion_libs/340-picolibc.sh
+++ b/scripts/build/companion_libs/340-picolibc.sh
@@ -150,6 +150,7 @@ do_cc_libstdcxx_picolibc()
     final_opts+=( "lang_list=c,c++" )
     final_opts+=( "build_step=libstdcxx" )
     final_opts+=( "extra_config+=('--enable-stdio=stdio_pure')" )
+    final_opts+=( "extra_config+=('--with-headers=${CT_PREFIX_DIR}/picolibc/include')" )
     if [ "${CT_PICOLIBC_older_than_1_8}" = "y" ]; then
 	final_opts+=( "extra_config+=('--disable-wchar_t')" )
     fi


### PR DESCRIPTION
When building picolibc as a companion library the configure step can end up picking up certain headers from the build system which causes build failures. Pass an appropriate --with-headers= to the GCC back end when building picolibc as a companion library so that the correct headers are detected by ./configure.