### PR TITLE
libc/glibc: Add workaround for makeinfo build issue

### DIFF
--- a/config/libc/glibc.in
+++ b/config/libc/glibc.in
@@ -289,6 +289,12 @@ comment "|  Building GLIBC locales requires that GLIBC supports        "
 comment "|  the build machine as the target.                           "
 endif # LIBC_GLIBC && GLIBC_LOCALES
 
+# Older Glibc versions are incompatible with newer makeinfo versions. Skip
+# building the user manual if needed.
+config GLIBC_MAKEINFO_WORKAROUND
+    def_bool y
+    depends on GLIBC_2_23_or_older
+
 if KERNEL_LINUX
 
 choice GLIBC_SUPPORTED_KERNEL

--- a/scripts/build/libc/glibc.sh
+++ b/scripts/build/libc/glibc.sh
@@ -182,6 +182,10 @@ glibc_backend_once()
     # or even after they get installed...
     echo "ac_cv_path_BASH_SHELL=/bin/bash" >>config.cache
 
+    if [ "${CT_GLIBC_MAKEINFO_WORKAROUND}" = "y" ]; then
+        echo "ac_cv_prog_MAKEINFO=" >>config.cache
+    fi
+
     CT_SymlinkToolsMultilib
 
     # Configure with --prefix the way we want it on the target...


### PR DESCRIPTION
Newer versions of makeinfo fail to build the older versions of the glibc manual triggering build failures. Add a workaround for this my disabling makeinfo for the glibc build where needed.

Fixes #2358