### PR TITLE
binutils: Don't enable plugins with static toolchain

### DIFF
--- a/config/binutils/binutils.in
+++ b/config/binutils/binutils.in
@@ -132,6 +132,7 @@ config BINUTILS_LINKER_DEFAULT
 config BINUTILS_PLUGINS
     bool
     prompt "Enable support for plugins"
+    depends on !STATIC_TOOLCHAIN
     help
       binutils can be extended through the use of plugins.
       Especially, gold can use the lto-plugin, as installed


### PR DESCRIPTION
A static toolchain by definition can't load plugins and GCC will reject the --enable-plugin configure option if we're trying to build a static toolchain.

Fixes #2288
Signed-off-by: Chris Packham <judge.packham@gmail.com>