### PR TITLE
arch: nios2: Qualify selects

### DIFF
--- a/config/arch/nios2.in
+++ b/config/arch/nios2.in
@@ -8,8 +8,8 @@
 ## select ARCH_SUPPORTS_WITH_ARCH
 ## select ARCH_SUPPORTS_FLAT_FORMAT
 ## select GCC_REQUIRE_older_than_15
-## select GDB_REQUIRE_older_than_16
-## select GLIBC_REQUIRE_older_than_2_41
+## select GDB_REQUIRE_older_than_16 if DEBUG_GDB
+## select GLIBC_REQUIRE_older_than_2_41 if LIBC_GLIBC
 ##
 ## help The NIOS2 architecture, as defined by:
 ## help     http://www.altera.com


### PR DESCRIPTION
Previous commits added selects so that the nios2 architecture only used GDB/GLIBC versions that still support it however these weren't qualified leading to kconfig complaints such as

  WARNING: unmet direct dependencies detected for GLIBC_REQUIRE_older_than_2_41
    Depends on [n]: LIBC_GLIBC_SHOW [=n]
    Selected by [y]:
    - ARCH_NIOS2 [=y] && GEN_CHOICE_ARCH [=y]

Qualify these selects with if DEBUG_GDB and if LIBC_GLIBC to stop the complaints.

Fixes: 9d91cebe ("gdb: Add 16.1")
Fixes: 87605d65 ("glibc: Add 2.41")