### PR TITLE
picolibc: follow CT_JOBS limit

### DIFF
--- a/scripts/build/companion_libs/340-picolibc.sh
+++ b/scripts/build/companion_libs/340-picolibc.sh
@@ -135,10 +135,10 @@ EOF
         "${CT_LIBC_PICOLIBC_EXTRA_CONFIG_ARRAY[@]}"
 
     CT_DoLog EXTRA "Building C library"
-    CT_DoExecLog ALL ninja
+    CT_DoExecLog ALL ninja ${CT_JOBSFLAGS}
 
     CT_DoLog EXTRA "Installing C library"
-    CT_DoExecLog ALL ninja install
+    CT_DoExecLog ALL ninja ${CT_JOBSFLAGS} install
 }
 
 fi # CT_LIBC_PICOLIBC -o CT_COMP_LIBS_PICOLIBC

--- a/scripts/crosstool-NG.sh
+++ b/scripts/crosstool-NG.sh
@@ -605,7 +605,7 @@ if [ -z "${CT_RESTART}" ]; then
     AUTO_JOBS=$[ BUILD_NCPUS + 1 ]
     [ ${CT_PARALLEL_JOBS} -eq 0 ] && CT_JOBSFLAGS="${CT_JOBSFLAGS} -j${AUTO_JOBS}"
     [ ${CT_PARALLEL_JOBS} -gt 0 ] && CT_JOBSFLAGS="${CT_JOBSFLAGS} -j${CT_PARALLEL_JOBS}"
-    CT_JOBSFLAGS="${CT_JOBSFLAGS} -l${CT_LOAD}"
+    [ -n "${CT_LOAD}" ] && CT_JOBSFLAGS="${CT_JOBSFLAGS} -l${CT_LOAD}"
 
     # Override 'download only' option
     [ -n "${CT_SOURCE}" ] && CT_ONLY_DOWNLOAD=y


### PR DESCRIPTION
- respect `CT_JOBS` when building picolibc
- fix `CT_JOBSFLAGS` if `CT_LOAD` is not defined