### PR TITLE
m4/ctng_python_version.m4: Handle python not existing

### DIFF
--- a/m4/ctng_python_version.m4
+++ b/m4/ctng_python_version.m4
@@ -6,12 +6,16 @@ AC_DEFUN([CTNG_PYTHON_VERSION],
 [
   AC_MSG_CHECKING(for python version greater than $1.$2)
 
-  pyvermajor=$($PYTHON_BIN -c "import sys; print(sys.version_info.major)")
-  pyverminor=$($PYTHON_BIN -c "import sys; print(sys.version_info.minor)")
+  AS_IF([test -n "$PYTHON_BIN"],
+        pyvermajor=$($PYTHON_BIN -c "import sys; print(sys.version_info.major)")
+        pyverminor=$($PYTHON_BIN -c "import sys; print(sys.version_info.minor)"),
+        pyvermajor=0
+        pyverminor=0)
 
   AS_IF([test $pyvermajor -ge $1 -a $pyverminor -ge $2],
         eval "python_$1_$2_or_newer=y"
-        [CTNG_SET_KCONFIG_OPTION([python_$1_$2_or_newer])
-        AC_MSG_RESULT([yes: ${pyvermajor}.${pyverminor}])],
-        AC_MSG_RESULT([no: ${pyvermajor}.${pyverminor}]))
+        AC_MSG_RESULT([yes: ${pyvermajor}.${pyverminor}]),
+        AC_MSG_RESULT([no]))
+
+  CTNG_SET_KCONFIG_OPTION([python_$1_$2_or_newer])
 ])dnl


### PR DESCRIPTION
Update the python version check to handle the fact that python may not be present at all.

Fixes: #2416