### PR TITLE
Set PKG_CONFIG_PATH for binutils configure-gas

### DIFF
--- a/scripts/build/binutils/binutils.sh
+++ b/scripts/build/binutils/binutils.sh
@@ -237,7 +237,9 @@ do_binutils_backend() {
                 ;;
         esac
     fi
-    CT_DoExecLog ALL make "${extra_make_flags[@]}" ${CT_JOBSFLAGS}
+    CT_DoExecLog ALL                                            \
+    PKG_CONFIG_PATH="${complibs}/lib/pkgconfig"                 \
+    make "${extra_make_flags[@]}" ${CT_JOBSFLAGS}
 
     CT_DoLog EXTRA "Installing binutils"
     CT_DoExecLog ALL make install


### PR DESCRIPTION
Set PKG_CONFIG_PATH for binutils configure-gas.  
Otherwise, "Building binutils" fails with `configure: error: --with-zstd was given, but pkgconfig/libzstd.pc is not found`.  
