### PR TITLE
UNTESTED: make: Add patch for gcc 15 compatibility

### DIFF
--- a/packages/make/4.3/0000-gcc-15-compat.patch
+++ b/packages/make/4.3/0000-gcc-15-compat.patch
@@ -1,0 +1,12 @@
+diff -Naur make-4.3/lib/fnmatch.c make-4.3-orig/lib/fnmatch.c
+--- make-4.3/lib/fnmatch.c	2025-09-12 16:44:37.871483583 +1200
++++ make-4.3-orig/lib/fnmatch.c	2020-01-03 20:11:27.000000000 +1300
+@@ -121,7 +121,7 @@
+    whose names are inconsistent.  */
+ 
+ # if !defined _LIBC && !defined getenv
+-extern char *getenv (const char *name);
++extern char *getenv ();
+ # endif
+ 
+ # ifndef errno

--- a/packages/make/4.4.1/0000-gcc-15-compat.patch
+++ b/packages/make/4.4.1/0000-gcc-15-compat.patch
@@ -1,0 +1,12 @@
+diff -Naur make-4.4.1/lib/fnmatch.c make-4.4.1-orig/lib/fnmatch.c
+--- make-4.4.1/lib/fnmatch.c	2025-09-12 16:44:50.659399731 +1200
++++ make-4.4.1-orig/lib/fnmatch.c	2023-02-27 05:04:31.000000000 +1300
+@@ -121,7 +121,7 @@
+    whose names are inconsistent.  */
+ 
+ # if !defined _LIBC && !defined getenv
+-extern char *getenv (const char *name);
++extern char *getenv ();
+ # endif
+ 
+ # ifndef errno


### PR DESCRIPTION
GCC 15 defaults to C23 and the meaning of function declarations without arguments has changed. Add parameters for getenv().

Fixes #2446