### PR TITLE
Build companions on gcc15

### DIFF
--- a/config/comp_libs/gmp.in
+++ b/config/comp_libs/gmp.in
@@ -1,1 +1,6 @@
 # GMP options
+config GMP_EXTRA_CFLAGS
+    string "extra target CFLAGS"
+    default "-std=gnu17" if GCC_15_or_later
+    help
+        Extra target CFLAGS to use when building.

--- a/config/comp_libs/ncurses.in
+++ b/config/comp_libs/ncurses.in
@@ -55,3 +55,8 @@ config NCURSES_TARGET_FALLBACKS
       List of terminal descriptions that will be compiled into the curses
       library for the target.
 
+config NCURSES_EXTRA_CFLAGS
+    string "extra target CFLAGS"
+    default "-std=gnu17" if GCC_15_or_later
+    help
+        Extra target CFLAGS fto use when building.

--- a/scripts/build/companion_libs/100-gmp.sh
+++ b/scripts/build/companion_libs/100-gmp.sh
@@ -122,6 +122,8 @@ do_gmp_backend() {
         extra_config+=("--with-pic")
     fi
 
+    cflags+=" ${CT_GMP_EXTRA_CFLAGS}"
+
     # GMP's configure script doesn't respect the host parameter
     # when not cross-compiling, ie when build == host so set
     # CC_FOR_BUILD and CPP_FOR_BUILD.

--- a/scripts/build/companion_libs/220-ncurses.sh
+++ b/scripts/build/companion_libs/220-ncurses.sh
@@ -152,6 +152,8 @@ do_ncurses_backend() {
         ncurses_opts+=("--with-shared")
     fi
 
+    cflags+=" ${CT_NCURSES_EXTRA_CFLAGS}"
+
     CT_DoLog EXTRA "Configuring ncurses"
     CT_DoExecLog CFG                                                    \
     CFLAGS="${cflags}"                                                  \


### PR DESCRIPTION
Use -std=c17 for companion libs, which won't build with C23 standard, default for gcc15