### PR TITLE
ncurses: Pass --disable-widec to configure

### DIFF
--- a/scripts/build/companion_libs/220-ncurses.sh
+++ b/scripts/build/companion_libs/220-ncurses.sh
@@ -133,6 +133,8 @@ do_ncurses_backend() {
         esac
     done
 
+    ncurses_opts+=("--disable-widec")
+
     if [ "${CT_NCURSES_NEW_ABI}" != "y" ]; then
         ncurses_opts+=("--with-abi-version=5")
     fi


### PR DESCRIPTION
The default for wide char support has changed in ncurses-6.5. This causes build failures for gdb. Pass --disable-widec to prevent the build errors.

Fixes #2292, #2294
Signed-off-by: Chris Packham <judge.packham@gmail.com>