### PR TITLE
README.md: Remove old note

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,7 @@ Crosstool-NG aims at building toolchains. Toolchains are an essential component 
 
 Refer to [documentation at crosstool-NG website](http://crosstool-ng.github.io/docs/) for more information on how to configure, install and use crosstool-NG.
 
-**Note 1:** If you elect to build a uClibc-based toolchain, you will have to prepare a config file for uClibc with <= crosstool-NG-1.21.0. In >= crosstool-NG-1.22.0 you only need to prepare a config file for uClibc(or uClibc-ng) if you really need a custom config for uClibc.
-
-**Note 2:** If you call `ct-ng --help` you will get help for `make(2)`. This is because ct-ng is in fact a `make(2)` script. There is no clean workaround for this.
+**Note:** If you call `ct-ng --help` you will get help for `make(2)`. This is because ct-ng is in fact a `make(2)` script. There is no clean workaround for this.
 
 ## Repository layout
 


### PR DESCRIPTION
Remove a note about uClibc and crosstool-ng-1.21.0.