### PR TITLE
Fix libiberty installation order (binutils)

### DIFF
--- a/scripts/build/binutils/binutils.sh
+++ b/scripts/build/binutils/binutils.sh
@@ -334,9 +334,13 @@ do_binutils_for_target() {
     local -a install_targets
     local t
 
-    [ "${CT_BINUTILS_FOR_TARGET_IBERTY}"  = "y" ] && targets+=("libiberty")
     [ "${CT_BINUTILS_FOR_TARGET_BFD}"     = "y" ] && targets+=("bfd")
     [ "${CT_BINUTILS_FOR_TARGET_OPCODES}" = "y" ] && targets+=("opcodes")
+
+    # libiberty should be installed after opcodes
+    # because of this bug: https://sourceware.org/bugzilla/show_bug.cgi?id=34337
+    [ "${CT_BINUTILS_FOR_TARGET_IBERTY}"  = "y" ] && targets+=("libiberty")
+
     for t in "${targets[@]}"; do
         build_targets+=("all-${t}")
         install_targets+=("install-${t}")


### PR DESCRIPTION
Hi!

Recently I faced with a bug similar to [this one](https://github.com/crosstool-ng/crosstool-ng/issues/2097).

It looks like `libiberty` should be installed after `opcodes`, because otherwise wrong version of `libiberty` will be linked to opcodes.

It happens because:
1. we install `libiberty` (not `-fPIC` version)
2. we install `bfd`
3. we trying to install `opcodes`. `opcodes` is linked to `bfd` (located at install root) and `libiberty` (`-fPIC` version, located at build dir)
4. `libtool` calculate linkage flag for `bfd` firstly: this flags contains `-L/path/to/sysroot/install/dir`
5. `libtool` calculate linkage flag for `libiberty` secondly: this flags contains `-L/build/dir/../libiberty/pic`. This flags put after `bfd` linkage flags
6. linker trying to link wrong version of `libiberty` to `opcodes`: `/path/to/sysroot/install/dir/libiberty.a` (not `-fPIC` version)

```console
[ALL  ]    libtool: install: (cd /builds/rutoken/dev/ci/linux/linux-toolchains/build/.build/aarch64-unknown-linux-gnu/build/build-binutils-for-target/opcodes; /usr/bin/bash /builds/rutoken/dev/ci/linux/linux-toolchains/build/.build/aarch64-unknown-linux-gnu/build/build-binutils-for-target/opcodes/libtool  --silent --tag CC --mode=relink aarch64-unknown-linux-gnu-gcc -W -Wall -Wstrict-prototypes -Wmissing-prototypes -Wshadow -Wstack-usage=262144 -g -O2 -release 2.45 -o libopcodes.la -rpath /usr/lib dis-buf.lo disassemble.lo dis-init.lo aarch64-asm.lo aarch64-dis.lo aarch64-opc.lo aarch64-asm-2.lo aarch64-dis-2.lo aarch64-opc-2.lo arm-dis.lo ../bfd/libbfd.la -L/builds/rutoken/dev/ci/linux/linux-toolchains/build/.build/aarch64-unknown-linux-gnu/build/build-binutils-for-target/opcodes/../libiberty/pic -liberty -Wl,-lc,--as-needed,-lm,--no-as-needed -inst-prefix-dir /builds/rutoken/dev/ci/linux/linux-toolchains/toolchains/glibc-arm64-gcc15/aarch64-unknown-linux-gnu/sysroot)


[ALL  ]    /opt/x-tools/glibc-arm64-gcc15/lib/gcc/aarch64-unknown-linux-gnu/15.2.0/../../../../aarch64-unknown-linux-gnu/bin/ld: /opt/x-tools/glibc-arm64-gcc15/aarch64-unknown-linux-gnu/sysroot/usr/lib/libiberty.a(obstack.o)(.text+0x4): unresolvable R_AARCH64_ADR_PREL_PG_HI21 relocation against symbol `stderr@@GLIBC_2.17'
[ALL  ]    /opt/x-tools/glibc-arm64-gcc15/lib/gcc/aarch64-unknown-linux-gnu/15.2.0/../../../../aarch64-unknown-linux-gnu/bin/ld: final link failed: bad value
[ERROR]    collect2: error: ld returned 1 exit status
[ERROR]    libtool: install: error: relink `libopcodes.la' with the above command before installing it
```

For more info: https://sourceware.org/bugzilla/show_bug.cgi?id=34337
