### PR TITLE
binutils, gdb: fix stray brace that disables zstd support

### DIFF
--- a/scripts/build/binutils/binutils.sh
+++ b/scripts/build/binutils/binutils.sh
@@ -181,7 +181,7 @@ do_binutils_backend() {
 
     [ "${CT_TOOLCHAIN_ENABLE_NLS}" != "y" ] && extra_config+=("--disable-nls")
 
-    if [ "${CT_COMP_LIBS_ZSTD}}" = "y" ]; then
+    if [ "${CT_COMP_LIBS_ZSTD}" = "y" ]; then
         extra_config+=("--with-zstd=${complibs}")
     else
         extra_config+=("--without-zstd")

--- a/scripts/build/debug/300-gdb.sh
+++ b/scripts/build/debug/300-gdb.sh
@@ -147,7 +147,7 @@ do_debug_gdb_build()
             native_extra_config+=("--disable-inprocess-agent")
         fi
 
-        if [ "${CT_COMP_LIBS_ZSTD}}" = "y" ]; then
+        if [ "${CT_COMP_LIBS_ZSTD}" = "y" ]; then
             native_extra_config+=("--with-zstd=${complibs}")
         else
             native_extra_config+=("--without-zstd")


### PR DESCRIPTION
The zstd guard is written with a stray `}` in two build scripts:

```sh
if [ "${CT_COMP_LIBS_ZSTD}}" = "y" ]; then
```

`"${CT_COMP_LIBS_ZSTD}}"` expands to e.g. `y}`, so the test is never true and the tool is always configured `--without-zstd`, even when `CT_COMP_LIBS_ZSTD=y` builds the zstd companion library. As a result the affected tools are built without zstd support (no `--compress-debug-sections=zstd`, and no zstd-compressed LTO objects). Removing the extra brace restores the intended `--with-zstd=${complibs}`.

Fixed in both places:

- `scripts/build/binutils/binutils.sh` (binutils `ld`/`as`)
- `scripts/build/debug/300-gdb.sh` (native `gdb`)
