### PR TITLE
contrib/gcc-test-suite: Add configuration options including qemu setup

### DIFF
--- a/config/contrib/gcc-test-suite.in
+++ b/config/contrib/gcc-test-suite.in
@@ -1,0 +1,47 @@
+choice
+    bool "How to execute tests"
+    default TEST_SUITE_GCC_SSH
+
+config TEST_SUITE_GCC_SSH
+    bool "Run test suite on remote host"
+    help
+      Select this option to execute GCC tests on a remote host,
+      specified by TEST_SUITE_GCC_HOST.
+
+config TEST_SUITE_GCC_QEMU
+    bool "Run test suite using qemu"
+    help
+      Select this option to execute GCC tests using qemu on the local
+      host.
+
+endchoice
+
+config TEST_SUITE_GCC_TARGET_HOSTNAME
+    string "Remote host to execute GCC tests"
+    default "127.0.0.1"
+    depends on TEST_SUITE_GCC_SSH
+    help
+      Set this to the remote host name where gcc tests will be run.
+
+config TEST_SUITE_GCC_TARGET_USERNAME
+    string "Username on remote host"
+    default "root"
+    depends on TEST_SUITE_GCC_SSH
+    help
+      Set this to the username on the remote hosts for GCC tests.
+
+config TEST_SUITE_GCC_QEMU_PROGRAM
+    string "Qemu program"
+    depends on TEST_SUITE_GCC_QEMU
+    help
+      Specifies the qemu program name. If unset, this will be "qemu-"
+      followed by the first component of the target name.
+
+config TEST_SUITE_GCC_QEMU_ARGS
+    string "Qemu program args"
+    depends on TEST_SUITE_GCC_QEMU
+    default "-L @SYSROOT@"
+    help
+      Specifies any arguments needed by qemu before the executable
+      filename. If unset, this will be "-L" followed by the path to
+      the sysroot in the installed toolchain.

--- a/config/test_suite.in
+++ b/config/test_suite.in
@@ -17,11 +17,14 @@ config TEST_SUITE_GCC
       The GCC test suite includes a collection of various toolchain tests for GCC -
       it utilizes the DejaGnu test framework.
 
-      For some tests a network enabled target with ssh server is required.
-
       A helper Makefile is provided for running the tests - please see the included
       README for information on how to run the test suite.
+
+if TEST_SUITE_GCC
+source "config/contrib/gcc-test-suite.in"
+endif
 
 endmenu
 
 endif
+

--- a/contrib/gcc-test-suite/Makefile
+++ b/contrib/gcc-test-suite/Makefile
@@ -13,15 +13,22 @@
 #
 
 # Internal configuration
-TARGET:=@@DG_TARGET@@
 TOPDIR:=$(shell pwd)
 LOGDIR:=$(TOPDIR)/tmp
 
 # Include default configuration
 include default.cfg
 
+TARGET:=$(DG_TARGET)
+
 # Add toolchain to path
 PATH:=$(shell cd ../../bin && pwd):$(PATH)
+
+# Set sysroot
+SYSROOT:=$(shell cd ../../$(TARGET)/sysroot && pwd)
+
+# Set qemu
+DG_QEMU_PROGRAM:=qemu-$(shell echo $(TARGET) | sed 's/-.*$$//')
 
 # Select test set
 ifeq ($(DG_TOOLNAME),gcc)
@@ -29,6 +36,12 @@ ifeq ($(DG_TOOLNAME),gcc)
 endif
 ifeq ($(DG_TOOLNAME),g++)
 	DG_TESTS:=$(DG_CPP_TESTS)
+endif
+
+ifeq ($(DG_QEMU),y)
+    TARGET_BOARD=unix
+else
+    TARGET_BOARD=board
 endif
 
 # Check that we have 'runtest' installed
@@ -48,6 +61,7 @@ $(LOGDIR)/site.exp: $(TOPDIR)/default.cfg $(LOGDIR)
 	   echo 'set tmpdir "$(TOPDIR)"'; \
 	   echo 'set target_alias $(TARGET)';     } > $@
 
+# Create config for remote execution
 $(LOGDIR)/board.exp: $(TOPDIR)/default.cfg $(LOGDIR)
 	@{ echo 'load_generic_config "unix"';                    \
 	   echo 'process_multilib_options ""';                   \
@@ -57,19 +71,26 @@ $(LOGDIR)/board.exp: $(TOPDIR)/default.cfg $(LOGDIR)
 	   echo 'set_board_info hostname $(DG_TARGET_HOSTNAME)'; \
 	   echo 'set_board_info username $(DG_TARGET_USERNAME)'; } > $@
 
