### PR TITLE
expat: Use correct bootstrap command

### DIFF
--- a/packages/expat/package.desc
+++ b/packages/expat/package.desc
@@ -1,6 +1,6 @@
 repository='git https://github.com/libexpat/libexpat.git'
 repository_subdir='expat'
-bootstrap='./buildconf.sh && make -C doc all'
+bootstrap='./buildconf.sh'
 mirrors='http://downloads.sourceforge.net/project/expat/expat/${CT_EXPAT_VERSION} https://github.com/libexpat/libexpat/releases/download/R_${CT_EXPAT_VERSION//./_}'
 archive_formats='.tar.xz .tar.lz .tar.bz2 .tar.gz'
 relevantpattern='*.*|.'


### PR DESCRIPTION
The bootstrap command generates the configure script, which is then used as part of the standard build process. It's not possible to run make because configure hasn't been run to generate the required makefiles. Remove the `make` command from the expat bootstrap.

Fixes #2379