### PR TITLE
CI: Use arm-none-eabi to get newlib tarball

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -85,7 +85,7 @@ jobs:
       - name: "ct-ng source"
         run: |
           mkdir -p src
-          for sample in aarch64-unknown-linux-gnu arm-picolibc-eabi \
+          for sample in aarch64-unknown-linux-gnu arm-none-eabi \
                 arm-unknown-linux-musleabi armv6-nommu-linux-uclibcgnueabi \
                 x86_64-w64-mingw32; do \
                 ct-ng $sample; \


### PR DESCRIPTION
Use arm-none-eabi instead of arm-picolibc-eabi. The none-eabi configuration includes picolibc and newlib so it will ensure both are downloaded.