### PR TITLE
scripts: fix zstd companion library usage

### DIFF
--- a/packages/musl/package.desc
+++ b/packages/musl/package.desc
@@ -1,4 +1,4 @@
 repository='git git://git.musl-libc.org/musl'
-mirrors='https://www.musl-libc.org/releases'
+mirrors='https://www.musl-libc.org/releases https://sources.buildroot.net/musl/'
 archive_formats='.tar.gz'
 signature_format='packed/.asc'

--- a/scripts/build/binutils/binutils.sh
+++ b/scripts/build/binutils/binutils.sh
@@ -33,6 +33,7 @@ do_binutils_for_build() {
     binutils_opts+=( "prefix=${CT_BUILDTOOLS_PREFIX_DIR}" )
     binutils_opts+=( "cflags=${CT_CFLAGS_FOR_BUILD}" )
     binutils_opts+=( "ldflags=${CT_LDFLAGS_FOR_BUILD}" )
+    binutils_opts+=( "complibs=${CT_BUILDTOOLS_PREFIX_DIR}" )
 
     do_binutils_backend "${binutils_opts[@]}"
 
@@ -66,6 +67,7 @@ do_binutils_for_host() {
     binutils_opts+=( "cflags=${CT_CFLAGS_FOR_HOST}" )
     binutils_opts+=( "ldflags=${CT_LDFLAGS_FOR_HOST}" )
     binutils_opts+=( "build_manuals=${CT_BUILD_MANUALS}" )
+    binutils_opts+=( "complibs=${CT_HOST_COMPLIBS_DIR}" )
 
     do_binutils_backend "${binutils_opts[@]}"
 
@@ -118,6 +120,7 @@ do_binutils_backend() {
     local static_build
     local cflags
     local ldflags
+    local complibs
     local build_manuals=no
     local -a extra_config
     local -a extra_make_flags
@@ -181,8 +184,8 @@ do_binutils_backend() {
 
     [ "${CT_TOOLCHAIN_ENABLE_NLS}" != "y" ] && extra_config+=("--disable-nls")
 
-    if [ "${CT_COMP_LIBS_ZSTD}}" = "y" ]; then
-        extra_config+=("--with-zstd=${complibs}")
+    if [ "${CT_COMP_LIBS_ZSTD}" = "y" ]; then
+        extra_config+=("--with-zstd")
     else
         extra_config+=("--without-zstd")
     fi
@@ -200,6 +203,7 @@ do_binutils_backend() {
     CT_DoLog DEBUG "Extra config passed: '${extra_config[*]}'"
 
     CT_DoExecLog CFG                                            \
+    PKG_CONFIG_PATH="${complibs}/lib/pkgconfig"                 \
     CC_FOR_BUILD="${CT_BUILD}-gcc"                              \
     CFLAGS_FOR_BUILD="${CT_CFLAGS_FOR_BUILD}"                   \
     CXXFLAGS_FOR_BUILD="${CT_CFLAGS_FOR_BUILD} ${CT_CXXFLAGS_FOR_BUILD}" \

--- a/scripts/build/companion_libs/070-zstd.sh
+++ b/scripts/build/companion_libs/070-zstd.sh
@@ -81,12 +81,12 @@ do_zstd_backend() {
     done
 
     CT_DoLog EXTRA "Building zstd"
-    CT_DoExecLog ALL make ${CT_JOBSFLAGS} -C "${CT_SRC_DIR}/zstd/lib" libzstd.a-nomt-release BUILD_DIR="${PWD}" CC="${host}-gcc" AS="${host}-as" CFLAGS="${cflags}" LDFLAGS="${ldflags}"
+    CT_DoExecLog ALL make ${CT_JOBSFLAGS} -C "${CT_SRC_DIR}/zstd/lib" libzstd.a-nomt-release BUILD_DIR="${PWD}" CC="${host}-gcc" AS="${host}-as" AR="${host}-ar" CFLAGS="${cflags}" LDFLAGS="${ldflags}"
 
     # There is no library only check in zstd
 
     CT_DoLog EXTRA "Installing zstd"
-    CT_DoExecLog ALL make -C "${CT_SRC_DIR}/zstd/lib" install-static install-includes BUILD_DIR="${PWD}" PREFIX="$prefix"
+    CT_DoExecLog ALL make -C "${CT_SRC_DIR}/zstd/lib" install-static install-includes install-pc BUILD_DIR="${PWD}" PREFIX="$prefix"
 }
 
 fi # CT_ZSTD

--- a/scripts/build/debug/300-gdb.sh
+++ b/scripts/build/debug/300-gdb.sh
@@ -69,6 +69,12 @@ do_debug_gdb_build()
         cross_extra_config+=("--with-expat")
         cross_extra_config+=("--without-libexpat-prefix")
 
+        if [ "${CT_COMP_LIBS_ZSTD}" = "y" ]; then
+            cross_extra_config+=("--with-zstd")
+        else
+            cross_extra_config+=("--without-zstd")
+        fi
+
         # ct-ng always builds ncurses in cross mode as a static library.
         # Starting from the patchset 20200718 ncurses defines a special macro
         # NCURSES_STATIC for a static library. This is critical for mingw host
@@ -84,6 +90,7 @@ do_debug_gdb_build()
             prefix="${CT_PREFIX_DIR}" \
             static="${CT_GDB_CROSS_STATIC}" \
             static_libstdcxx="${CT_GDB_CROSS_STATIC}" \
+            complibs="${CT_HOST_COMPLIBS_DIR}"          \
             --with-sysroot="${CT_SYSROOT_DIR}"          \
             "${cross_extra_config[@]}"
 
@@ -147,12 +154,6 @@ do_debug_gdb_build()
             native_extra_config+=("--disable-inprocess-agent")
         fi
 
-        if [ "${CT_COMP_LIBS_ZSTD}}" = "y" ]; then
-            native_extra_config+=("--with-zstd=${complibs}")
-        else
-            native_extra_config+=("--without-zstd")
-        fi
-
         export ac_cv_func_strncmp_works=yes
 
         # TBD do we need all these?
@@ -165,6 +166,7 @@ do_debug_gdb_build()
             --without-develop
             --sysconfdir=/etc
             --localstatedir=/var
+            --without-zstd
         )
 
         # Target libexpat resides in sysroot and does not have
@@ -259,6 +261,7 @@ do_debug_gdb_build()
 do_gdb_backend()
 {
     local host prefix destdir cflags ldflags static buildtype subdir includedir
+    local complibs
     local -a extra_config
     local -a extra_make_flags
 
@@ -334,6 +337,7 @@ do_gdb_backend()
 
     # TBD: is passing CPP/CC/CXX/LD needed? GCC should be determining this automatically from the triplets
     CT_DoExecLog CFG                                \
+    PKG_CONFIG_PATH="${complibs}/lib/pkgconfig"     \
     CPP="${host}-cpp"                               \
     CC="${host}-gcc"                                \
     CXX="${host}-g++"                               \


### PR DESCRIPTION
Proper fix that was introduced in https://github.com/crosstool-ng/crosstool-ng/pull/2144

- added proper AR for zstd build to fix macos builds
- zstd was never installed properly because of the absence of a pkg-config file
- binutils option `--with-zstd=` does not process paths (see https://github.com/bminor/binutils-gdb/blob/200164d46732f6a2fb9d81aa9650c006db4148e6/config/zstd.m4)