### PR TITLE
Fixes false indication of glibc's option HAS_OBSOLETE_LIBCRYPT

### DIFF
--- a/config/libc/glibc.in
+++ b/config/libc/glibc.in
@@ -155,11 +155,11 @@ config GLIBC_HAS_OBSOLETE_RPC
     def_bool y
     depends on GLIBC_2_14_or_later && !GLIBC_2_32_or_later
 
-# As of 2.38 libcrypt is no longer built by default. It will likely be removed in a future
-# version.
+# As of 2.38 libcrypt is no longer built by default. It was completely removed
+# as of 2.39
 config GLIBC_HAS_OBSOLETE_LIBCRYPT
     def_bool y
-    depends on GLIBC_2_38_or_later
+    depends on GLIBC_2_38_or_later && !GLIBC_2_39_or_later
 
 config GLIBC_EXTRA_CONFIG_ARRAY
     string


### PR DESCRIPTION
As of glibc-2.39, the HAS_OBSOLETE_LIBCRYPT option has been removed.

This patch updates menuconfig to reflect this.

See more in glibc's release notes at https://lists.gnu.org/archive/html/info-gnu/2024-01/msg00017.html