### PR TITLE
ncurses: update signature_format to packed/.asc

### DIFF
--- a/packages/ncurses/package.desc
+++ b/packages/ncurses/package.desc
@@ -1,4 +1,4 @@
 # No public repository for ncurses
 mirrors='https://invisible-mirror.net/archives/ncurses $(CT_Mirrors GNU ncurses)'
 archive_formats='.tar.gz'
-signature_format='packed/.sig'
+signature_format='packed/.asc'


### PR DESCRIPTION
When enabling `CT_VERIFY_DOWNLOAD_SIGNATURE`, I received a gpg verification error.

Upon inspection, I noticed the detached gpg signatures at https://invisible-mirror.net/archives/ncurses/ had a `.asc` extension instead of `.sig`.