### PR TITLE
gmp: Fix C23 compatibility patch to work with older host compilers

### DIFF
--- a/packages/gmp/6.3.0/0000-Complete-function-prototype-in-acinclude.patch
+++ b/packages/gmp/6.3.0/0000-Complete-function-prototype-in-acinclude.patch
@@ -14,7 +14,7 @@ Subject: [PATCH] Complete function prototype in acinclude.m4 for C23
  #if defined (__GNUC__) && ! defined (__cplusplus)
  typedef unsigned long long t1;typedef t1*t2;
 -void g(){}
-+void g(int,t1 const*,t1,t2,t1 const*,int){}
++void g(int p1,t1 const* p2,t1 p3,t2 p4,t1 const* p5,int p6){}
  void h(){}
  static __inline__ t1 e(t2 rp,t2 up,int n,t1 v0)
  {t1 c,x,r;int i;if(v0){c=1;for(i=1;i<n;i++){x=up[i];r=x+1;rp[i]=r;}}return c;}
@@ -25,7 +25,7 @@ Subject: [PATCH] Complete function prototype in acinclude.m4 for C23
  #if defined (__GNUC__) && ! defined (__cplusplus)
  typedef unsigned long long t1;typedef t1*t2;
 -void g(){}
-+void g(int,t1 const*,t1,t2,t1 const*,int){}
++void g(int p1,t1 const* p2,t1 p3,t2 p4,t1 const* p5,int p6){}
  void h(){}
  static __inline__ t1 e(t2 rp,t2 up,int n,t1 v0)
  {t1 c,x,r;int i;if(v0){c=1;for(i=1;i<n;i++){x=up[i];r=x+1;rp[i]=r;}}return c;}


### PR DESCRIPTION
The patch added in 1e9bf8151513b054f60f34bc89507c31dc242cf0 changes the definition of the function `g` used in `configure` tests from `void g(){}` to `void g(int,t1 const*,t1,t2,t1 const*,int){}`.

However, omitting parameter names in function definitions is a C23 feature. This thus causes configuration to fail with a GCC 9 host compiler:

```c
conftest.c: In function 'g':
conftest.c:7:8: error: parameter name omitted
    7 | void g(int,t1 const*,t1,t2,t1 const*,int){}
      |        ^~~
conftest.c:7:12: error: parameter name omitted
    7 | void g(int,t1 const*,t1,t2,t1 const*,int){}
      |            ^~~~~~~~~
conftest.c:7:22: error: parameter name omitted
    7 | void g(int,t1 const*,t1,t2,t1 const*,int){}
      |                      ^~
conftest.c:7:25: error: parameter name omitted
    7 | void g(int,t1 const*,t1,t2,t1 const*,int){}
      |                         ^~
conftest.c:7:28: error: parameter name omitted
    7 | void g(int,t1 const*,t1,t2,t1 const*,int){}
      |                            ^~~~~~~~~
conftest.c:7:38: error: parameter name omitted
    7 | void g(int,t1 const*,t1,t2,t1 const*,int){}