### PR TITLE
debug: Add option to keep only the last-saved step's state

### DIFF
--- a/config/global/ct-behave.in
+++ b/config/global/ct-behave.in
@@ -149,6 +149,18 @@ config DEBUG_CT_SAVE_STEPS_COMPRESS
     default "zstd"  if DEBUG_CT_SAVE_STEPS_COMPRESS_ZSTD
     default ""      if DEBUG_CT_SAVE_STEPS_COMPRESS_NONE
 
+config DEBUG_CT_SAVE_STEPS_LAST_ONLY
+    bool
+    prompt "Keep only the last-saved step's state"
+    depends on DEBUG_CT_SAVE_STEPS
+    help
+      Remove earlier saved states as the build progresses, keeping only
+      the most recently saved step. This bounds the disk space used by
+      saved states to roughly one snapshot, which is useful on space-
+      constrained CI runners.
+
+      You can still restart the build, but only from the last-saved step.
+
 config NO_OVERRIDE_LC_MESSAGES
     bool
     prompt "Do *not* overide LC_MESSAGES (EXPERIMENTAL)"

--- a/docs/ct-ng.1.in
+++ b/docs/ct-ng.1.in
@@ -134,6 +134,11 @@ step, a previous build should have run at least to that step, or further.
 
 The list of steps is viewable with the action
 .BR list-steps .
+
+Note that if the
+.B "Keep only the last-saved step's state"
+option is enabled, only the most recently saved step is retained, so the build
+can only be restarted from that step.
 .\"
 .SH EXIT VALUE
 The

--- a/scripts/functions
+++ b/scripts/functions
@@ -1424,6 +1424,18 @@ CT_DoSaveState() {
         *)     cat "${CT_BUILD_LOG}" >"${state_dir}/log";;
     esac
     CT_LogEnable
+
+    # Optionally prune earlier states, keeping only the one just saved. We
+    # prune after the new state is complete, so an interrupted save never
+    # leaves us without a valid state to restart from.
+    if [ "${CT_DEBUG_CT_SAVE_STEPS_LAST_ONLY}" = "y" ]; then
+        CT_DoLog STATE "  Removing previously-saved states"
+        for v in "${CT_STATE_DIR}"/*; do
+            [ -d "${v}" ] || continue
+            [ "${v}" = "${state_dir}" ] && continue
+            CT_DoForceRmdir "${v}"
+        done
+    fi
 }
 
 # This function restores a previously saved state


### PR DESCRIPTION
Add `CT_DEBUG_CT_SAVE_STEPS_LAST_ONLY`, which prunes earlier saved states as the build progresses, keeping only the most recently saved step. This bounds the disk space used by saved states to roughly one snapshot, which is useful on space-constrained CI runners (e.g. GitHub Actions).

Pruning happens after the new state is fully written, so an interrupted save never leaves the build without a valid state to restart from. The build can still be restarted, but only from the last-saved step.

Closes #2436.

Successful build on GitHub Actions can be found here: https://github.com/tzarc/qmk_toolchains/actions/runs/28990567525