### PR TITLE
m4/ctng_python.m4: add python 3.13 to searched versions

### DIFF
--- a/m4/ctng_python.m4
+++ b/m4/ctng_python.m4
@@ -60,7 +60,7 @@ AC_DEFUN([CTNG_PYTHON],
 [
   AC_MSG_CHECKING(for python build information)
   AC_MSG_RESULT([])
-  for python in python3.12 python3.11 python3.10 python3.9 python3.8 python3.7 dnl
+  for python in python 3.13 python3.12 python3.11 python3.10 python3.9 python3.8 python3.7 dnl
 python3.6 python3.5 python3.4 python3.3 python3.2 python3.1 python3.0 python2.7 dnl
 python2.6 python2.5 python2.4 python2.3 python2.2 python2.1 python; do
     AC_CHECK_PROGS(PYTHON_BIN, [$python])


### PR DESCRIPTION
When trying to build and run ct-ng locally on Archlinux, we get plenty of warnings interleaved with the expected output, right at the list-samples step:

  [...]
  config/configure.in:54:warning: config symbol defined without type
  [L...]   aarch64-ol7u9-linux-gnu
  config/configure.in:54:warning: config symbol defined without type
  [L...]   aarch64-ol8u6-linux-gnu
  config/configure.in:54:warning: config symbol defined without type
  [L...]   aarch64-ol8u7-linux-gnu
  config/configure.in:54:warning: config symbol defined without type
  [L...]   aarch64-rpi3-linux-gnu
  config/configure.in:54:warning: config symbol defined without type
  [...]

The corresponding config/configure.in file indeed shows that the KConfig variable for python >= 3.4 is indeed missing some default value:

  [...]
  config CONFIGURE_has_gnu_m4_1_4_12_or_newer
      def_bool y

  config CONFIGURE_has_python_3_4_or_newer

  config CONFIGURE_has_bison_2_7_or_newer
      def_bool y
  [...]

The m4 script in charge of detecting a valid python version, having an explicit list of supported python version, does not have the latest python version (3.13, released in October, 2024), which happens to be the current default python version on Archlinux.

Fix ct-ng list-samples output by adding this 3.13 version in the list of tested versions.