### PR TITLE
m4: refine m4's ssp lib requirement for mingw32

### DIFF
--- a/scripts/build/companion_tools/100-m4.sh
+++ b/scripts/build/companion_tools/100-m4.sh
@@ -57,9 +57,15 @@ do_m4_backend()
             ldflags="${ldflags} -lrt"
             ;;
         *-mingw32)
-            # m4 is built with stack smashing protection enabled which
-            # is not part of mingw-w64 c library in v7.0.0 and later.
-            libs="${libs} -lssp"
+            case "${CT_CC_GCC_LIBSSP}" in
+                "" | "n") ;;
+                *)
+                    # m4 is built with stack smashing protection enabled which
+                    # is not part of mingw-w64 c library in v7.0.0 and later.
+                    libs="${libs} -lssp"
+                    ;;
+
+            esac
             ;;
     esac
 


### PR DESCRIPTION
Do not link m4 with libssp if it is explicitly disabled in gcc