### PR TITLE
Pie fix ol8

### DIFF
--- a/samples/mips64-ol9u5-linux-gnu/crosstool.config
+++ b/samples/mips64-ol9u5-linux-gnu/crosstool.config
@@ -25,5 +25,5 @@ CT_ISL_V_0_16=y
 CT_GCC_ORACLE_V_11=y
 CT_GCC_ORACLE_VERSION="11.5.0-2.0.1"
 CT_GCC_ORACLE_DEVEL_BRANCH="oracle/gcc/ol9-u5"
-CT_CC_GCC_CORE_EXTRA_CONFIG_ARRAY="--enable-host-pie --enable-host-bind-now"
-CT_CC_GCC_EXTRA_CONFIG_ARRAY="--enable-host-pie --enable-host-bind-now"
+CT_CC_GCC_CORE_EXTRA_CONFIG_ARRAY="--enable-host-bind-now"
+CT_CC_GCC_EXTRA_CONFIG_ARRAY="--enable-host-bind-now"


### PR DESCRIPTION
Hello, the previous version of this sample would build successfully for ol9 (and Ubuntu LTS), but not ol8. This allows for building on ol8, as well as the other platforms.