### PR TITLE
Add ncurses patch to handle debian mingw32 toolchain

### DIFF
--- a/packages/ncurses/6.2/0001-MKlib_gen-Handle-gcc-version-containing-too.patch
+++ b/packages/ncurses/6.2/0001-MKlib_gen-Handle-gcc-version-containing-too.patch
@@ -1,0 +1,30 @@
+From 745adcba14fb4612c36c3bd07a44ceaad61b3e4a Mon Sep 17 00:00:00 2001
+From: Keith Packard <keithp@keithp.com>
+Date: Thu, 17 Apr 2025 09:34:12 -0700
+Subject: [PATCH] MKlib_gen: Handle gcc version containing - too
+
+Debian's mingw32 compilers add a -posix or -win32 suffix to the
+version number. Handle that by allowing either . or - as a separator
+after the actual version number.
+
+Signed-off-by: Keith Packard <keithp@keithp.com>
+---
+ ncurses/base/MKlib_gen.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ncurses/base/MKlib_gen.sh b/ncurses/base/MKlib_gen.sh
+index 5a3770e..31543da 100755
+--- a/ncurses/base/MKlib_gen.sh
++++ b/ncurses/base/MKlib_gen.sh
+@@ -76,7 +76,7 @@ USE="$3"
+ PRG=`echo "$1" | $AWK '{ sub(/^[ 	]*/,""); sub(/[ 	].*$/, ""); print; }' || exit 0`
+ FSF=`"$PRG" --version 2>/dev/null || exit 0 | fgrep "Free Software Foundation" | head -n 1`
+ ALL=`"$PRG" -dumpversion 2>/dev/null || exit 0`
+-ONE=`echo "$ALL" | sed -e 's/\..*$//'`
++ONE=`echo "$ALL" | sed -e 's/[-.].*$//'`
+ if test -n "$FSF" && test -n "$ALL" && test -n "$ONE" ; then
+ 	if test $ONE -ge 5 ; then
+ 		echo ".. adding -P option to work around $PRG $ALL" >&2
+-- 
+2.49.0
+


### PR DESCRIPTION
As the patch itself says, debian's mingw32 toolchains set the gcc version number to <version>-win32 or <version>-posix. That messes up ncurses version detection which only looks for a `.`. With this patch, I was able to build a canadian cross compiler on Linux that runs on windows and builds arm binaries.