### PR TITLE
Disable fail-fast for CI build

### DIFF
--- a/.github/workflows/build-toolchains.yml
+++ b/.github/workflows/build-toolchains.yml
@@ -18,6 +18,7 @@ jobs:
   build:
     runs-on: ${{ matrix.host }}
     strategy:
+      fail-fast: false
       matrix:
         host: ["ubuntu-22.04", "macos-14"]
         sample: ${{ fromJSON(inputs.samples) }}


### PR DESCRIPTION
This makes other failures surface that would not be seen before due to cancelation because of another failure.