### PR TITLE
picolibc: Map CT_ARCH to expected CPU value

### DIFF
--- a/scripts/build/companion_libs/340-picolibc.sh
+++ b/scripts/build/companion_libs/340-picolibc.sh
@@ -77,6 +77,11 @@ NANO_MALLOC:newlib-nano-malloc
         for cflag in ${cflags_for_target}; do
             meson_cflags="${meson_cflags} '${cflag}',"
         done
+
+        local -l target_arch="${CT_TARGET_ARCH}"
+        if [ "${CT_ARCH}" = "sh" ]; then
+            target_arch="sh"
+        fi
         cat << EOF > picolibc-cross.txt
 [binaries]
 c = '${CT_TARGET}-${CT_CC}'
@@ -86,8 +91,8 @@ strip = '${CT_TARGET}-strip'
 
 [host_machine]
 system = '${CT_TARGET_VENDOR}'
-cpu_family = '${CT_TARGET_ARCH}'
-cpu = '${CT_TARGET_ARCH}'
+cpu_family = '${target_arch}'
+cpu = '${target_arch}'
 endian = '${CT_ARCH_ENDIAN}'
 
 [properties]


### PR DESCRIPTION
In the case of creating a compiler for SuperH-2, big endian the target (`CT_TARGET_ARCH`) is "sh2eb-elf". However, picolibc expects "sh".