### PR TITLE
c6x: pin to GCC 13

### DIFF
--- a/samples/tic6x-uclinux/crosstool.config
+++ b/samples/tic6x-uclinux/crosstool.config
@@ -9,4 +9,5 @@ CT_LIBC_UCLIBC_NG=y
 CT_UCLIBC_NG_SRC_DEVEL=y
 CT_UCLIBC_NG_DEVEL_URL="https://github.com/DspHack/uclibc-ng.git"
 CT_THREADS_LT=y
+CT_GCC_V_13=y
 CT_CC_LANG_CXX=y


### PR DESCRIPTION
The custom uclibc has compile errors with GCC 14. Ignoring that even a bare metal config fails to build (assembler errors in libgcc) with GCC
14. For now pin the sample config to GCC 13 since that seems to work.