### PR TITLE
gmp: Add upstream patch for C23 compatibility

### DIFF
--- a/packages/gmp/6.3.0/0000-Complete-function-prototype-in-acinclude.patch
+++ b/packages/gmp/6.3.0/0000-Complete-function-prototype-in-acinclude.patch
@@ -1,0 +1,31 @@
+From: Marc Glisse <marc.glisse@inria.fr>
+Date: Wed, 29 Jan 2025 22:38:02 +0100
+Subject: [PATCH] Complete function prototype in acinclude.m4 for C23
+ compatibility
+---
+ acinclude.m4 |    2 +-
+ configure    |    2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+--- a/acinclude.m4
++++ b/acinclude.m4
+@@ -609,7 +609,7 @@
+ 
+ #if defined (__GNUC__) && ! defined (__cplusplus)
+ typedef unsigned long long t1;typedef t1*t2;
+-void g(){}
++void g(int,t1 const*,t1,t2,t1 const*,int){}
+ void h(){}
+ static __inline__ t1 e(t2 rp,t2 up,int n,t1 v0)
+ {t1 c,x,r;int i;if(v0){c=1;for(i=1;i<n;i++){x=up[i];r=x+1;rp[i]=r;}}return c;}
+--- a/configure
++++ b/configure
+@@ -6568,7 +6568,7 @@
+ 
+ #if defined (__GNUC__) && ! defined (__cplusplus)
+ typedef unsigned long long t1;typedef t1*t2;
+-void g(){}
++void g(int,t1 const*,t1,t2,t1 const*,int){}
+ void h(){}
+ static __inline__ t1 e(t2 rp,t2 up,int n,t1 v0)
+ {t1 c,x,r;int i;if(v0){c=1;for(i=1;i<n;i++){x=up[i];r=x+1;rp[i]=r;}}return c;}


### PR DESCRIPTION
Add a patch from upstream GMP that updates some custom configure checks for C23 compatibility (gnu32 will be the default for GCC 15).

Reported-by: Marc Poulhiès <dkm@kataplop.net>