### PR TITLE
gdb: fix readline for gdb 15.2

### DIFF
--- a/packages/gdb/15.2/0000-readline-bring-in-signal.c-from-gdb-16-branch.patch
+++ b/packages/gdb/15.2/0000-readline-bring-in-signal.c-from-gdb-16-branch.patch
@@ -116,16 +116,7 @@ issues.
  #  endif
  #endif /* SIGTSTP */
     /* Any signals that should be blocked during cleanup should go here. */
-@@ -261,6 +255,8 @@
-     case SIGTERM:
- #if defined (SIGALRM)
-     case SIGALRM:
-+      if (sig == SIGALRM)
-+	_rl_timeout_handle_sigalrm ();
- #endif
- #if defined (SIGQUIT)
-     case SIGQUIT:
-@@ -285,19 +281,6 @@
+@@ -285,19 +279,6 @@
  
        /* We don't have to bother unblocking the signal because we are not
  	 running in a signal handler context. */
@@ -145,7 +136,7 @@ issues.
  
  #if defined (__EMX__)
        signal (sig, SIG_ACK);
-@@ -311,16 +294,6 @@
+@@ -311,16 +292,6 @@
  
        /* We don't need to modify the signal mask now that this is not run in
  	 a signal handler context. */
@@ -162,7 +153,7 @@ issues.
  
        rl_reset_after_signal ();      
      }
-@@ -330,7 +303,7 @@
+@@ -330,7 +301,7 @@
  }
  
  #if defined (SIGWINCH)

--- a/packages/gdb/15.2/0001-readline-tcap.h-Update-definitions-for-C23.patch
+++ b/packages/gdb/15.2/0001-readline-tcap.h-Update-definitions-for-C23.patch
@@ -1,0 +1,49 @@
+From 11d45226114bf2e1405964c81c7610a8d6074947 Mon Sep 17 00:00:00 2001
+From: Chris Packham <judge.packham@gmail.com>
+Date: Wed, 30 Apr 2025 16:37:48 +1200
+Subject: [PATCH] readline/tcap.h: Update definitions for C23
+
+C23 changes how function definitions like int `int tputs ()` are
+interpreted. In older standards this meant that the function arguments
+are unknown. In C23 this is interpreted as `int tputs (void)` so now
+when we compile with GCC15 (which defaults to -std=gnu23) we get an
+error such as
+
+  readline/display.c:2839:17: error: too many arguments to function 'tputs'; expected 0, have 3
+
+Add the function arguments for tgetent(), tgetflag(), tgetnum(),
+tgetstr(), tputs() and tgoto().
+
+Signed-off-by: Chris Packham <judge.packham@gmail.com>
+---
+ readline/readline/tcap.h | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/readline/readline/tcap.h b/readline/readline/tcap.h
+index 859e6eed5aa..9e2ed124e49 100644
+--- a/readline/readline/tcap.h
++++ b/readline/readline/tcap.h
+@@ -46,14 +46,14 @@ extern char *UP, *BC;
+ 
+ extern short ospeed;
+ 
+-extern int tgetent ();
+-extern int tgetflag ();
+-extern int tgetnum ();
+-extern char *tgetstr ();
++extern int tgetent (char *bp, const char *name);
++extern int tgetflag (char *id);
++extern int tgetnum (char *id);
++extern char *tgetstr (char *id, char **area);
+ 
+-extern int tputs ();
++extern int tputs (const char *str, int affcnt, int (*putc)(int));
+ 
+-extern char *tgoto ();
++extern char *tgoto (const char *cap, int col, int row);
+ 
+ #endif /* HAVE_TERMCAP_H */
+ 
+-- 
+2.49.0
+


### PR DESCRIPTION
Remove a nonexistent function call and keep janitorial changes only. Add missing patch for tcap.h