### PR TITLE
binutils: Disable gprofng

### DIFF
--- a/scripts/build/binutils/binutils.sh
+++ b/scripts/build/binutils/binutils.sh
@@ -167,6 +167,9 @@ do_binutils_backend() {
         extra_config+=("--disable-multilib")
     fi
 
+    # Disable gprofng, it contains unportable code
+    extra_config+=("--disable-gprofng")
+
     # Disable gdb when building from the binutils-gdb repository.
     extra_config+=("--disable-sim")
     extra_config+=("--disable-gdb")


### PR DESCRIPTION
It contains unportable code that fails to build against implementations
other than glibc.
