### PR TITLE
m4/ctng_python.m4: clear cached variables

### DIFF
--- a/m4/ctng_python.m4
+++ b/m4/ctng_python.m4
@@ -63,6 +63,11 @@ AC_DEFUN([CTNG_PYTHON],
   for python in python3.13 python3.12 python3.11 python3.10 python3.9 python3.8 python3.7 dnl
 python3.6 python3.5 python3.4 python3.3 python3.2 python3.1 python3.0 python2.7 dnl
 python2.6 python2.5 python2.4 python2.3 python2.2 python2.1 python; do
+    AS_UNSET(ac_cv_path_PYTHON_BIN)
+    AS_UNSET(PYTHON_BIN)
+    AS_UNSET(ac_cv_prog_PYTHON_BIN_)
+    AS_UNSET(PYTHON_BIN_)
+
     AC_PATH_PROGS(PYTHON_BIN, [$python])
     AC_CHECK_PROGS(PYTHON_BIN_, [$python])
     ctng_python_bin=$PYTHON_BIN


### PR DESCRIPTION
Prevent cached variables interfering with checks made in separate loop iterations.

This patch fixes python detection in case a user has installed multiple python versions.