### PR TITLE
Fix target architecture detection for big-endian ARM in picolibc script

### DIFF
--- a/scripts/build/companion_libs/340-picolibc.sh
+++ b/scripts/build/companion_libs/340-picolibc.sh
@@ -81,6 +81,8 @@ NANO_MALLOC:newlib-nano-malloc
         local -l target_arch="${CT_TARGET_ARCH}"
         if [ "${CT_ARCH}" = "sh" ]; then
             target_arch="sh"
+        elif [ "${CT_ARCH}" = "arm" ]; then
+            target_arch="arm"
         fi
         cat << EOF > picolibc-cross.txt
 [binaries]


### PR DESCRIPTION
Attempting to compile picolibc under a big endian arm environment fails due to the `cpu_family` and `cpu` resolving under picolibc's cross file  to `armeb` which is not a valid configuration for picolibc as it expects `arm`.

```
[CFG  ]    Build type: cross build
[CFG  ]    Project name: picolibc
[CFG  ]    Project version: 1.8.10
[CFG  ]    Cross compiler sanity tests disabled via the cross file.
[CFG  ]    C compiler for the host machine: armeb-eabi-gcc (gcc 16.1.0 "armeb-eabi-gcc (crosstool-NG 1.28.0.58_27cd838 - sturdy-pancake) 16.1.0")
[CFG  ]    C linker for the host machine: armeb-eabi-gcc ld.bfd 1.28.0.58
[CFG  ]    C compiler for the build machine: cc (gcc 13.3.0 "cc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0")
[CFG  ]    C linker for the build machine: cc ld.bfd 2.42
[CFG  ]    Build machine cpu family: x86_64
[CFG  ]    Build machine cpu: x86_64
[CFG  ]    Host machine cpu family: armeb
[CFG  ]    Host machine cpu: armeb
[CFG  ]    Target machine cpu family: armeb
[CFG  ]    Target machine cpu: armeb
[CFG  ]    Compiler for C supports arguments -nostdlib: YES 
[CFG  ]    
[CFG  ]    ../../../src/picolibc-1.8.10/meson.build:130:2: ERROR: Problem encountered: 
[CFG  ]    
[CFG  ]    Unsupported architecture: "armeb"
[CFG  ]    
[CFG  ]        Read the Supported Architectures section in README.md
[CFG  ]        to learn how to add a new architecture.
[CFG  ]    
[CFG  ]    
```
