### PR TITLE
Fix error 'cannot find -latomic_asneeded'

### DIFF
--- a/scripts/build/cc/gcc.sh
+++ b/scripts/build/cc/gcc.sh
@@ -664,6 +664,7 @@ do_gcc_core_backend() {
         --exec_prefix="${exec_prefix}"                 \
         --with-local-prefix="${CT_SYSROOT_DIR}"        \
         "${extra_config[@]}"                           \
+        --disable-libatomic                            \
         --enable-languages="${lang_list}"              \
         "${extra_user_config[@]}"
 


### PR DESCRIPTION
Fix #2482

I'v been told by the GCC devs that stage-1 should not have libatomic.