### PR TITLE
gcc: Allow addition of -fno-exceptions when building libstdc++

### DIFF
--- a/config/cc/gcc.in
+++ b/config/cc/gcc.in
@@ -265,6 +265,14 @@ config CC_GCC_LIBSTDCXX_HOSTED_DISABLE
       Answer 'y' here to force freestanding mode, otherwise answer let
       ./configure decide. 
 
+config CC_GCC_LIBSTDCXX_TARGET_CXXFLAGS
+    string
+    prompt "Target CXXFLAGS for libstdc++"
+    default ""
+    help
+      Used to add extra CXXFLAGS when compiling the target libstdc++
+      library (e.g. -fno-exceptions).
+
 config CC_GCC_LIBMUDFLAP
     bool
     prompt "Compile libmudflap"

--- a/config/comp_libs/picolibc.in
+++ b/config/comp_libs/picolibc.in
@@ -27,6 +27,14 @@ config LIBC_PICOLIBC_GCC_LIBSTDCXX
       the picolibc companion library. This version is linked when
       "--specs=picolibcpp.specs" is specified.
 
+config LIBC_PICOLIBC_GCC_LIBSTDCXX_TARGET_CXXFLAGS
+    string
+    prompt "Target CXXFLAGS for libstdc++ picolibc variant"
+    default ""
+    help
+      Used to add extra CXXFLAGS when compiling the target libstdc++
+      picolibc library (e.g. -fno-exceptions).
+
 comment "Configuration for picolibc can be found under"
 comment "* -> C-library"
 comment "*   -> picolibc"

--- a/scripts/build/cc/gcc.sh
+++ b/scripts/build/cc/gcc.sh
@@ -913,6 +913,7 @@ do_cc_for_host() {
     final_opts+=( "ldflags=${CT_LDFLAGS_FOR_HOST}" )
     final_opts+=( "lang_list=$( cc_gcc_lang_list )" )
     final_opts+=( "build_step=gcc_host" )
+    final_opts+=( "extra_cxxflags_for_target=${CT_CC_GCC_LIBSTDCXX_TARGET_CXXFLAGS}" )
     if [ "${CT_BUILD_MANUALS}" = "y" ]; then
         final_opts+=( "build_manuals=yes" )
     fi

--- a/scripts/build/companion_libs/340-picolibc.sh
+++ b/scripts/build/companion_libs/340-picolibc.sh
@@ -157,6 +157,9 @@ do_cc_libstdcxx_picolibc()
     if [ "${CT_LIBC_PICOLIBC_ENABLE_TARGET_OPTSPACE}" = "y" ]; then
         final_opts+=( "enable_optspace=yes" )
     fi
+    if [ -n "${CT_LIBC_PICOLIBC_GCC_LIBSTDCXX_TARGET_CXXFLAGS}" ]; then
+        final_opts+=( "extra_cxxflags_for_target=${CT_LIBC_PICOLIBC_GCC_LIBSTDCXX_TARGET_CXXFLAGS}" )
+    fi
 
     if [ "${CT_BARE_METAL}" = "y" ]; then
         final_opts+=( "mode=baremetal" )


### PR DESCRIPTION
Newlib-nano has a configuration variable which controls additional flags used when building libstdc++, such as `-fno-exceptions`.  Add two new variables to allow this to be added to any libstdc++ build as well as to the picolibc-specific build when picolibc is added as a companion library: `CC_GCC_LIBSTDCXX_TARGET_CXXFLAGS` and `LIBC_PICOLIBC_GCC_LIBSTDCXX_TARGET_CXXFLAGS`