### PR TITLE
scripts: Remove --passive-ftp from wget usage

### DIFF
--- a/scripts/scripts.mk
+++ b/scripts/scripts.mk
@@ -32,7 +32,7 @@ ifneq ($(strip $(V)),2)
 endif
 
 ifneq ($(CT_WGET),)
-download_cmd = $(CT_WGET) --passive-ftp $(wget_silent_opt) -O $@
+download_cmd = $(CT_WGET) $(wget_silent_opt) -O $@
 else
 ifneq ($(CT_CURL),)
 download_cmd = $(CT_CURL) --ftp-pasv $(curl_silent_opt) -o $@


### PR DESCRIPTION
We dropped the common usage of wget --passive-ftp in commit 4773bd60 ("Drop --passive-ftp from wget's default options") but there was a leftover remnant that could get invoked when using `ct-ng updatetools`. Clean this up too.

Fixes #2433