+# create config for local execution via qemu
+$(LOGDIR)/unix.exp: $(TOPDIR)/default.cfg $(LOGDIR)
+	@{ echo 'load_generic_config "unix"';                    \
+	   echo 'process_multilib_options ""';                   \
+	   echo 'set_board_info bmk,use_alarm 1';                \
+	   echo 'set_board_info exec_shell "$(DG_QEMU_PROGRAM) $(DG_QEMU_ARGS)"'; } > $@
+
 # As Martin puts it:
 #  > The thing is that when you run 50k+ test cases the odds are that at
 #  > least one will fail and thus runtest basically always return an error
 #  > despite the fact that the test session has executed successfully.
 # So just ignore any error reported by runtest
-test: $(LOGDIR)/board.exp $(LOGDIR)/site.exp $(LOGDIR)
+test: $(LOGDIR)/$(TARGET_BOARD).exp $(LOGDIR)/site.exp $(LOGDIR)
 	@runtest --tool $(DG_TOOLNAME)          \
 	         --srcdir $(TOPDIR)/testsuite   \
 	         --objdir $(LOGDIR)             \
 	         --outdir $(LOGDIR)             \
 	         --all                          \
 	         --target $(TARGET)             \
-	         --target_board board           \
+	         --target_board $(TARGET_BOARD) \
 	         $(DG_TESTS)                    \
 	         GXX_UNDER_TEST=$(TARGET)-g++   || true
 	@printf "Result files available in '%s'\n" "$(LOGDIR)"

--- a/contrib/gcc-test-suite/default.cfg
+++ b/contrib/gcc-test-suite/default.cfg
@@ -1,9 +1,16 @@
 # Default test suite configuration
 
+DG_TARGET = @@DG_TARGET@@
+
 # Default DejaGnu configuration
 DG_TOOLNAME = gcc
-DG_TARGET_HOSTNAME = 127.0.0.1
-DG_TARGET_USERNAME = root
+DG_SSH = @@DG_SSH@@
+DG_QEMU = @@DG_QEMU@@
+DG_TARGET_HOSTNAME = @@DG_TARGET_HOSTNAME@@
+DG_TARGET_USERNAME = @@DG_TARGET_USERNAME@@
+
+DG_QEMU_PROGRAM = @@DG_QEMU_PROGRAM@@
+DG_QEMU_ARGS = @@DG_QEMU_ARGS@@
 
 # Default tests
 DG_C_TESTS = 

--- a/scripts/build/test_suite/gcc.sh
+++ b/scripts/build/test_suite/gcc.sh
@@ -21,8 +21,17 @@ do_test_suite_gcc_build() {
                             "${CT_SRC_DIR}/gcc/gcc/testsuite"  \
                             "${CT_TEST_SUITE_DIR}/gcc"
 
-    CT_DoExecLog ALL sed -i -r -e "s/@@DG_TARGET@@/${CT_TARGET}/g;"     \
-                         "${CT_TEST_SUITE_DIR}/gcc/Makefile"
+    DG_QEMU_ARGS=`echo "${CT_TEST_SUITE_GCC_QEMU_ARGS}" | sed 's/@SYSROOT@/$(SYSROOT)/'`
+
+    CT_DoExecLog ALL sed -i -r \
+		 -e "s/@@DG_TARGET@@/${CT_TARGET}/g"     \
+		 -e "s/@@DG_SSH@@/${CT_TEST_SUITE_GCC_SSH}/g" \
+		 -e "s/@@DG_QEMU@@/${CT_TEST_SUITE_GCC_QEMU}/g" \
+		 -e "s/@@DG_TARGET_HOSTNAME@@/${CT_TEST_SUITE_GCC_TARGET_HOSTNAME}/g" \
+		 -e "s/@@DG_TARGET_USERNAME@@/${CT_TEST_SUITE_GCC_TARGET_USERNAME}/g" \
+		 -e "s/@@DG_QEMU_PROGRAM@@/${CT_TEST_SUITE_GCC_QEMU_PROGRAM}/g" \
+		 -e "s/@@DG_QEMU_ARGS@@/${DG_QEMU_ARGS}/g" \
+			 "${CT_TEST_SUITE_DIR}/gcc/default.cfg"
 
     CT_EndStep
 }


### PR DESCRIPTION
This makes the options necessary to run the gcc test suite configurable in the crosstool-ng config file.

That includes the ability to run the test suite using qemu instead of on a remote host.