### PR TITLE
gcc: Add default pie support to do_gcc_backend

### DIFF
--- a/scripts/build/cc/gcc.sh
+++ b/scripts/build/cc/gcc.sh
@@ -1176,6 +1176,10 @@ do_gcc_backend() {
         fi
     fi
 
+    if [ "${CT_CC_GCC_ENABLE_DEFAULT_PIE}" = "y" ]; then
+        extra_config+=("--enable-default-pie")
+    fi
+
     if [ "${CT_CC_GCC_ENABLE_TARGET_OPTSPACE}" = "y" ] || \
        [ "${enable_optspace}" = "yes" ]; then
         extra_config+=("--enable-target-optspace")


### PR DESCRIPTION
This was added to do_gcc_core_backend but not do_gcc_backend so the final compiler didn't have the configuration. Fix this so that the setting affects bot the core and final compilers.

Fixes #2632